### PR TITLE
Hotfix webp image style derivatives.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -211,6 +211,9 @@
             },
             "drupal/entity_embed": {
                 "Logs flooded with warning messages Invalid display settings encountered": "https://www.drupal.org/files/issues/2019-12-11/3077225-10.reduce-invalid-config-logs.patch"
+            },
+            "drupal/webp": {
+                "Module does not support image generation for images with UPPERCASED extension": "https://www.drupal.org/files/issues/2019-12-20/module_does_not_support_image_generation_for_images_with_UPPERCASED_extension-3101989-4.patch"
             }
         },
         "installer-types": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc310eca4466591b64f107b0f73a1a9c",
+    "content-hash": "588e8ee6102806c99fc29f3c68d730ec",
     "packages": [
         {
             "name": "acquia/blt",
@@ -8974,6 +8974,9 @@
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
                     }
+                },
+                "patches_applied": {
+                    "Module does not support image generation for images with UPPERCASED extension": "https://www.drupal.org/files/issues/2019-12-20/module_does_not_support_image_generation_for_images_with_UPPERCASED_extension-3101989-4.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -18295,5 +18298,6 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/docroot/profiles/custom/sitenow/config/sync/imagemagick.settings.yml
+++ b/docroot/profiles/custom/sitenow/config/sync/imagemagick.settings.yml
@@ -31,7 +31,7 @@ image_formats:
     enabled: false
   WEBP:
     mime_type: image/webp
-    enabled: false
+    enabled: true
   TIFF:
     mime_type: image/tiff
     enabled: false

--- a/docroot/profiles/custom/sitenow/config/sync/webp.settings.yml
+++ b/docroot/profiles/custom/sitenow/config/sync/webp.settings.yml
@@ -1,3 +1,3 @@
-quality: 100
+quality: 90
 _core:
   default_config_hash: gOcBKg5XbrudN3Hw5LYNWCXNrqmyh-Iq_YCpkyMa9Jo


### PR DESCRIPTION
The patch fixes the issue but I added a couple config changes for good measure. I'm surprised core doesn't transliterate file extension by default...