### PR TITLE
Do not compile frontend assets after syncing each multisite.

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -50,6 +50,7 @@ sync:
     - drupal:sync:db
     - drupal:update
     - drupal:config:import
+    - sitenow:multisite:noop
 command-hooks:
   frontend-reqs:
     dir: ${docroot}

--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -13,6 +13,21 @@ use Symfony\Component\Yaml\Yaml;
 class MultisiteCommands extends BltTasks {
 
   /**
+   * A no-op command.
+   *
+   * This is called in sync.commands to override the frontend step.
+   *
+   * @see: https://github.com/acquia/blt/issues/3697
+   *
+   * @command sitenow:multisite:noop
+   *
+   * @aliases smn
+   */
+  public function noop() {
+
+  }
+
+  /**
    * Execute a Drush command against all multisites.
    *
    * @param string $cmd


### PR DESCRIPTION
Resolves #240. 

Frontend assets can be compiled for all workspaces by running `blt frontend` manually (or by running what `blt frontend` is running).