### PR TITLE
check for external breadcrumb. resolves #271

### DIFF
--- a/docroot/modules/custom/sitenow_articles/sitenow_articles.module
+++ b/docroot/modules/custom/sitenow_articles/sitenow_articles.module
@@ -44,7 +44,11 @@ function sitenow_articles_preprocess_breadcrumb(&$variables) {
   // https://www.drupal.org/project/drupal/issues/2787051...
   $routes = [];
   foreach ($variables["links"] as $key => $link) {
-    $routes[$key] = $link->getUrl()->getRouteName();
+    $url = $link->getURL();
+    // Test for external paths.
+    if ($url->isRouted()) {
+      $routes[$key] = $link->getUrl()->getRouteName();
+    }
   }
   // For breadcrumb links built from view articles path, reduce duplicates.
   if (in_array('view.articles.page_articles', $routes)) {


### PR DESCRIPTION
Since all breadcrumbs (menu items) may not be routes (internal) and the articles logic only cares to find a specific route, do a check for whether or not the breadcrumb has/is a route.

#271 