### PR TITLE
Refactor install command to require manual confirmation.

### DIFF
--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -98,21 +98,20 @@ class MultisiteCommands extends BltTasks {
    * This command invokes the BLT drupal:install command which handles passing
    * arguments and options to Drush site:install.
    *
-   * @see: Acquia\Blt\Robo\Commands\Drupal\InstallCommand
-   *
-   * @command uiowa:multisite:install
-   *s
    * @param array $options
    *   Command options.
-   *
    * @option dry-run
    *   Report back the uninstalled sites but do not install.
+   *
+   * @command uiowa:multisite:install
    *
    * @aliases umi
    *
    * @throws \Exception
+   *
+   * @see: Acquia\Blt\Robo\Commands\Drupal\InstallCommand
    */
-  public function install($options = ['dry-run' => FALSE]) {
+  public function install(array $options = ['dry-run' => FALSE]) {
     $app = EnvironmentDetector::getAhGroup() ?? 'local';
     $env = EnvironmentDetector::getAhEnv() ?? 'local';
 

--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -95,9 +95,6 @@ class MultisiteCommands extends BltTasks {
   /**
    * Invoke the BLT install process on multisites where Drupal is not installed.
    *
-   * This command invokes the BLT drupal:install command which handles passing
-   * arguments and options to Drush site:install.
-   *
    * @param array $options
    *   Command options.
    * @option dry-run

--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -95,23 +95,31 @@ class MultisiteCommands extends BltTasks {
   /**
    * Invoke the BLT install process on multisites where Drupal is not installed.
    *
-   * This command can be called manually or at regular intervals through a
-   * scheduled cron task. It invokes the BLT drupal:install command which
-   * handles passing arguments and options to Drush site:install.
+   * This command invokes the BLT drupal:install command which handles passing
+   * arguments and options to Drush site:install.
    *
    * @see: Acquia\Blt\Robo\Commands\Drupal\InstallCommand
    *
    * @command uiowa:multisite:install
+   *s
+   * @param array $options
+   *   Command options.
+   *
+   * @option dry-run
+   *   Report back the uninstalled sites but do not install.
    *
    * @aliases umi
+   *
+   * @throws \Exception
    */
-  public function install() {
+  public function install($options = ['dry-run' => FALSE]) {
     $app = EnvironmentDetector::getAhGroup() ?? 'local';
     $env = EnvironmentDetector::getAhEnv() ?? 'local';
 
+    $uninstalled = [];
+
     foreach ($this->getConfigValue('multisites') as $multisite) {
       $this->switchSiteContext($multisite);
-      $profile = $this->getConfigValue('project.profile.name');
 
       // Skip sites whose database do not exist on the application in AH env.
       if (EnvironmentDetector::isAhEnv()) {
@@ -124,36 +132,49 @@ class MultisiteCommands extends BltTasks {
       }
 
       if (!$this->getInspector()->isDrupalInstalled()) {
-        $this->say("Drupal not installed for {$multisite}. Installing...");
-
-        try {
-          $this->input()->setInteractive(FALSE);
-          $this->invokeCommand('drupal:install', [
-            '--site' => $multisite,
-          ]);
-        }
-        catch (BltException $e) {
-          $this->sendNotification("Drupal installation FAILED for site {$multisite} in {$env} environment on {$app} application.");
-        }
-
-        // If a requester was added, add them as a webmaster for the site.
-        if ($requester = $this->getConfigValue("uiowa.profiles.{$profile}.requester")) {
-          $this->taskDrush()
-            ->stopOnFail(FALSE)
-            ->drush('user:create')
-            ->args($requester)
-            ->drush('user:role:add')
-            ->args([
-              'webmaster',
-              $requester,
-            ])
-            ->run();
-        }
-
-        $this->sendNotification("Drupal installation complete for site {$multisite} in {$env} environment on {$app} application.");
+        $uninstalled[] = $multisite;
       }
-      else {
-        $this->say("Drupal already installed for {$multisite}. Skipping.");
+    }
+
+    if (!empty($uninstalled)) {
+      $this->io()->listing($uninstalled);
+
+      if (!$options['dry-run']) {
+        if ($this->confirm('You will invoke the drupal:install command for the sites listed above. Are you sure?', TRUE)) {
+          foreach ($uninstalled as $multisite) {
+            $this->switchSiteContext($multisite);
+            $profile = $this->getConfigValue('project.profile.name');
+
+            try {
+              $this->input()->setInteractive(FALSE);
+              $this->invokeCommand('drupal:install', [
+                '--site' => $multisite,
+              ]);
+            }
+            catch (BltException $e) {
+              $this->sendNotification("Drupal installation FAILED for site {$multisite} in {$env} environment on {$app} application.");
+            }
+
+            // If a requester was added, add them as a webmaster for the site.
+            if ($requester = $this->getConfigValue("uiowa.profiles.{$profile}.requester")) {
+              $this->taskDrush()
+                ->stopOnFail(FALSE)
+                ->drush('user:create')
+                ->args($requester)
+                ->drush('user:role:add')
+                ->args([
+                  'webmaster',
+                  $requester,
+                ])
+                ->run();
+            }
+
+            $this->sendNotification("Drupal installation complete for site {$multisite} in {$env} environment on {$app} application.");
+          }
+        }
+        else {
+          throw new \Exception('Canceled.');
+        }
       }
     }
   }

--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -173,6 +173,9 @@ class MultisiteCommands extends BltTasks {
         }
       }
     }
+    else {
+      $this->say('There are no uninstalled sites.');
+    }
   }
 
   /**


### PR DESCRIPTION
Running this command without confirmation could be disastrous. This is unfortunately just another step in the provisioning process.

Deploy a release, SSH into the application, CD to the app root and run `./vendor/bin/blt uiowa:multisite:install`.