### PR TITLE
Set cache time to constant, removed config option

### DIFF
--- a/docroot/modules/custom/uiowa_events/src/Form/UIEventsSettingsForm.php
+++ b/docroot/modules/custom/uiowa_events/src/Form/UIEventsSettingsForm.php
@@ -53,15 +53,6 @@ class UIEventsSettingsForm extends ConfigFormBase {
       ],
     ];
 
-    $form['global']['uiowa_events_cache_time'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Events Caching'),
-      '#default_value' => $config->get('uiowa_events.cache_time'),
-      '#description' => $this->t('Enter the number of minutes event data should be cached. (Minimum of 5 minutes)'),
-      '#size' => 60,
-      '#required' => TRUE,
-    ];
-
     $form['global']['uiowa_events_single_event_path'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Single event path'),

--- a/docroot/modules/custom/uiowa_events/uiowa_events.module
+++ b/docroot/modules/custom/uiowa_events/uiowa_events.module
@@ -220,8 +220,8 @@ function uiowa_events_load(array $params = ['display_id' => 'events'], array $ar
 
     // If cache is not set to TRUE.
     if ($cache !== FALSE) {
-      // Create a cache item.
-      \Drupal::cache('uievents')->set($endpoint, $events, REQUEST_TIME + (60 * $config->get('uiowa_events.cache_time')));
+      // Create a cache item set to 15 minutes.
+      \Drupal::cache('uievents')->set($endpoint, $events, REQUEST_TIME + (60 * 15));
     }
   }
   // Return an array of events with optional params.

--- a/docroot/profiles/custom/sitenow/config/sync/uiowa_events.settings.yml
+++ b/docroot/profiles/custom/sitenow/config/sync/uiowa_events.settings.yml
@@ -1,5 +1,4 @@
 uiowa_events:
-  cache_time: '60'
   single_event_path: event
   event_link: event-link-internal
   base_endpoint: 'https://content.uiowa.edu/api/v1/'


### PR DESCRIPTION
- Removed the config form option (and its default profile setting)
- Set cache creation to 15 minutes

I believe this is all that is required, and that the cache value isn't referenced elsewhere.

Chose 15 minute cache as a practical minimum, as it seems a short enough time that updates will be available in a short time, while keeping most of the benefits of caching. Let me know if this should be changed, or if there's a more specific approach to choosing cache time.