### PR TITLE
Document local logging setup and patch entity_embed to prevent log flooding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ If you have troubles with an error on DrupalVM related to /tmp/xdebug.log, https
 
 **TLDR;** Run `sudo chmod 766 /tmp/xdebug.log` in the VM.
 
+## Databases
+Use [SequelPro](https://www.sequelpro.com/) to [connect to DrupalVM](http://docs.drupalvm.com/en/latest/configurations/databases-mysql/#connect-using-sequel-pro-or-a-similar-client).
+
+## Logging
+As long as a site has a local settings file, it should be configured to show all warnings and errors to the screen. Other log messages, like watchdog, can be viewed by tailing the syslog: `sudo tail -f /var/log/syslog | grep drupal`. [PimpMyLog](http://docs.drupalvm.com/en/latest/extras/pimpmylog/) is also available at https://pimpmylog.local.drupal.uiowa.edu but requires more configuration to work with syslog.
+
 ### BLT Configuration
 Make sure you have an [Acquia Cloud key and secret](https://docs.acquia.com/acquia-cloud/develop/api/auth/) saved in the `blt/local.blt.yml` file. This file is ignored by Git. Be sure you do not accidentally commit your credentials to the `blt/blt.yml` file which is tracked in Git. Do not share your key or secret with anyone.
 ```
@@ -78,9 +84,6 @@ Drupal core requires the following specific command to update dev dependencies p
 Certain scaffold files should be resolved/removed afterwards. The redirects in the `docroot/.htaccess` file need to be re-implemented and the `docroot/robots.txt` should be removed. Different updates may require difference procedures. For example, BLT may download default config files that we don't use like `docroot/sites/default/default.services.yml`.
 
 Configuration tracked in the repository will need to be exported before deployment. To ensure configuration is exported correctly, manually sync a site from production using Drush. Then run database updates and export any configuration changes. Add and commit the config changes and then run another `blt dsa` to check for any further config discrepancies. If there are none, proceed with code deployment as per usual.
-
-## Databases
-Use [SequelPro](https://www.sequelpro.com/) to [connect to DrupalVM](http://docs.drupalvm.com/en/latest/configurations/databases-mysql/#connect-using-sequel-pro-or-a-similar-client).
 
 # Resources
 Additional [BLT documentation](https://docs.acquia.com/blt/) may be useful. You may also access a list of BLT commands by running this:

--- a/box/config.yml
+++ b/box/config.yml
@@ -54,9 +54,9 @@ apache_vhosts:
     extra_parameters: '{{ apache_vhost_php_fpm_parameters }}'
 
   -
-    servername: 'adminer.{{ drupal_domain }}'
-    serveralias: 'www.adminer.{{ drupal_domain }}'
-    documentroot: '{{ adminer_install_dir }}'
+    servername: 'pimpmylog.{{ drupal_domain }}'
+    serveralias: 'www.pimpmylog.{{ drupal_domain }}'
+    documentroot: '{{ pimpmylog_install_dir }}'
     extra_parameters: '{{ apache_vhost_php_fpm_parameters }}'
 
   -
@@ -889,6 +889,7 @@ extra_packages:
 
 installed_extras:
   - mailhog
+  - pimpmylog
   - memcached
   - nodejs
   - solr

--- a/composer.json
+++ b/composer.json
@@ -194,7 +194,10 @@
                 "Section Dependency": "https://www.drupal.org/files/issues/2019-08-23/layout_builder_styles-3062261-%2310.patch"
             },
             "drupal/honeypot": {
-                "Better spam protection through field weight":"https://www.drupal.org/files/issues/2019-08-08/honeypot_field_weight_2811189-18.patch"
+                "Better spam protection through field weight": "https://www.drupal.org/files/issues/2019-08-08/honeypot_field_weight_2811189-18.patch"
+            },
+            "drupal/entity_embed": {
+                "Logs flooded with warning messages Invalid display settings encountered": "https://www.drupal.org/files/issues/2019-12-11/3077225-10.reduce-invalid-config-logs.patch"
             }
         },
         "installer-types": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "092c42dd6a7bcbe829867f0baa344aaa",
+    "content-hash": "b905452150da1712b6dab4d922a5cba2",
     "packages": [
         {
             "name": "acquia/blt",
@@ -4939,6 +4939,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Logs flooded with warning messages Invalid display settings encountered": "https://www.drupal.org/files/issues/2019-12-11/3077225-10.reduce-invalid-config-logs.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -7306,7 +7309,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.10",
-                    "datestamp": "1572617586",
+                    "datestamp": "1581850829",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8228,7 +8231,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-rc2",
-                    "datestamp": "1572359629",
+                    "datestamp": "1573250584",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."
@@ -17961,5 +17964,6 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
While monitoring server logs, I noticed entity_embed flooded entries and looked to fix it locally. Documented how to monitor Drupal watchdog locally since dblog is never enabled.