### PR TITLE
Copy global Drush commands to build artifact.

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -53,7 +53,7 @@ command-hooks:
     command: 'yarn workspaces run gulp'
   post-deploy-build:
     dir: ${repo.root}
-    command: './vendor/bin/blt uiowa:git:version'
+    command: './vendor/bin/blt uiowa:post:build'
 sync:
   commands:
     - 'blt:init:settings'

--- a/blt/src/Blt/Plugin/Commands/GitCommands.php
+++ b/blt/src/Blt/Plugin/Commands/GitCommands.php
@@ -98,18 +98,27 @@ class GitCommands extends BltTasks {
   }
 
   /**
-   * Write an unannotated Git tag version string to custom asset info files.
+   * Run post build tasks.
    *
    * This command should not be executed directly. It is called after the
-   * build artifact is created to write info versions dynamically.
+   * build artifact is created in blt.yml.
    *
    * @see: blt/blt.yml
    *
-   * @command uiowa:git:version
+   * @command uiowa:post:build
    *
    * @hidden
    */
-  public function version() {
+  public function postArtifactBuild() {
+    $this->writeGitVersion();
+    $this->copyDrushCommands();
+  }
+
+  /**
+   * Write an unannotated Git tag version string to custom assets.
+   *
+   */
+  protected function writeGitVersion() {
     $result = $this->taskGit()
       ->dir($this->getConfigValue('repo.root'))
       ->exec('describe --tags')
@@ -163,10 +172,8 @@ class GitCommands extends BltTasks {
    * any hard-coded commands (ex. PolicyCommands.php) will not be committed to
    * the build artifact. Rather than override that file and lose upstream
    * changes, we can copy our Drush commands via a post-command hook.
-   *
-   * @hook post-command artifact:build
    */
-  public function copyDrushCommands() {
+  protected function copyDrushCommands() {
     $root = $this->getConfigValue('repo.root');
     $deploy_dir = $this->getConfigValue('deploy.dir');
 

--- a/blt/src/Blt/Plugin/Commands/GitCommands.php
+++ b/blt/src/Blt/Plugin/Commands/GitCommands.php
@@ -116,7 +116,6 @@ class GitCommands extends BltTasks {
 
   /**
    * Write an unannotated Git tag version string to custom assets.
-   *
    */
   protected function writeGitVersion() {
     $result = $this->taskGit()


### PR DESCRIPTION
The post-artifact build hook documented at https://docs.acquia.com/blt/extending-blt/#overriding-variables-at-runtime does not seem to be working. As a result, our UiowaCommands are not copied into the build artifact. This refactors the post-build step into one command that account for additional functionality.