### PR TITLE
Scope drush cache by app first to reduce permission errors.

### DIFF
--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -84,7 +84,7 @@ class MultisiteCommands extends BltTasks {
         if (!in_array($multisite, $options['exclude'])) {
           // Define a site-specific cache directory.
           // @see: https://github.com/acquia/blt/issues/2957
-          $tmp = "/tmp/.drush/{$app}/{$env}/" . md5($multisite);
+          $tmp = "/tmp/.drush-cache-{$app}/{$env}/" . md5($multisite);
 
           $this->taskDrush()
             ->drush($cmd)

--- a/hooks/dev/post-code-deploy/post-code-deploy.sh
+++ b/hooks/dev/post-code-deploy/post-code-deploy.sh
@@ -24,7 +24,7 @@ repo_root="/var/www/html/$site.$target_env"
 export PATH=$repo_root/vendor/bin:$PATH
 cd $repo_root
 
-export DRUSH_PATHS_CACHE_DIRECTORY=/tmp/.drush/${site}/${target_env}/$RANDOM
+export DRUSH_PATHS_CACHE_DIRECTORY=/tmp/.drush-cache-${site}/${target_env}
 blt artifact:ac-hooks:post-code-deploy $site $target_env $source_branch $deployed_tag $repo_url $repo_type --environment=$target_env -v --no-interaction -D drush.ansi=false
 
 set +v


### PR DESCRIPTION
Trying another cache directory structure to solve the permissions errors on prod deployments.