### PR TITLE
Refactor automatic site installs out of code deploy cloud hooks.

### DIFF
--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -60,7 +60,7 @@ class MultisiteCommands extends BltTasks {
       throw new \Exception('Aborted.');
     }
     else {
-      $app = EnvironmentDetector::getAhGroup() ?? 'uiowa';
+      $app = EnvironmentDetector::getAhGroup() ?? 'local';
       $env = EnvironmentDetector::getAhEnv() ?? 'local';
 
       foreach ($this->getConfigValue('multisites') as $multisite) {
@@ -106,7 +106,7 @@ class MultisiteCommands extends BltTasks {
    * @aliases umi
    */
   public function install() {
-    $app = EnvironmentDetector::getAhGroup() ?? 'uiowa';
+    $app = EnvironmentDetector::getAhGroup() ?? 'local';
     $env = EnvironmentDetector::getAhEnv() ?? 'local';
 
     foreach ($this->getConfigValue('multisites') as $multisite) {

--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -131,7 +131,8 @@ class MultisiteCommands extends BltTasks {
           $this->invokeCommand('drupal:install', [
             '--site' => $multisite,
           ]);
-        } catch (BltException $e) {
+        }
+        catch (BltException $e) {
           $this->sendNotification("Drupal installation FAILED for site {$multisite} in {$env} environment.");
         }
 
@@ -676,4 +677,5 @@ EOD;
       curl_close($ch);
     }
   }
+
 }

--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -133,7 +133,7 @@ class MultisiteCommands extends BltTasks {
           ]);
         }
         catch (BltException $e) {
-          $this->sendNotification("Drupal installation FAILED for site {$multisite} in {$env} environment.");
+          $this->sendNotification("Drupal installation FAILED for site {$multisite} in {$env} environment on {$app} application.");
         }
 
         // If a requester was added, add them as a webmaster for the site.
@@ -150,7 +150,7 @@ class MultisiteCommands extends BltTasks {
             ->run();
         }
 
-        $this->sendNotification("Drupal installation complete for site {$multisite} in {$env} environment.");
+        $this->sendNotification("Drupal installation complete for site {$multisite} in {$env} environment on {$app} application.");
       }
       else {
         $this->say("Drupal already installed for {$multisite}. Skipping.");

--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -92,7 +92,7 @@ class MultisiteCommands extends BltTasks {
   }
 
   /**
-   * Install multisites that have empty databases.
+   * Invoke the BLT install process on multisites where Drupal is not installed.
    *
    * This command can be called manually or at regular intervals through a
    * scheduled cron task. It invokes the BLT drupal:install command which

--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -103,10 +103,8 @@ class MultisiteCommands extends BltTasks {
    * @command uiowa:multisite:install
    *
    * @aliases umi
-   *
    */
-  public function install()
-  {
+  public function install() {
     $app = EnvironmentDetector::getAhGroup() ?? 'uiowa';
 
     foreach ($this->getConfigValue('multisites') as $multisite) {

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -19,8 +19,8 @@ class ReplaceCommands extends BltTasks {
     // Disable alias since we are targeting a specific URI.
     $this->config->set('drush.alias', '');
 
-    $app = EnvironmentDetector::getAhGroup();
-    $env = EnvironmentDetector::getAhEnv();
+    $app = EnvironmentDetector::getAhGroup() ?? 'uiowa';
+    $env = EnvironmentDetector::getAhEnv() ?? 'local';
 
     foreach ($this->getConfigValue('multisites') as $multisite) {
       $this->switchSiteContext($multisite);

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -20,7 +20,6 @@ class ReplaceCommands extends BltTasks {
     $this->config->set('drush.alias', '');
 
     $app = EnvironmentDetector::getAhGroup() ?? 'uiowa';
-    $env = EnvironmentDetector::getAhEnv() ?? 'local';
 
     foreach ($this->getConfigValue('multisites') as $multisite) {
       $this->switchSiteContext($multisite);

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -19,7 +19,7 @@ class ReplaceCommands extends BltTasks {
     // Disable alias since we are targeting a specific URI.
     $this->config->set('drush.alias', '');
 
-    $app = EnvironmentDetector::getAhGroup() ?? 'uiowa';
+    $app = EnvironmentDetector::getAhGroup() ?? 'local';
 
     foreach ($this->getConfigValue('multisites') as $multisite) {
       $this->switchSiteContext($multisite);

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -24,7 +24,6 @@ class ReplaceCommands extends BltTasks {
 
     foreach ($this->getConfigValue('multisites') as $multisite) {
       $this->switchSiteContext($multisite);
-      $profile = $this->getConfigValue('project.profile.name');
       $db = $this->getConfigValue('drupal.db.database');
 
       // Check for database include on this application.
@@ -37,67 +36,6 @@ class ReplaceCommands extends BltTasks {
           $this->say("Deploying updates to <comment>$multisite</comment>...");
           $this->invokeCommand('drupal:update');
           $this->say("Finished deploying updates to $multisite.");
-        }
-        else {
-          $this->logger->warning("Drupal not installed for <comment>$multisite</comment>. Installing...");
-          $uri = $this->getConfig()->get('site');
-
-          if (empty($uri)) {
-            throw new \Exception('Cannot determine site directory for installation.');
-          }
-
-          $uid = uniqid('admin_');
-
-          $site_install_options = [
-            'sites-subdir' => $uri,
-            'account-name' => $uid,
-            'account-mail' => base64_decode('aXRzLXdlYkB1aW93YS5lZHU='),
-          ];
-
-          // If this is the sitenow profile, set the existing-config option.
-          if ($profile === 'sitenow' && $this->getConfigValue('cm.core.install_from_config') == TRUE) {
-            $site_install_options['existing-config'] = NULL;
-          }
-
-          $result = $this->taskDrush()
-            ->stopOnFail(TRUE)
-            ->drush('site:install')
-            ->arg($profile)
-            ->options($site_install_options)
-            ->drush('user:role:add')
-            ->args([
-              'administrator',
-              $uid,
-            ])
-            ->drush('config:set')
-            ->args([
-              'system.site',
-              'name',
-              $uri,
-            ])
-            ->run();
-
-          if (!$result->wasSuccessful()) {
-            throw new \Exception("Site install task failed for {$uri}.");
-          }
-
-          // If a requester was added, add them as a webmaster for the site.
-          if ($requester = $this->getConfigValue('uiowa.profiles.sitenow.requester')) {
-            $result = $this->taskDrush()
-              ->stopOnFail(FALSE)
-              ->drush('user:create')
-              ->args($requester)
-              ->drush('user:role:add')
-              ->args([
-                'webmaster',
-                $requester,
-              ])
-              ->run();
-
-            if (!$result->wasSuccessful()) {
-              throw new \Exception("Webmaster task failed for {$uri}.");
-            }
-          }
         }
       }
     }

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -19,86 +19,85 @@ class ReplaceCommands extends BltTasks {
     // Disable alias since we are targeting a specific URI.
     $this->config->set('drush.alias', '');
 
+    $app = EnvironmentDetector::getAhGroup();
+    $env = EnvironmentDetector::getAhEnv();
+
     foreach ($this->getConfigValue('multisites') as $multisite) {
       $this->switchSiteContext($multisite);
       $profile = $this->getConfigValue('project.profile.name');
       $db = $this->getConfigValue('drupal.db.database');
 
       // Check for database include on this application.
-      if (EnvironmentDetector::isAhEnv() || EnvironmentDetector::isLocalEnv()) {
-        $app = EnvironmentDetector::getAhGroup();
+      if (EnvironmentDetector::isAhEnv() && !file_exists("/var/www/site-php/{$app}/{$db}-settings.inc")) {
+        $this->say("Skipping $multisite on AH environment. Database {$db} does not exist.");
+        continue;
+      }
+      else {
+        if ($this->getInspector()->isDrupalInstalled()) {
+          $this->say("Deploying updates to <comment>$multisite</comment>...");
+          $this->invokeCommand('drupal:update');
+          $this->say("Finished deploying updates to $multisite.");
+        }
+        else {
+          $this->logger->warning("Drupal not installed for <comment>$multisite</comment>. Installing...");
+          $uri = $this->getConfig()->get('site');
 
-        if (file_exists("/var/www/site-php/{$app}/{$db}-settings.inc")) {
-
-          if ($this->getInspector()->isDrupalInstalled()) {
-            $this->say("Deploying updates to <comment>$multisite</comment>...");
-            $this->invokeCommand('drupal:update');
-            $this->say("Finished deploying updates to $multisite.");
+          if (empty($uri)) {
+            throw new \Exception('Cannot determine site directory for installation.');
           }
-          else {
-            $this->logger->warning("Drupal not installed for <comment>$multisite</comment>. Installing...");
-            $uri = $this->getConfig()->get('site');
 
-            if (empty($uri)) {
-              throw new \Exception('Cannot determine site directory for installation.');
-            }
+          $uid = uniqid('admin_');
 
-            $uid = uniqid('admin_');
+          $site_install_options = [
+            'sites-subdir' => $uri,
+            'account-name' => $uid,
+            'account-mail' => base64_decode('aXRzLXdlYkB1aW93YS5lZHU='),
+          ];
 
-            $site_install_options = [
-              'sites-subdir' => $uri,
-              'account-name' => $uid,
-              'account-mail' => base64_decode('aXRzLXdlYkB1aW93YS5lZHU='),
-            ];
+          // If this is the sitenow profile, set the existing-config option.
+          if ($profile === 'sitenow' && $this->getConfigValue('cm.core.install_from_config') == TRUE) {
+            $site_install_options['existing-config'] = NULL;
+          }
 
-            // If this is the sitenow profile, set the existing-config option.
-            if ($profile === 'sitenow' && $this->getConfigValue('cm.core.install_from_config') == TRUE) {
-              $site_install_options['existing-config'] = NULL;
-            }
+          $result = $this->taskDrush()
+            ->stopOnFail(TRUE)
+            ->drush('site:install')
+            ->arg($profile)
+            ->options($site_install_options)
+            ->drush('user:role:add')
+            ->args([
+              'administrator',
+              $uid,
+            ])
+            ->drush('config:set')
+            ->args([
+              'system.site',
+              'name',
+              $uri,
+            ])
+            ->run();
 
+          if (!$result->wasSuccessful()) {
+            throw new \Exception("Site install task failed for {$uri}.");
+          }
+
+          // If a requester was added, add them as a webmaster for the site.
+          if ($requester = $this->getConfigValue('uiowa.profiles.sitenow.requester')) {
             $result = $this->taskDrush()
-              ->stopOnFail(TRUE)
-              ->drush('site:install')
-              ->arg($profile)
-              ->options($site_install_options)
+              ->stopOnFail(FALSE)
+              ->drush('user:create')
+              ->args($requester)
               ->drush('user:role:add')
               ->args([
-                'administrator',
-                $uid,
-              ])
-              ->drush('config:set')
-              ->args([
-                'system.site',
-                'name',
-                $uri,
+                'webmaster',
+                $requester,
               ])
               ->run();
 
             if (!$result->wasSuccessful()) {
-              throw new \Exception("Site install task failed for {$uri}.");
-            }
-
-            // If a requester was added, add them as a webmaster for the site.
-            if ($requester = $this->getConfigValue('uiowa.profiles.sitenow.requester')) {
-              $result = $this->taskDrush()
-                ->stopOnFail(FALSE)
-                ->drush('user:create')
-                ->args($requester)
-                ->drush('user:role:add')
-                ->args([
-                  'webmaster',
-                  $requester,
-                ])
-                ->run();
-
-              if (!$result->wasSuccessful()) {
-                throw new \Exception("Webmaster task failed for {$uri}.");
-              }
+              throw new \Exception("Webmaster task failed for {$uri}.");
             }
           }
-        }
-        else {
-          $this->say("Skipping $multisite. Database {$db} does not exist.");
         }
       }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -7295,7 +7295,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.10",
-                    "datestamp": "1572617586",
+                    "datestamp": "1581850829",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8787,16 +8787,16 @@
         },
         {
             "name": "drush/drush",
-            "version": "9.7.1",
+            "version": "9.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drush-ops/drush.git",
-                "reference": "6f9a8d235daec06fd6f47b2d84da675750566479"
+                "reference": "ab5e345a72c9187a7d770486a09691f6526826aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drush-ops/drush/zipball/6f9a8d235daec06fd6f47b2d84da675750566479",
-                "reference": "6f9a8d235daec06fd6f47b2d84da675750566479",
+                "url": "https://api.github.com/repos/drush-ops/drush/zipball/ab5e345a72c9187a7d770486a09691f6526826aa",
+                "reference": "ab5e345a72c9187a7d770486a09691f6526826aa",
                 "shasum": ""
             },
             "require": {
@@ -8816,7 +8816,7 @@
                 "psr/log": "~1.0",
                 "psy/psysh": "~0.6",
                 "symfony/console": "^3.4",
-                "symfony/event-dispatcher": "^3.4",
+                "symfony/event-dispatcher": "^3.4 || ^4.0",
                 "symfony/finder": "^3.4 || ^4.0",
                 "symfony/process": "^3.4",
                 "symfony/var-dumper": "^3.4 || ^4.0",
@@ -8932,7 +8932,7 @@
             ],
             "description": "Drush is a command line shell and scripting interface for Drupal, a veritable Swiss Army knife designed to make life easier for those of us who spend some of our working hours hacking away at the command prompt.",
             "homepage": "http://www.drush.org",
-            "time": "2019-06-30T19:46:39+00:00"
+            "time": "2020-02-09T17:29:51+00:00"
         },
         {
             "name": "easyrdf/easyrdf",

--- a/docroot/modules/custom/sitenow_seo/sitenow_seo.module
+++ b/docroot/modules/custom/sitenow_seo/sitenow_seo.module
@@ -13,8 +13,7 @@ use Drupal\Core\Form\FormStateInterface;
 function sitenow_seo_form_google_analytics_admin_settings_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Restrict access to some Google Analytics form items for all roles
   // except administrator.
-  $roles = \Drupal::currentUser()->getRoles();
-  if (!in_array('administrator', $roles)) {
+  if (!sitenow_is_user_admin(\Drupal::currentUser())) {
     $form['tracking']['#access'] = FALSE;
     $form['advanced']['#access'] = FALSE;
   }

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -278,7 +278,7 @@ function sitenow_update_8015(&$sandbox) {
 }
 
 /**
- * Remove administrator role from all existing user 1 accounts.
+ * Remove administrator role from existing user 1 account.
  */
 function sitenow_update_8016() {
   /** @var \Drupal\user\UserInterface $user */

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -276,3 +276,13 @@ function sitenow_update_8015(&$sandbox) {
     $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
   }
 }
+
+/**
+ * Remove administrator role from all existing user 1 accounts.
+ */
+function sitenow_update_8016() {
+  /** @var \Drupal\user\UserInterface $user */
+  $user = User::load(1);
+  $user->removeRole('administrator');
+  $user->save();
+}

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -795,10 +795,12 @@ function sitenow_editor_js_settings_alter(array &$settings) {
  * Helper function to determine if the current user is an admin.
  *
  * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+ *   The current user account.
  *
  * @return bool
+ *   Boolean indicating whether or not current user is an admin.
  */
-function sitenow_is_user_admin(UserInterface $current_user) {
+function sitenow_is_user_admin(AccountProxyInterface $current_user) {
   if ($current_user->id() === 1 || in_array('administrator', $current_user->getRoles())) {
     return TRUE;
   }

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -9,13 +9,13 @@ use Drupal\Component\Utility\Html;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Session\AccountProxy;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\user\Entity\User;
-use Drupal\user\UserInterface;
 use Drupal\views\ViewExecutable;
 use Drupal\media\Entity\Media;
 use Drupal\file\Entity\File;
@@ -794,13 +794,13 @@ function sitenow_editor_js_settings_alter(array &$settings) {
 /**
  * Helper function to determine if the current user is an admin.
  *
- * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+ * @param \Drupal\Core\Session\AccountProxy $current_user
  *   The current user account.
  *
  * @return bool
  *   Boolean indicating whether or not current user is an admin.
  */
-function sitenow_is_user_admin(AccountProxyInterface $current_user) {
+function sitenow_is_user_admin(AccountProxy $current_user) {
   if ($current_user->id() === 1 || in_array('administrator', $current_user->getRoles())) {
     return TRUE;
   }

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -801,7 +801,7 @@ function sitenow_editor_js_settings_alter(array &$settings) {
  *   Boolean indicating whether or not current user is an admin.
  */
 function sitenow_is_user_admin(AccountProxy $current_user) {
-  if ($current_user->id() === 1 || in_array('administrator', $current_user->getRoles())) {
+  if ($current_user->id() == 1 || in_array('administrator', $current_user->getRoles())) {
     return TRUE;
   }
   else {


### PR DESCRIPTION
Resolves #1032 

This PR creates a command that can be run manually or scheduled in desired environments. It changes the install process to use the BLT `drupal:install` command which handles some things we were doing manually with Drush.