### PR TITLE
Catch type error in moderation state messaging viewing old revisions

### DIFF
--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -544,21 +544,6 @@ function sitenow_preprocess_page(&$variables) {
   $admin_context = \Drupal::service('router.admin_context');
   if (!$admin_context->isAdminRoute()) {
     $node = \Drupal::routeMatch()->getParameter('node');
-    if (isset($node)) {
-      // Get moderation state of node.
-      $revision_id = $node->getRevisionId();
-      $revision = \Drupal::entityTypeManager()->getStorage('node')->loadRevision($revision_id);
-      $moderation_state = $revision->get('moderation_state')->getString();
-      $status = $revision->get('status')->value;
-      if ($status == 0) {
-        $pre_vowel = (in_array($moderation_state[0], ['a', 'e', 'i', 'o', 'u']) ? 'n' : '');
-        $warning_text = t('This content is currently in a@pre_vowel <em>"@moderation_state"</em> state.', [
-          '@pre_vowel' => $pre_vowel,
-          '@moderation_state' => $moderation_state,
-        ]);
-        \Drupal::messenger()->addWarning($warning_text);
-      }
-    }
     $node = (isset($node) ? $node : \Drupal::routeMatch()->getParameter('node_preview'));
     if ($node instanceof NodeInterface) {
       $variables['header_attributes'] = new Attribute();

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -546,6 +546,19 @@ function sitenow_preprocess_page(&$variables) {
     $node = \Drupal::routeMatch()->getParameter('node');
     $node = (isset($node) ? $node : \Drupal::routeMatch()->getParameter('node_preview'));
     if ($node instanceof NodeInterface) {
+      // Get moderation state of node.
+      $revision_id = $node->getRevisionId();
+      $revision = \Drupal::entityTypeManager()->getStorage('node')->loadRevision($revision_id);
+      $moderation_state = $revision->get('moderation_state')->getString();
+      $status = $revision->get('status')->value;
+      if ($status == 0) {
+        $pre_vowel = (in_array($moderation_state[0], ['a', 'e', 'i', 'o', 'u']) ? 'n' : '');
+        $warning_text = t('This content is currently in a@pre_vowel <em>"@moderation_state"</em> state.', [
+          '@pre_vowel' => $pre_vowel,
+          '@moderation_state' => $moderation_state,
+        ]);
+        \Drupal::messenger()->addWarning($warning_text);
+      }
       $variables['header_attributes'] = new Attribute();
       if ($node->hasField('field_publish_options') && !$node->get('field_publish_options')->isEmpty()) {
         $publish_options = $node->get('field_publish_options')->getValue();


### PR DESCRIPTION
Remove moderation message as it is causing errors like:
```
drupal-watchdog web-33202 Mar 26 16:03:19 web-33202 uiowa01[4634]: https://coronavirus.uiowa.edu|1585238599|php|72.168.160.15|https://coronavirus.uiowa.edu/node/66/revisions/1236/view|https://coronavirus.uiowa.edu/node/66/revisions|81||Error: Call to a member function getRevisionId() on string in sitenow_preprocess_page() (line 549 of /mnt/www/html/uiowa01/docroot/profiles/custom/sitenow/sitenow.profile) 
```