### PR TITLE
hotfix move old card logic local to hr icon card

### DIFF
--- a/docroot/sites/hr.uiowa.edu/modules/hr_core/hr_core.module
+++ b/docroot/sites/hr.uiowa.edu/modules/hr_core/hr_core.module
@@ -102,6 +102,9 @@ function hr_core_theme_suggestions_paragraph_alter(&$suggestions, $variables) {
           if ($result) {
             $suggestions[] = 'paragraph__card__title_overlay';
           }
+          if (in_array('card--img-icon', $classes)) {
+            $suggestions[] = 'paragraph__card__icon';
+          }
         }
         break;
 

--- a/docroot/sites/hr.uiowa.edu/themes/hr/hr.theme
+++ b/docroot/sites/hr.uiowa.edu/themes/hr/hr.theme
@@ -6,6 +6,8 @@
  */
 
 use Drupal\node\NodeInterface;
+use Drupal\file\Entity\File;
+use Drupal\media\Entity\Media;
 
 /**
  * Implements hook_theme_suggestions_HOOK_alter().
@@ -73,14 +75,38 @@ function hr_preprocess_paragraph__card(&$variables) {
   $paragraph = $variables['paragraph'];
   $admin_context = \Drupal::service('router.admin_context');
   if (!$admin_context->isAdminRoute()) {
-    if (isset($variables["content"]['card_image'])) {
+    if (isset($variables["content"]['field_card_image'])) {
       if ($paragraph->hasField('field_uip_classes') && !$paragraph->get('field_uip_classes')->isEmpty()) {
         $values = $paragraph->get('field_uip_classes')->getValue();
         if (array_search('card--img-icon', array_column($values, 'value')) !== FALSE) {
-          $variables["content"]["card_image"]["#style_name"] = 'uiowa_card_icon';
-          $variables['content']['card_image']['#theme_wrappers'] = [
-            'container' => ['#attributes' => ['class' => ['card--img-icon-wrapper']]],
-          ];
+          // Render card image.
+          $image_field = $paragraph->get('field_card_image');
+          if (!$image_field->isEmpty()) {
+            $image = $image_field->first()->getValue();
+            $media = Media::load($image['target_id']);
+            if ($media) {
+              $media_field = $media->get('field_media_image')
+                ->first()
+                ->getValue();
+              $file = File::load($media_field['target_id']);
+              $uri = $file->getFileUri();
+              $alt = ($media_field['alt'] ? $media_field['alt'] : '');
+              $image = [
+                '#theme' => 'image_style',
+                '#width' => NULL,
+                '#height' => NULL,
+                '#style_name' => 'uiowa_card_icon',
+                '#uri' => $uri,
+                '#alt' => $alt,
+                '#weight' => -1,
+              ];
+              $variables["content"]['card_image'] = $image;
+              $variables['content']['card_image']['#theme_wrappers'] = [
+                'container' => ['#attributes' => ['class' => ['card--img-icon-wrapper']]],
+              ];
+              unset($variables["content"]['field_card_image']);
+            }
+          }
         }
       }
     }

--- a/docroot/sites/hr.uiowa.edu/themes/hr/templates/paragraphs/paragraph--card--icon.html.twig
+++ b/docroot/sites/hr.uiowa.edu/themes/hr/templates/paragraphs/paragraph--card--icon.html.twig
@@ -1,0 +1,60 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{% set classes = [
+  'paragraph',
+  'paragraph--type--' ~ paragraph.bundle|clean_class,
+  view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+  not paragraph.isPublished() ? 'paragraph--unpublished'
+] %}
+
+{% block paragraph %}
+<div{{ attributes.addclass(classes) }}>
+  <div{{ card_attributes.addClass('card') }}>
+    {{ content.card_image }}
+
+    <div class="card-body">
+      {{ content.field_card_title }}
+      {{ content.field_card_subtitle }}
+      {{ content.field_card_body }}
+    </div>
+  </div>
+</div>
+{% endblock paragraph %}


### PR DESCRIPTION
HR's image icon cards broke because they weren't using the 16:9 image style. Moved old sitenow logic to hr to fix.