### PR TITLE
Updated policy.clas config to reflect updated carousel config.

### DIFF
--- a/config/policy.clas.uiowa.edu/core.entity_view_display.paragraph.carousel_image.default.yml
+++ b/config/policy.clas.uiowa.edu/core.entity_view_display.paragraph.carousel_image.default.yml
@@ -1,0 +1,37 @@
+uuid: 803322b7-917a-4699-a375-19dbf18b71d5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.carousel_image.field_carousel_image_caption
+    - field.field.paragraph.carousel_image.field_carousel_image_image
+    - field.field.paragraph.carousel_image.field_uip_classes
+    - field.field.paragraph.carousel_image.field_uip_id
+    - paragraphs.paragraphs_type.carousel_image
+  module:
+    - text
+id: paragraph.carousel_image.default
+targetEntityType: paragraph
+bundle: carousel_image
+mode: default
+content:
+  field_carousel_image_caption:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_carousel_image_image:
+    type: entity_reference_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: full__widescreen
+      link: false
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_uip_classes: true
+  field_uip_id: true
+  search_api_excerpt: true


### PR DESCRIPTION
This should fix the issue that is causing the the post deploy hook on uiowa01 to fail on policy.clas.uiowa.edu.