### PR TITLE
Set collegiate sites cm.strategy to none for now.

### DIFF
--- a/docroot/profiles/custom/collegiate/default.blt.yml
+++ b/docroot/profiles/custom/collegiate/default.blt.yml
@@ -9,7 +9,7 @@ drush:
   aliases:
     local: self
 cm:
-  strategy: core-only
+  strategy: none
   core:
     install_from_config: false
     dirs:

--- a/docroot/sites/cogscilang.grad.uiowa.edu/blt.yml
+++ b/docroot/sites/cogscilang.grad.uiowa.edu/blt.yml
@@ -14,7 +14,7 @@ drupal:
   db:
     database: cogscilang_grad_uiowa_edu
 cm:
-  strategy: core-only
+  strategy: none
   core:
     install_from_config: false
     dirs:

--- a/docroot/sites/icsa.uiowa.edu/blt.yml
+++ b/docroot/sites/icsa.uiowa.edu/blt.yml
@@ -19,4 +19,4 @@ cm:
     dirs:
       sync:
         path: ../config/icsa.uiowa.edu
-  strategy: core-only
+  strategy: none

--- a/docroot/sites/informatics.grad.uiowa.edu/blt.yml
+++ b/docroot/sites/informatics.grad.uiowa.edu/blt.yml
@@ -19,4 +19,4 @@ cm:
     dirs:
       sync:
         path: ../config/informatics.grad.uiowa.edu
-  strategy: core-only
+  strategy: none

--- a/docroot/sites/iowasuperfund.uiowa.edu/blt.yml
+++ b/docroot/sites/iowasuperfund.uiowa.edu/blt.yml
@@ -19,4 +19,4 @@ cm:
     dirs:
       sync:
         path: ../config/iowasuperfund.uiowa.edu
-  strategy: core-only
+  strategy: none

--- a/docroot/sites/policy.clas.uiowa.edu/blt.yml
+++ b/docroot/sites/policy.clas.uiowa.edu/blt.yml
@@ -19,4 +19,4 @@ cm:
     dirs:
       sync:
         path: ../config/policy.clas.uiowa.edu
-  strategy: core-only
+  strategy: none

--- a/docroot/sites/theming.uiowa.edu/blt.yml
+++ b/docroot/sites/theming.uiowa.edu/blt.yml
@@ -19,4 +19,4 @@ cm:
     dirs:
       sync:
         path: ../config/theming.uiowa.edu
-  strategy: core-only
+  strategy: none

--- a/docroot/sites/uiowa.edu/blt.yml
+++ b/docroot/sites/uiowa.edu/blt.yml
@@ -19,4 +19,4 @@ cm:
     dirs:
       sync:
         path: ../config/uiowa.edu
-  strategy: core-only
+  strategy: none

--- a/docroot/sites/uipda.grad.uiowa.edu/blt.yml
+++ b/docroot/sites/uipda.grad.uiowa.edu/blt.yml
@@ -19,4 +19,4 @@ cm:
     dirs:
       sync:
         path: ../config/uipda.grad.uiowa.edu
-  strategy: core-only
+  strategy: none


### PR DESCRIPTION
Follow up from #1041. I think more work needs to be done for collegiate sites to adopt the automated BLT config workflow. This change simply stops BLT from importing config on deployments.