### PR TITLE
Force add missing UIDS JS.

### DIFF
--- a/docroot/themes/custom/uids_base/assets/js/uids_base.js
+++ b/docroot/themes/custom/uids_base/assets/js/uids_base.js
@@ -1,0 +1,6 @@
+/**
+ * @file
+ * UIDS behaviors.
+ */
+
+document.documentElement.className = document.documentElement.className.replace("no-js", "js");


### PR DESCRIPTION
Because custom theme asset directories are ignored in the top level .gitignore, we have to either compile JS during build or force add them combined with a local gitignore that negates it.

https://github.com/uiowa/uiowa/blob/master/.gitignore#L32
https://github.com/uiowa/uiowa/blob/master/docroot/themes/custom/uids_base/.gitignore#L1

Long term, compiling all assets might be preferable.