### PR TITLE
Remove AC inc for default site.

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -769,12 +769,6 @@ $settings['entity_update_batch_size'] = 50;
 #   include $app_root . '/' . $site_path . '/settings.local.php';
 # }
 
-// Acquia Cloud does not allow a database named 'default' so we can't rely on
-// the BLT database magic.
-if (file_exists('/var/www/site-php')) {
-  require '/var/www/site-php/uiowa/sitenow-settings.inc';
-}
-
 require DRUPAL_ROOT . "/../vendor/acquia/blt/settings/blt.settings.php";
 /**
  * IMPORTANT.


### PR DESCRIPTION
BLT will set the default DB include to use the AH site group name, i.e. the application name (uiowa).

This change will require syncing the sitenow database to the uiowa database in dev (and then syncing up, eventually).

We want to keep the default settings file stock because BLT copies into each multisite during initialization.