### PR TITLE
Added header text to featured content entity browser view

### DIFF
--- a/docroot/profiles/custom/sitenow/config/sync/views.view.featured_content.yml
+++ b/docroot/profiles/custom/sitenow/config/sync/views.view.featured_content.yml
@@ -844,7 +844,18 @@ display:
           entity_field: sticky
           plugin_id: boolean
       sorts: {  }
-      header: {  }
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'Only published content is available for selection.'
+          plugin_id: text_custom
       footer: {  }
       empty: {  }
       relationships: {  }


### PR DESCRIPTION
### Problem
When people go in to select featured content, they can only see published content in the entity browser view.

### Solution
Added view header help text informing the editor that only published content is available for selection.