### PR TITLE
Brand - Switch lockup form to use uids_base

### DIFF
--- a/docroot/sites/brand.uiowa.edu/modules/brand_core/src/Theme/LockupForm.php
+++ b/docroot/sites/brand.uiowa.edu/modules/brand_core/src/Theme/LockupForm.php
@@ -33,6 +33,6 @@ class LockupForm implements ThemeNegotiatorInterface {
    * @inheritDoc
    */
   public function determineActiveTheme(RouteMatchInterface $route_match) {
-    return 'uiowa_bootstrap';
+    return 'uids_base';
   }
 }


### PR DESCRIPTION
Resolves #1451

Other style overrides still are being applied: https://github.com/uiowa/uiowa/blob/master/docroot/sites/brand.uiowa.edu/modules/brand_core/css/lockup-preview.css

<img width="1446" alt="Screen Shot 2020-04-21 at 5 07 38 PM" src="https://user-images.githubusercontent.com/4663676/79918880-e7a69600-83f2-11ea-808e-02661b015166.png">
