### PR TITLE
Remove docs on vagrant/virtualbox issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project is based on BLT, an open-source project template and tool that enab
     ```
 ----
 # Local Environment
-Follow the [BLT docs](https://docs.acquia.com/blt/install/local-development/) to get started wit [DrupalVM](https://www.drupalvm.com/). **Note** that there is currently an issue with Vagrant 2.2.6 and the latest version of VirtualBox. Download [VirtualBox 6.0](https://www.virtualbox.org/wiki/Download_Old_Builds_6_0) instead.
+Follow the [BLT docs](https://docs.acquia.com/blt/install/local-development/) to get started wit [DrupalVM](https://www.drupalvm.com/).
 
 All BLT commands should be run on the VM. You can SSH into the VM using `vagrant ssh`. See the [Vagrant docs](https://www.vagrantup.com/docs/cli/) for basic CLI usage.
 


### PR DESCRIPTION
While working locally, I noticed the following message:
```
==> uiowa: A newer version of the box 'geerlingguy/drupal-vm' is available and already
==> uiowa: installed, but your Vagrant machine is running against
==> uiowa: version '2.0.6'. To update to version '2.0.8',
==> uiowa: destroy and recreate your machine.
```

This worked for me without issue but requires a `vagrant destroy` which drops all local databases. Make sure you're at a stopping point before doing this, e.g. all config exported.

While updating local dev tools, I updating Vagrant to the latest release which resolves an issue with VirtualBox 6.1. I probably did not follow the proper update/uninstall methods but everything seems to work for me even after a restart. I can't guarantee it will work for anyone else.

I don't think any testing/review needs to happen here. The point of this PR is just to remove our documented caveat on installing Vagrant/VirtualBox so that the BLT docs can be followed as-is.