### PR TITLE
Events followup.

### DIFF
--- a/docroot/modules/custom/sitenow_events/src/Controller/EventsController.php
+++ b/docroot/modules/custom/sitenow_events/src/Controller/EventsController.php
@@ -2,41 +2,13 @@
 
 namespace Drupal\sitenow_events\Controller;
 
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Controller\ControllerBase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Returns responses for single event routes.
  */
 class EventsController extends ControllerBase {
-
-  /**
-   * The Config.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
-   */
-  protected $configFactory;
-
-  /**
-   * EventsController constructor.
-   *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
-   *   The config factory.
-   */
-  public function __construct(ConfigFactoryInterface $configFactory) {
-    $this->configFactory = $configFactory->get('sitenow_events.settings');
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('config.factory')
-    );
-  }
 
   /**
    * Builds the response.
@@ -51,7 +23,7 @@ class EventsController extends ControllerBase {
    */
   public function build($event_id, $event_instance) {
     // If the configuration is to link out, make all event pages 404.
-    if ($this->configFactory->get('sitenow_events.event_link') == 'event-link-external') {
+    if ($this->config('sitenow_events.settings')->get('sitenow_events.event_link') == 'event-link-external') {
       throw new NotFoundHttpException();
     }
     else {

--- a/docroot/profiles/custom/sitenow/config/sync/config_ignore.settings.yml
+++ b/docroot/profiles/custom/sitenow/config/sync/config_ignore.settings.yml
@@ -8,6 +8,7 @@ ignored_config_entities:
   12: uiowa_footer.settings
   14: views.view.articles
   16: 'webform.webform.*'
+  18: sitenow_events.settings
 enable_export_filtering: '1'
 _core:
   default_config_hash: v7E8C8wJWeAW2BGohMNY1tZSBc4bexM6O62tGxecTfE


### PR DESCRIPTION
Removes the DI from the events controller in favor of the existing config method on the parent class. Adds sitenow_events.settings to config ignore.