### PR TITLE
uiowa alerts - swap role "alert" for "region" on custom alert

### DIFF
--- a/docroot/modules/custom/uiowa_alerts/src/Plugin/Block/AlertsBlock.php
+++ b/docroot/modules/custom/uiowa_alerts/src/Plugin/Block/AlertsBlock.php
@@ -109,7 +109,7 @@ class AlertsBlock extends BlockBase implements ContainerFactoryPluginInterface {
               'alert',
               "alert-{$level}",
             ],
-            'role' => 'alert',
+            'role' => 'region',
             'aria-label' => ($level == 'danger') ? 'alert message' : "{$level} message",
           ],
           'message_wrapper' => [


### PR DESCRIPTION
Relates to #1437

The custom alert message should not have `role=alert` since it is loaded with the page. Replaced with `role=region`. The hawk alert, using Drupal's core message functionality via JS will still have role alert since it is dynamically called and updated.
