### PR TITLE
Update project and theme gitignore files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,10 +28,10 @@ docroot/libraries
 drush/Commands/contrib
 
 # Ignore custom theme build artifacts
-docroot/sites/*/themes/*/assets/css
-docroot/sites/*/themes/*/assets/js
-docroot/themes/custom/*/assets/css
-docroot/themes/custom/*/assets/js
+docroot/sites/*/themes/*/assets
+docroot/themes/custom/*/assets
+docroot/themes/custom/*/hds
+docroot/themes/custom/*/uids
 docroot/themes/custom/*/styleguide
 
 # Ignore build artifacts

--- a/docroot/sites/cogscilang.grad.uiowa.edu/blt.yml
+++ b/docroot/sites/cogscilang.grad.uiowa.edu/blt.yml
@@ -13,8 +13,6 @@ drush:
 drupal:
   db:
     database: cogscilang_grad_uiowa_edu
-cloud:
-  appId: 21a2a0ab-b4ed-4ecf-8bd4-9266c70f5ef1
 cm:
   core:
     install_from_config: false

--- a/docroot/themes/custom/collegiate_theme/.gitignore
+++ b/docroot/themes/custom/collegiate_theme/.gitignore
@@ -1,13 +1,1 @@
-node_modules
-node_modules/*
-vendor
-composer.lock
-.DS_Store
-hds/fractal.js
-hds/gulpfile.js
-hds/docs
-hds/dist
-hds/_preview.twig
-assets/css/*
-assets/webfonts/*
-hds/*
+!assets/js

--- a/docroot/themes/custom/uids_base/.gitignore
+++ b/docroot/themes/custom/uids_base/.gitignore
@@ -1,8 +1,1 @@
-node_modules
-node_modules/*
-vendor
-composer.lock
-.DS_Store
-assets/css/*
-assets/fonts/*
-uids/*
+!assets/js


### PR DESCRIPTION
Only the top level gitignore file can specify files and directories that should be ignored during development but not in the build artifact. Otherwise, gitignore files in subdirectories will be copied into the build artifact directory and take effect during deployment.

Ideally, we can standardize our theme build process to make this easy to manage.