### PR TITLE
Fixed problem with outputting array of classes for drop down nav.

### DIFF
--- a/docroot/themes/custom/uids_base/templates/layout/header.html.twig
+++ b/docroot/themes/custom/uids_base/templates/layout/header.html.twig
@@ -6,7 +6,6 @@
 {% if header_sticky %}
   {{ attach_library('uids_base/header-sticky') }}
 {% endif %}
-
 <header{{ attributes.addClass(header_classes) }}>
 
   <div class="uiowa-bar">
@@ -37,11 +36,13 @@
 
 {% block horizontal_nav %}
   {% if header_nav in ['horizontal', 'mega'] %}
+    {% set nav_attributes = create_attribute() %}
     {% set nav_classes = [
       'menu-horizontal',
-      'nav--' ~ header_type,
-    ] %}
-    <nav class="{{ nav_classes }}">
+      'nav--' ~ header_nav,
+    ]|merge(header_classes) %}
+
+    <nav{{ nav_attributes.addClass(nav_classes) }}>
       <div class="page__container">
         {{ page.primary_menu }}
       </div>


### PR DESCRIPTION
Resolves #1454 

# To test
```
blt ds --site=immuno.grad.uiowa.edu
drush @gradimmuno.local uli
```
* Vist https://gradimmuno.local.drupal.uiowa.edu/admin/appearance/settings/uids_base and change the navigation setting to something other than 'toggle'.
* Visit https://gradimmuno.local.drupal.uiowa.edu/ and confirm there is not a bunch of errors on the page.
* Inspect the drop-down menu and verify that classes are being added to the `<nav>` element after the `<header>` element
  <img width="521" alt="Screen Shot 2020-04-22 at 11 14 13 AM" src="https://user-images.githubusercontent.com/709009/80006474-892cf680-848a-11ea-9129-3dc160267c3e.png">
