### PR TITLE
Add Drush alias for uiowa01 application.

### DIFF
--- a/drush/sites/demo.site.yml
+++ b/drush/sites/demo.site.yml
@@ -25,11 +25,3 @@ test:
     dump-dir: /mnt/tmp
   root: /var/www/html/uiowa.test/docroot
   user: uiowa.test
-livedev:
-  uri: demo.dev.drupal.uiowa.edu
-  host: uiowadev.ssh.prod.acquia-sites.com
-  options: {  }
-  paths:
-    dump-dir: /mnt/tmp
-  root: /home/uiowa/dev/livedev
-  user: uiowa.dev

--- a/drush/sites/uiowa.site.yml
+++ b/drush/sites/uiowa.site.yml
@@ -1,6 +1,3 @@
-local:
-  uri: default
-  root: '${env.cwd}/docroot'
 dev:
     uri: uiowadev.prod.acquia-sites.com
     host: uiowadev.ssh.prod.acquia-sites.com

--- a/drush/sites/uiowa01.site.yml
+++ b/drush/sites/uiowa01.site.yml
@@ -1,0 +1,21 @@
+dev:
+  uri: uiowa01dev.prod.acquia-sites.com
+  host: uiowa01dev.ssh.prod.acquia-sites.com
+  options: {  }
+  paths: { dump-dir: /mnt/tmp }
+  root: /var/www/html/uiowa01.dev/docroot
+  user: uiowa01.dev
+prod:
+  uri: uiowa01.prod.acquia-sites.com
+  host: uiowa01.ssh.prod.acquia-sites.com
+  options: {  }
+  paths: { dump-dir: /mnt/tmp }
+  root: /var/www/html/uiowa01.prod/docroot
+  user: uiowa01.prod
+test:
+  uri: uiowa01stg.prod.acquia-sites.com
+  host: uiowa01stg.ssh.prod.acquia-sites.com
+  options: {  }
+  paths: { dump-dir: /mnt/tmp }
+  root: /var/www/html/uiowa01.test/docroot
+  user: uiowa01.test


### PR DESCRIPTION
I use these application aliases to quickly SSH in and poke around, e.g. `drush @uiowa01.dev ssh`. Also cleaned up some unused cruft from uiowa alias.