### PR TITLE
foundation for custom brand site

### DIFF
--- a/config/brand.uiowa.edu/.htaccess
+++ b/config/brand.uiowa.edu/.htaccess
@@ -1,0 +1,24 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php5.c>
+  php_flag engine off
+</IfModule>

--- a/config/brand.uiowa.edu/config_split.config_split.brand.yml
+++ b/config/brand.uiowa.edu/config_split.config_split.brand.yml
@@ -1,0 +1,17 @@
+uuid: 2631db12-1fae-41dd-81c2-99a69a5ec8d5
+langcode: en
+status: true
+dependencies: {  }
+id: brand
+label: Brand
+description: ''
+folder: ../config/brand.uiowa.edu
+module:
+  brand_core: 0
+theme: {  }
+blacklist:
+  - config_split.config_split.brand
+graylist: {  }
+graylist_dependents: true
+graylist_skip_equal: true
+weight: 110

--- a/docroot/sites/brand.uiowa.edu/modules/brand_core/brand_core.info.yml
+++ b/docroot/sites/brand.uiowa.edu/modules/brand_core/brand_core.info.yml
@@ -1,0 +1,5 @@
+name: brand_core
+type: module
+description: Core functionality of brand.uiowa.edu.
+package: BRAND
+core: 8.x

--- a/docroot/sites/brand.uiowa.edu/modules/brand_core/brand_core.install
+++ b/docroot/sites/brand.uiowa.edu/modules/brand_core/brand_core.install
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the brand_core module.
+ */

--- a/docroot/sites/brand.uiowa.edu/modules/brand_core/brand_core.module
+++ b/docroot/sites/brand.uiowa.edu/modules/brand_core/brand_core.module
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for brand_core module.
+ *
+ * @DCG
+ * This file is no longer required in Drupal 8.
+ * @see https://www.drupal.org/node/2217931
+ */


### PR DESCRIPTION
- There is active db config that registers this custom site split. This code needs to go with the next release/build or that active config will be deleted...

This allows the site split and custom module to import custom config and run update hooks specific to this site.