### PR TITLE
Feature: uids_base sprint updates

### DIFF
--- a/docroot/profiles/custom/sitenow/config/sync/core.entity_view_display.block_content.uiowa_banner.default.yml
+++ b/docroot/profiles/custom/sitenow/config/sync/core.entity_view_display.block_content.uiowa_banner.default.yml
@@ -30,7 +30,7 @@ content:
     weight: 3
     label: above
     settings:
-      view_mode: default
+      view_mode: full__ultrawide
       link: false
     third_party_settings: {  }
     region: content

--- a/docroot/themes/custom/uids_base/package.json
+++ b/docroot/themes/custom/uids_base/package.json
@@ -6,7 +6,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@uiowa/uids": "uiowa/uids#semver:^1.5.2",
+    "@uiowa/uids": "uiowa/uids#semver:^1.5.3",
     "breakpoint-sass": "^2.7.1",
     "browser-sync": "^2.26.7",
     "del": "^3.0.0",

--- a/docroot/themes/custom/uids_base/scss/admin.scss
+++ b/docroot/themes/custom/uids_base/scss/admin.scss
@@ -65,7 +65,8 @@
   &.uids-component--gray {
     background: $light;
   }
-  &.uids-component--black {
+  &.uids-component--black,
+  &.uids-component--brain-black {
     background: $secondary;
   }
   &.uids-component--gold {

--- a/docroot/themes/custom/uids_base/scss/components/blocks/cta-block/cta-block.scss
+++ b/docroot/themes/custom/uids_base/scss/components/blocks/cta-block/cta-block.scss
@@ -7,6 +7,12 @@
 .layout__region--second,
 .layout__region--third,
 .layout__region--fourth {
+  .uids-component--brain-black .cta__container>div {
+    @include breakpoint(sm) {
+      margin: .5rem 0;
+    }
+  }
+
   .cta__container>div {
     @include breakpoint(sm) {
       margin: 1.05rem 0;

--- a/docroot/themes/custom/uids_base/scss/components/elements/video/video.scss
+++ b/docroot/themes/custom/uids_base/scss/components/elements/video/video.scss
@@ -27,6 +27,7 @@
   @extend .embed-responsive-4by3;
 }
 
+.media--type-remote-video.media--view-mode-default,
 .media--type-remote-video.media--view-mode-small__no-crop,
 .media--type-remote-video.media--view-mode-medium__no-crop,
 .media--type-remote-video.media--view-mode-large__no-crop,

--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -10,7 +10,6 @@ $imgpath: '../../uids/assets/images/';
     //width: 100%;
     //flex: 1 0 auto;
     flex-basis: 100%;
-    ;
   }
 
   .block-system-breadcrumb-block,
@@ -19,6 +18,14 @@ $imgpath: '../../uids/assets/images/';
   .block-inline-blockuiowa-text-area,
   .block-views {
     //flex-basis: 100%;
+  }
+}
+
+// ie11
+@media all and (-ms-high-contrast: none),
+(-ms-high-contrast: active) {
+  .layout__container .block-inline-blockuiowa-text-area {
+    flex-basis: unset;
   }
 }
 

--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -376,7 +376,6 @@ $imgpath: '../../uids/assets/images/';
     flex-wrap: wrap;
 
     span {
-      flex: 1;
       border: 1px solid $grey-light;
       display: block;
       text-align: center;
@@ -385,6 +384,7 @@ $imgpath: '../../uids/assets/images/';
       @include breakpoint(container) {
         border-right: none;
         margin: 0;
+        flex: 1;
       }
 
       a {

--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -390,11 +390,13 @@ $imgpath: '../../uids/assets/images/';
       a {
         display: block;
         text-decoration: none;
-        color: $med-gray;
+        color: #4F4F4F;
         line-height: 1;
         @include padding($top: $md, $right: $md, $bottom: $md, $left: $md);
 
-        &:hover {
+        &:hover,
+        &:focus,
+        &.is-active {
           background: $light;
         }
       }

--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -340,3 +340,72 @@ $imgpath: '../../uids/assets/images/';
     display: block;
   }
 }
+
+
+// todo move back to uids as toc style also create tag style for term edit
+
+.view-a-z-list {
+  .views-row {
+    margin-bottom: $md;
+    font-size: 1.3rem;
+    border-bottom: 1px solid $light;
+    padding: $sm 0;
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    a {
+      text-decoration: none;
+      font-weight: $font-weight-light;
+      color: $secondary;
+
+      &:hover,
+      &:focus {
+        text-decoration: underline;
+      }
+    }
+  }
+}
+
+
+.view-display-id-attachment_a_z_list {
+  >div {
+    @include flexbox;
+    @include margin($top: $lg, $left: 0, $bottom: $xlg);
+    flex-wrap: wrap;
+
+    span {
+      flex: 1;
+      border: 1px solid $grey-light;
+      display: block;
+      text-align: center;
+      margin: 0 $sm $sm 0;
+
+      @include breakpoint(container) {
+        border-right: none;
+        margin: 0;
+      }
+
+      a {
+        display: block;
+        text-decoration: none;
+        color: $med-gray;
+        line-height: 1;
+        @include padding($top: $md, $right: $md, $bottom: $md, $left: $md);
+
+        &:hover {
+          background: $light;
+        }
+      }
+
+      &:last-child {
+        a {
+          @include breakpoint(container) {
+            border-right: 1px solid $grey-light;
+          }
+        }
+      }
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -352,9 +352,9 @@
     gulp-sass-glob "^1.0.9"
     gulp-sourcemaps "^2.6.4"
 
-"@uiowa/uids@uiowa/uids#semver:^1.5.2":
-  version "1.5.2"
-  resolved "https://codeload.github.com/uiowa/uids/tar.gz/39b40b812380ddb6483cbc110f105f4f514cce40"
+"@uiowa/uids@uiowa/uids#semver:^1.5.3":
+  version "1.5.3"
+  resolved "https://codeload.github.com/uiowa/uids/tar.gz/c82a1d65ff690c66323a849c1996ab9e8edd41b4"
   dependencies:
     "@frctl/consolidate" "^1.0.1"
     "@frctl/fractal" "^1.1.7"


### PR DESCRIPTION
In this PR:

- A-Z List styling
- Update for default view mode for video embeds
- uids_base version update to 1.5.3
- Config: added image style for banner block component
- IE11 fix for 3-2 grid

# How to test

Run `blt frontend`

**A-Z List**
- Go to https://uiowa.local.drupal.uiowa.edu/a-z and verify that it is styled. 

**Video embed**
- Add a remote video without configuring a view mode.  Save the layout and see if the video appears. 

**Banner Image config**
- Add an image to a banner component on https://uiowa.local.drupal.uiowa.edu/admissions/undergraduate-admissions.  Save the layout and verify that the image source is a responsive format. 

**IE11**
- View the home page in IE11 and verify that the grid is working. 

**Hover, Focus styles**
- Tab through the home page and verify that you see hover and focus styles. 
