### PR TITLE
Write custom asset info file versions dynamically.

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -49,6 +49,9 @@ command-hooks:
   frontend-assets:
     dir: ${docroot}
     command: 'yarn workspaces run gulp'
+  post-deploy-build:
+    dir: ${repo.root}
+    command: './vendor/bin/blt uiowa:git:version'
 sync:
   commands:
     - 'blt:init:settings'

--- a/blt/src/Blt/Plugin/Commands/GitCommands.php
+++ b/blt/src/Blt/Plugin/Commands/GitCommands.php
@@ -108,7 +108,7 @@ class GitCommands extends BltTasks {
     if (!empty($tag)) {
       $version = $tag;
     }
-    else {
+    elseif (!empty($sha)) {
       $version = $sha;
     }
 

--- a/blt/src/Blt/Plugin/Commands/GitCommands.php
+++ b/blt/src/Blt/Plugin/Commands/GitCommands.php
@@ -100,9 +100,16 @@ class GitCommands extends BltTasks {
   /**
    * Write an unannotated Git tag version string to custom asset info files.
    *
-   * @hook post-command artifact:build
+   * This command should not be executed directly. It is called after the
+   * build artifact is created to write info versions dynamically.
+   *
+   * @see: blt/blt.yml
+   *
+   * @command uiowa:git:version
+   *
+   * @hidden
    */
-  public function writeGitVersion() {
+  public function version() {
     $result = $this->taskGit()
       ->dir($this->getConfigValue('repo.root'))
       ->exec('describe --tags')

--- a/blt/src/Blt/Plugin/Commands/GitCommands.php
+++ b/blt/src/Blt/Plugin/Commands/GitCommands.php
@@ -120,10 +120,10 @@ class GitCommands extends BltTasks {
       if (isset($version)) {
         $data = "version: '{$version}'";
         file_put_contents($file, $data, FILE_APPEND);
-        $this->logger->info("Appended Git version {$version} to {$file}.");
+        $this->say("Appended Git version {$version} to {$file}.");
       }
       else {
-        $this->logger->warning("Unable to append Git version to {$file}.");
+        $this->say("Unable to append Git version to {$file}.");
       }
     }
   }

--- a/docroot/profiles/custom/collegiate/collegiate.info.yml
+++ b/docroot/profiles/custom/collegiate/collegiate.info.yml
@@ -1,6 +1,6 @@
 name: Collegiate
 type: profile
-description: 'A profile built by CLAS and the Graduate College for deploying Drupal 8 sites.'
+description: 'A profile for deploying Drupal 8 sites with Layout Builder.'
 core: 8.x
 install:
   - node

--- a/docroot/profiles/custom/sitenow/sitenow.info.yml
+++ b/docroot/profiles/custom/sitenow/sitenow.info.yml
@@ -1,4 +1,3 @@
-# sitenow should be installed using the configuration in the default directory.
 name: sitenow
 type: profile
 description: 'Base installation profile of University of Iowa sites.'


### PR DESCRIPTION
This PR invokes a [post-deploy-build hook](https://docs.acquia.com/blt/extending-blt/#overriding-variables-at-runtime) to write an [unannotated tag](https://git-scm.com/docs/git-describe#_examples) to our custom asset info files. This is to fix a pre-merge, pre-Travis regression where the profile version is empty on the status report page. I expanded it to work with other custom assets.

This will not update info files that already contain a version in the case that manual versioning is preferred. This will also not search for info files in nested modules.