### PR TITLE
Update Core to 8.6.7 and apply core patch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
             "drupal/core": {
                 "SiteConfigureForm overrides value from install profile": "https://www.drupal.org/files/issues/2018-03-27/drupal-profile-site-config-2849074-31-8.6.x.patch",
                 "The Media library doesn't modify the 'media' view if installed in a profile": "https://www.drupal.org/files/issues/2018-08-10/2992056-2.patch",
-                "User forms broken for admin without 'administer users": "https://www.drupal.org/files/issues/2018-06-15/user.form_.subadmin-2854252-89.patch"
+                "User forms broken for admin without 'administer users": "https://www.drupal.org/files/issues/2018-06-15/user.form_.subadmin-2854252-89.patch",
+                "Site extensions don't get rediscovered after drush cr": "https://www.drupal.org/files/issues/2018-07-11/specify_sitepath_cache_rebuild_extension_discovery-2985199-3.patch"
             }
         },
         "patchLevel": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc598ae14d82063046d8131ba685ac29",
+    "content-hash": "9d5c825332c0ee82355e7edbf2e903f7",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2329,16 +2329,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "8.6.6",
+            "version": "8.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "6736973f399a3a9ac8ecd41f3a159e1153f7ee39"
+                "reference": "e0a09bda1da7552204464894811a59387608c9f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/6736973f399a3a9ac8ecd41f3a159e1153f7ee39",
-                "reference": "6736973f399a3a9ac8ecd41f3a159e1153f7ee39",
+                "url": "https://api.github.com/repos/drupal/core/zipball/e0a09bda1da7552204464894811a59387608c9f9",
+                "reference": "e0a09bda1da7552204464894811a59387608c9f9",
                 "shasum": ""
             },
             "require": {
@@ -2545,7 +2545,8 @@
                 "patches_applied": {
                     "SiteConfigureForm overrides value from install profile": "https://www.drupal.org/files/issues/2018-03-27/drupal-profile-site-config-2849074-31-8.6.x.patch",
                     "The Media library doesn't modify the 'media' view if installed in a profile": "https://www.drupal.org/files/issues/2018-08-10/2992056-2.patch",
-                    "User forms broken for admin without 'administer users": "https://www.drupal.org/files/issues/2018-06-15/user.form_.subadmin-2854252-89.patch"
+                    "User forms broken for admin without 'administer users": "https://www.drupal.org/files/issues/2018-06-15/user.form_.subadmin-2854252-89.patch",
+                    "Site extensions don't get rediscovered after drush cr": "https://www.drupal.org/files/issues/2018-07-11/specify_sitepath_cache_rebuild_extension_discovery-2985199-3.patch"
                 }
             },
             "autoload": {
@@ -2569,7 +2570,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
-            "time": "2019-01-15T17:41:52+00:00"
+            "time": "2019-01-16T23:30:03+00:00"
         },
         {
             "name": "drupal/crop",


### PR DESCRIPTION
Site specific modules/themes code does not continue to run after `drush cr`. There is an issue with patch that remedies the problem:

https://www.drupal.org/project/drupal/issues/2985199