### PR TITLE
downgrade mysql to 5.6

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -16,6 +16,8 @@ config:
   ssl: true
 
 services:
+  database:
+    type: mysql:5.6
   cache:
     type: memcached:1.5
   appserver:


### PR DESCRIPTION
To match AC: https://docs.acquia.com/acquia-cloud/arch/tech-platform/

Requires a `lando rebuild`.