### PR TITLE
update uiowa_bar to 1.0.0-alpha-5

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9896,11 +9896,11 @@
         },
         {
             "name": "uiowa/uiowa_bar",
-            "version": "1.0.0-alpha4",
+            "version": "1.0.0-alpha5",
             "source": {
                 "type": "git",
                 "url": "git@github.com:uiowa/uiowa_bar",
-                "reference": "7be6431d8394f66fd4ac0efbebfa51afcda7a67c"
+                "reference": "fe2b4f22e10e87bd3720c9c589fc7ff3261b9cd0"
             },
             "require": {
                 "composer/installers": "^1.5"
@@ -9913,7 +9913,7 @@
                 }
             ],
             "description": "Drupal Module to implement the University of Iowa Branding Bar.",
-            "time": "2019-05-16T14:18:01+00:00"
+            "time": "2019-06-10T16:38:40+00:00"
         },
         {
             "name": "uiowa/uiowa_footer",


### PR DESCRIPTION
adds google tag manager to start tracking university wide analytics.