### PR TITLE
Feature: Banner and banner block template updates

### DIFF
--- a/docroot/themes/custom/uids_base/templates/block/block--inline-block--uiowa-banner.html.twig
+++ b/docroot/themes/custom/uids_base/templates/block/block--inline-block--uiowa-banner.html.twig
@@ -36,15 +36,17 @@
     'link_url': content.field_uiowa_banner_link[0]['#url'],
     'link_text': content.field_uiowa_banner_link[0]['#title'],
     'link_classes': ['bttn', 'bttn--primary', 'bttn--caps'],
-  }
+  },
+  'title_prefix': title_prefix,
+  'title_suffix': title_suffix,
 } %}
 
 {% embed '@uids_base/uids/banner.html.twig' with block_banner only %}
 
-{#  {% block heading %}#}
-{#    {{ title_prefix }}#}
-{#    {{ parent() }}#}
-{#    {{ title_suffix }}#}
-{#  {% endblock %}#}
+  {% block banner_image %}
+  {{ parent() }}
+  {{ title_prefix }}
+  {{ title_suffix }}
+  {% endblock banner_image %}
 
 {% endembed %}

--- a/docroot/themes/custom/uids_base/templates/block/block--inline-block--uiowa-banner.html.twig
+++ b/docroot/themes/custom/uids_base/templates/block/block--inline-block--uiowa-banner.html.twig
@@ -43,8 +43,10 @@
 
 {% embed '@uids_base/uids/banner.html.twig' with block_banner only %}
 
+
   {% block banner_image %}
   {{ parent() }}
+  {# Embed contextual links so that they'll show up in the upper right-hand corner. #}
   {{ title_prefix }}
   {{ title_suffix }}
   {% endblock banner_image %}

--- a/docroot/themes/custom/uids_base/templates/block/block--inline-block--uiowa-card.html.twig
+++ b/docroot/themes/custom/uids_base/templates/block/block--inline-block--uiowa-card.html.twig
@@ -26,8 +26,6 @@
 */
 #}
 
-{% block content %}
-
   {% embed '@uids_base/uids/blocks/card.html.twig' with {
     'card_image': content.field_uiowa_card_image,
     'card_text': content.field_uiowa_card_excerpt,
@@ -81,7 +79,4 @@
       {% endif %}
     {% endblock %}
 
-
   {% endembed %}
-
-{% endblock %}

--- a/docroot/themes/custom/uids_base/templates/uids/banner.html.twig
+++ b/docroot/themes/custom/uids_base/templates/uids/banner.html.twig
@@ -30,7 +30,7 @@
         <p class="banner__summary">{{ banner_summary }}</p>
       {% endif %}
 
-      {% if not link.link_url.isEmpty() %}
+      {% if link and link.link_url is not empty %}
         {% set link = link|merge({
           'link_icon_class': 'fas fa-arrow-right',
         }) %}


### PR DESCRIPTION
Resolves #1438 

* Re-adds contextual links to the banner block template.
* Updates the link URL empty check in the banner template so that it isn't triggered unintentionally.
