### PR TITLE
Fix linkit button styles after class change

### DIFF
--- a/docroot/modules/custom/sitenow_media_wysiwyg/js/button_style.js
+++ b/docroot/modules/custom/sitenow_media_wysiwyg/js/button_style.js
@@ -7,7 +7,7 @@
         attach: function (context, settings) {
             $('.editor-link-dialog', context).once('button-style-attach').each(function () {
                 $(".button-style").click(function () {
-                    var $class = $(".form-item-attributes-class input");
+                    var $class = $(".form-item--attributes-class input");
                     var $button = $(this).data("btn-type");
                     var $classes = $class.val().split(" ");
                     $class.val($class.val().trim());


### PR DESCRIPTION
The class form-item--attributes-class was updated and the JS didn't fire.

<img width="474" alt="Screen Shot 2020-05-08 at 9 53 52 AM" src="https://user-images.githubusercontent.com/4663676/81418179-de673a00-9111-11ea-8c53-ee419e1d40a6.png">
