### PR TITLE
Updated sitenow 16:9 responsive image setting to include fallback image.

### DIFF
--- a/docroot/profiles/custom/sitenow/config/sync/responsive_image.styles.sitenow_16_9.yml
+++ b/docroot/profiles/custom/sitenow/config/sync/responsive_image.styles.sitenow_16_9.yml
@@ -13,29 +13,29 @@ id: sitenow_16_9
 label: 'SiteNow 16:9'
 image_style_mappings:
   -
-    breakpoint_id: uiowa_bootstrap.xl
+    breakpoint_id: uiowa_bootstrap.mobile
     multiplier: 1x
     image_mapping_type: image_style
-    image_mapping: sitenow_16_9_xlarge
-  -
-    breakpoint_id: uiowa_bootstrap.lg
-    multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: sitenow_16_9_large
-  -
-    breakpoint_id: uiowa_bootstrap.md
-    multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: sitenow_16_9_medium
+    image_mapping: sitenow_16_9_small
   -
     breakpoint_id: uiowa_bootstrap.sm
     multiplier: 1x
     image_mapping_type: image_style
     image_mapping: sitenow_16_9_small
   -
-    breakpoint_id: uiowa_bootstrap.mobile
+    breakpoint_id: uiowa_bootstrap.md
     multiplier: 1x
     image_mapping_type: image_style
-    image_mapping: sitenow_16_9_small
+    image_mapping: sitenow_16_9_medium
+  -
+    breakpoint_id: uiowa_bootstrap.lg
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: sitenow_16_9_large
+  -
+    breakpoint_id: uiowa_bootstrap.xl
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: sitenow_16_9_xlarge
 breakpoint_group: uiowa_bootstrap
-fallback_image_style: '_empty image_'
+fallback_image_style: sitenow_16_9_large


### PR DESCRIPTION
Resolves #1536. 

Also look like the config decided to output the settings in a different order, but nothing but the fallback image actually changed.

# To test
1. Add the following to the bottom of `docroot/sites/iowasuperfund/settings/local.settings.php`:
    ```
    $config['stage_file_proxy.settings']['origin'] = 'https://iowasuperfund.prod.drupal.uiowa.edu';
    $config['stage_file_proxy.settings']['hotlink'] = TRUE;
    ```
2. `blt ds --site=iowasuperfund.uiowa.edu`
3. View https://iowasuperfund.local.drupal.uiowa.edu/news/2019/05/releasing-our-data to confirm that the featured image is showing up
