### PR TITLE
Set SSH agent forwarding option in Drush config.

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -1,5 +1,5 @@
 project:
-  prefix: BLT
+  prefix: uiowa
   human_name: 'The sitenow platform on the uiowa application.'
   profile:
     name: sitenow

--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -66,7 +66,8 @@ class MultisiteCommands extends BltTasks {
       unlink("{$root}/drush/sites/{$dir}.site.yml");
     }
 
-    $default = Yaml::parse(file_get_contents("{$root}/drush/sites/uiowa.site.yml"));
+    $app = $this->getConfig()->get('project.prefix');
+    $default = Yaml::parse(file_get_contents("{$root}/drush/sites/{$app}.site.yml"));
     $default['prod']['uri'] = $dir;
     $default['test']['uri'] = $test;
     $default['dev']['uri'] = $dev;

--- a/drush/drush.yml
+++ b/drush/drush.yml
@@ -2,7 +2,7 @@
 # for the entire application. For site-specific settings, like URI, use
 # ../docroot/sites/[site]/drush.yml
 ssh:
-  options: '-A'
+  options: '-A -o PasswordAuthentication=no -p 22'
 
 drush:
   paths:

--- a/drush/sites/demo.site.yml
+++ b/drush/sites/demo.site.yml
@@ -6,8 +6,6 @@ dev:
     dump-dir: /mnt/tmp
   root: /var/www/html/uiowa.dev/docroot
   user: uiowa.dev
-  ssh:
-    options: '-p 22'
 prod:
   uri: demo.prod.drupal.uiowa.edu
   host: web-33201.prod.hosting.acquia.com
@@ -16,8 +14,6 @@ prod:
     dump-dir: /mnt/tmp
   root: /var/www/html/uiowa.prod/docroot
   user: uiowa.prod
-  ssh:
-    options: '-p 22'
 test:
   uri: demo.stage.drupal.uiowa.edu
   host: staging-15039.prod.hosting.acquia.com
@@ -26,7 +22,5 @@ test:
     dump-dir: /mnt/tmp
   root: /var/www/html/uiowa.test/docroot
   user: uiowa.test
-  ssh:
-    options: '-p 22'
 local:
   uri: default

--- a/drush/sites/dentistrycallctr.site.yml
+++ b/drush/sites/dentistrycallctr.site.yml
@@ -5,7 +5,6 @@ dev:
   paths: { dump-dir: /mnt/tmp }
   root: /var/www/html/uiowa.dev/docroot
   user: uiowa.dev
-  ssh: { options: '-p 22' }
 prod:
   uri: callctr.dentistry.uiowa.edu
   host: web-33201.prod.hosting.acquia.com
@@ -13,7 +12,6 @@ prod:
   paths: { dump-dir: /mnt/tmp }
   root: /var/www/html/uiowa.prod/docroot
   user: uiowa.prod
-  ssh: { options: '-p 22' }
 test:
   uri: dentistrycallctr.stage.drupal.uiowa.edu
   host: staging-15039.prod.hosting.acquia.com
@@ -21,4 +19,3 @@ test:
   paths: { dump-dir: /mnt/tmp }
   root: /var/www/html/uiowa.test/docroot
   user: uiowa.test
-  ssh: { options: '-p 22' }

--- a/drush/sites/hr.site.yml
+++ b/drush/sites/hr.site.yml
@@ -5,7 +5,6 @@ dev:
   paths: { dump-dir: /mnt/tmp }
   root: /var/www/html/uiowa.dev/docroot
   user: uiowa.dev
-  ssh: { options: '-p 22' }
 prod:
   uri: hr.uiowa.edu
   host: web-33201.prod.hosting.acquia.com
@@ -13,7 +12,6 @@ prod:
   paths: { dump-dir: /mnt/tmp }
   root: /var/www/html/uiowa.prod/docroot
   user: uiowa.prod
-  ssh: { options: '-p 22' }
 test:
   uri: hr-d8.stage.drupal.uiowa.edu
   host: staging-15039.prod.hosting.acquia.com
@@ -21,4 +19,3 @@ test:
   paths: { dump-dir: /mnt/tmp }
   root: /var/www/html/uiowa.test/docroot
   user: uiowa.test
-  ssh: { options: '-p 22' }

--- a/drush/sites/protostudios.site.yml
+++ b/drush/sites/protostudios.site.yml
@@ -6,8 +6,6 @@ dev:
     dump-dir: /mnt/tmp
   root: /var/www/html/uiowa.dev/docroot
   user: uiowa.dev
-  ssh:
-    options: '-p 22'
 prod:
   uri: protostudios.uiowa.edu
   host: web-33201.prod.hosting.acquia.com
@@ -16,8 +14,6 @@ prod:
     dump-dir: /mnt/tmp
   root: /var/www/html/uiowa.prod/docroot
   user: uiowa.prod
-  ssh:
-    options: '-p 22'
 test:
   uri: protostudios.stage.drupal.uiowa.edu
   host: staging-15039.prod.hosting.acquia.com
@@ -26,5 +22,3 @@ test:
     dump-dir: /mnt/tmp
   root: /var/www/html/uiowa.test/docroot
   user: uiowa.test
-  ssh:
-    options: '-p 22'

--- a/drush/sites/sitesgis.site.yml
+++ b/drush/sites/sitesgis.site.yml
@@ -6,8 +6,6 @@ dev:
     dump-dir: /mnt/tmp
   root: /var/www/html/uiowa.dev/docroot
   user: uiowa.dev
-  ssh:
-    options: '-p 22'
 prod:
   uri: gis.sites.uiowa.edu
   host: web-33201.prod.hosting.acquia.com
@@ -16,8 +14,6 @@ prod:
     dump-dir: /mnt/tmp
   root: /var/www/html/uiowa.prod/docroot
   user: uiowa.prod
-  ssh:
-    options: '-p 22'
 test:
   uri: sitesgis.stage.drupal.uiowa.edu
   host: staging-15039.prod.hosting.acquia.com
@@ -26,5 +22,3 @@ test:
     dump-dir: /mnt/tmp
   root: /var/www/html/uiowa.test/docroot
   user: uiowa.test
-  ssh:
-    options: '-p 22'

--- a/drush/sites/uiowa.site.yml
+++ b/drush/sites/uiowa.site.yml
@@ -5,7 +5,6 @@ dev:
     paths: { dump-dir: /mnt/tmp }
     root: /var/www/html/uiowa.dev/docroot
     user: uiowa.dev
-    ssh: { options: '-p 22' }
 prod:
     uri: uiowa.prod.acquia-sites.com
     host: web-33201.prod.hosting.acquia.com
@@ -13,7 +12,6 @@ prod:
     paths: { dump-dir: /mnt/tmp }
     root: /var/www/html/uiowa.prod/docroot
     user: uiowa.prod
-    ssh: { options: '-p 22' }
 test:
     uri: uiowastg.prod.acquia-sites.com
     host: staging-15039.prod.hosting.acquia.com
@@ -21,4 +19,3 @@ test:
     paths: { dump-dir: /mnt/tmp }
     root: /var/www/html/uiowa.test/docroot
     user: uiowa.test
-    ssh: { options: '-p 22' }


### PR DESCRIPTION
Resolves #190 so that remote-to-remote sql/r:sync's work.