### PR TITLE
Require image selection for carousel image

### DIFF
--- a/docroot/profiles/custom/sitenow/config/sync/field.field.paragraph.carousel_image.field_carousel_image_image.yml
+++ b/docroot/profiles/custom/sitenow/config/sync/field.field.paragraph.carousel_image.field_carousel_image_image.yml
@@ -12,7 +12,7 @@ entity_type: paragraph
 bundle: carousel_image
 label: Image
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
Resolves #797 -- image field required for carousels following Drupal 8.8 update.