### PR TITLE
Return exit code 1 on Gulp task failures.

### DIFF
--- a/docroot/themes/custom/collegiate_theme/gulpfile.js
+++ b/docroot/themes/custom/collegiate_theme/gulpfile.js
@@ -46,7 +46,7 @@ function css() {
     .pipe(plumber({
       handleError: function (err) {
         console.log(err);
-        this.emit('end');
+        process.exit(1);
       }
     }))
     .pipe(sass({
@@ -54,8 +54,7 @@ function css() {
         includePaths: config.css.includePaths
       }).on('error', function (err) {
         console.log(err.message);
-        // sass.logError.
-        this.emit('end');
+        process.exit(1);
       }))
     .pipe(prefix(['last 2 versions', '> 1%', 'ie 9', 'ie 10'], {
       cascade: true

--- a/docroot/themes/custom/uids_base/gulpfile.js
+++ b/docroot/themes/custom/uids_base/gulpfile.js
@@ -57,8 +57,7 @@ function css() {
         includePaths: config.css.includePaths
       }).on('error', function (err) {
         console.log(err.message);
-        // sass.logError.
-        this.emit('end');
+        process.exit(1);
       }))
     .pipe(prefix(['last 2 versions', '> 1%', 'ie 9', 'ie 10'], {
       cascade: true

--- a/docroot/themes/custom/uids_base/gulpfile.js
+++ b/docroot/themes/custom/uids_base/gulpfile.js
@@ -49,7 +49,7 @@ function css() {
     .pipe(plumber({
       handleError: function (err) {
         console.log(err);
-        this.emit('end');
+        process.exit(1);
       }
     }))
     .pipe(sass({

--- a/docroot/themes/custom/uids_base/scss/components/global/menus/mega-menu/mega-menu.scss
+++ b/docroot/themes/custom/uids_base/scss/components/global/menus/mega-menu/mega-menu.scss
@@ -1,3 +1,3 @@
 @import "assets/scss/_variables.scss";
 @import "assets/scss/_utilities.scss";
-@import "components/03 - global/menus/mega-menu/_mega-menu.scss";
+//@import "components/03 - global/menus/mega-menu/_mega-menu.scss";

--- a/docroot/themes/custom/uiowa_bootstrap/gulpfile.js
+++ b/docroot/themes/custom/uiowa_bootstrap/gulpfile.js
@@ -26,7 +26,7 @@ gulp.task('css', function () {
           message:  "Error: <%= error.message %>",
           sound:    "Beep"
         })(error);
-        this.emit('end');
+        process.exit(1);
       }}))
     .pipe(sourcemaps.init())
     .pipe(sass({
@@ -51,7 +51,7 @@ gulp.task('js', function () {
           message:  "Error: <%= error.message %>",
           sound:    "Beep"
         })(error);
-        this.emit('end');
+        process.exit(1);
       }}))
     .pipe(gulp.dest(config.js.dest));
 });


### PR DESCRIPTION
Resolves #1061 

Our Gulp tasks do not return exit codes > 0 on error. This can lead to corrupt/missing frontend dependencies in the build artifact.

I _think_ we should change `this.emit('end');` to `process.exit(1);` or have both. I'm not sure what `this.emit('end');` does.

