### PR TITLE
Add command to clean Acquia remote.

### DIFF
--- a/blt/src/Blt/Plugin/Commands/GitCommands.php
+++ b/blt/src/Blt/Plugin/Commands/GitCommands.php
@@ -36,22 +36,26 @@ class GitCommands extends BltTasks {
       list($sha, $ref) = explode("\t", $head);
 
       if (!in_array($ref, $keep)) {
-        $delete[] = $ref;
+        $delete[$sha] = $ref;
       }
     }
 
-    $this->io()->section('Refs');
-    $this->io()->listing($delete);
+    if (!empty($delete)) {
+      $this->printArrayAsTable($delete, ['SHA', 'Ref']);
 
-    if (!$this->confirm('You will delete all the branches above from the Acquia remote. Are you sure?')) {
-      throw new \Exception('Aborted.');
+      if (!$this->confirm('You will delete all the branches above from the Acquia remote. Are you sure?')) {
+        throw new \Exception('Aborted.');
+      }
+      else {
+        foreach ($delete as $ref) {
+          $this->taskExecStack()
+            ->exec("git push --delete acquia {$ref}")
+            ->run();
+        }
+      }
     }
     else {
-      foreach ($delete as $ref) {
-        $this->taskExecStack()
-          ->exec("git push --delete acquia {$ref}")
-          ->run();
-      }
+      $this->say('There are no branches to clean up.');
     }
   }
 

--- a/blt/src/Blt/Plugin/Commands/GitCommands.php
+++ b/blt/src/Blt/Plugin/Commands/GitCommands.php
@@ -55,7 +55,7 @@ class GitCommands extends BltTasks {
       }
     }
     else {
-      $this->say('There are no branches to clean up.');
+      $this->yell('There are no branches to clean up!');
     }
   }
 

--- a/blt/src/Blt/Plugin/Commands/GitCommands.php
+++ b/blt/src/Blt/Plugin/Commands/GitCommands.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Sitenow\Blt\Plugin\Commands;
+
+use Acquia\Blt\Robo\BltTasks;
+use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\AnnotatedCommand\CommandError;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Defines commands in the Sitenow namespace.
+ */
+class GitCommands extends BltTasks {
+
+  /**
+   * Delete all remote branches except master and develop.
+   *
+   * @command clean:acquia
+   */
+  public function cleanAcquiaRemote() {
+    $result = $this->taskExecStack()
+      ->exec('git ls-remote --heads acquia')
+      ->silent(TRUE)
+      ->run();
+
+    $output = $result->getMessage();
+    $heads = explode(PHP_EOL, $output);
+
+    $keep = [
+      'refs/heads/master',
+      'refs/heads/pipelines-build-master',
+      'refs/heads/pipelines-build-develop',
+    ];
+
+    $delete = [];
+
+    foreach ($heads as $head) {
+      list($sha, $ref) = explode("\t", $head);
+
+      if (!in_array($ref, $keep)) {
+        $delete[] = $ref;
+      }
+    }
+
+    $this->io()->section('Refs');
+    $this->io()->listing($delete);
+
+    if (!$this->confirm('You will delete all the branches above from the Acquia remote. Are you sure?')) {
+      throw new \Exception('Aborted.');
+    }
+    else {
+      foreach ($delete as $ref) {
+        $this->taskExecStack()
+          ->exec("git push --delete acquia {$ref}")
+          ->run();
+      }
+    }
+  }
+
+}

--- a/blt/src/Blt/Plugin/Commands/GitCommands.php
+++ b/blt/src/Blt/Plugin/Commands/GitCommands.php
@@ -3,9 +3,6 @@
 namespace Sitenow\Blt\Plugin\Commands;
 
 use Acquia\Blt\Robo\BltTasks;
-use Consolidation\AnnotatedCommand\CommandData;
-use Consolidation\AnnotatedCommand\CommandError;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * Defines commands in the Sitenow namespace.

--- a/blt/src/Blt/Plugin/Commands/GitCommands.php
+++ b/blt/src/Blt/Plugin/Commands/GitCommands.php
@@ -17,6 +17,7 @@ class GitCommands extends BltTasks {
   public function cleanAcquiaRemote() {
     $result = $this->taskExecStack()
       ->exec('git ls-remote --heads acquia')
+      ->stopOnFail()
       ->silent(TRUE)
       ->run();
 

--- a/blt/src/Blt/Plugin/Commands/GitCommands.php
+++ b/blt/src/Blt/Plugin/Commands/GitCommands.php
@@ -10,11 +10,13 @@ use Acquia\Blt\Robo\BltTasks;
 class GitCommands extends BltTasks {
 
   /**
-   * Delete all remote branches except master and develop.
+   * Delete all remote branches except master and develop from Acquia remote.
    *
-   * @command clean:acquia
+   * @command git:clean:acquia
+   *
+   * @aliases gca
    */
-  public function cleanAcquiaRemote() {
+  public function cleanAcquia() {
     $result = $this->taskExecStack()
       ->exec('git ls-remote --heads acquia')
       ->stopOnFail()


### PR DESCRIPTION
Its difficult to deploy an artifact with so many refs cluttering up the interface. This command can be run locally to delete all refs except master/develop in the Acquia remote. Requires adding the remote locally, i.e. `git remote add acquia URL`.