### PR TITLE
Move acquia credentials to custom uiowa key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ This project is based on BLT, an open-source project template and tool that enab
 ### BLT Configuration
 Make sure you have an [Acquia Cloud key and secret](https://docs.acquia.com/acquia-cloud/develop/api/auth/) saved in the `blt/local.blt.yml` file. This file is ignored by Git. Be sure you do not accidentally commit your credentials to the `blt/blt.yml` file which is tracked in Git. Do not share your key or secret with anyone.
 ```
-credentials:
-  acquia:
-    key: foo
-    secret: bar
+uiowa:
+  credentials:
+    acquia:
+      key: foo
+      secret: bar
 ```
 
 Set the multisites that you want BLT to sync by default:

--- a/blt/src/Blt/Plugin/Commands/Sitenow/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/Sitenow/MultisiteCommands.php
@@ -431,8 +431,8 @@ EOD;
    */
   public function validateCredentials() {
     $credentials = [
-      'credentials.acquia.key',
-      'credentials.acquia.secret',
+      'uiowa.credentials.acquia.key',
+      'uiowa.credentials.acquia.secret',
     ];
 
     foreach ($credentials as $cred) {


### PR DESCRIPTION
All custom BLT configuration has been moved under an arbitrary uiowa key to avoid conflicts with other core BLT config. I forgot to move this config the first time around. This will require developers to update their local.blt.yml file.