### PR TITLE
Fix preview error caused by moderation check

### DIFF
--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -548,16 +548,18 @@ function sitenow_preprocess_page(&$variables) {
     if ($node instanceof NodeInterface) {
       // Get moderation state of node.
       $revision_id = $node->getRevisionId();
-      $revision = \Drupal::entityTypeManager()->getStorage('node')->loadRevision($revision_id);
-      $moderation_state = $revision->get('moderation_state')->getString();
-      $status = $revision->get('status')->value;
-      if ($status == 0) {
-        $pre_vowel = (in_array($moderation_state[0], ['a', 'e', 'i', 'o', 'u']) ? 'n' : '');
-        $warning_text = t('This content is currently in a@pre_vowel <em>"@moderation_state"</em> state.', [
-          '@pre_vowel' => $pre_vowel,
-          '@moderation_state' => $moderation_state,
-        ]);
-        \Drupal::messenger()->addWarning($warning_text);
+      if ($revision_id) {
+        $revision = \Drupal::entityTypeManager()->getStorage('node')->loadRevision($revision_id);
+        $moderation_state = $revision->get('moderation_state')->getString();
+        $status = $revision->get('status')->value;
+        if ($status == 0) {
+          $pre_vowel = (in_array($moderation_state[0], ['a', 'e', 'i', 'o', 'u']) ? 'n' : '');
+          $warning_text = t('This content is currently in a@pre_vowel <em>"@moderation_state"</em> state.', [
+            '@pre_vowel' => $pre_vowel,
+            '@moderation_state' => $moderation_state,
+          ]);
+          \Drupal::messenger()->addWarning($warning_text);
+        }
       }
       $variables['header_attributes'] = new Attribute();
       if ($node->hasField('field_publish_options') && !$node->get('field_publish_options')->isEmpty()) {


### PR DESCRIPTION
Resolves #1378 where if revision id is null, the following moderation state get string fails resulting in a 500 error on preview.

This now checks for a revision id before moving forward with the moderation check/status message.

## To Test
Editors can successfully view published/needs review/draft states of their node content including previewing their current changes and looking back at old revisions.
