### PR TITLE
Enable site_splits for afam, amstud, nais, and anthropology sites

### DIFF
--- a/config/africanamericanstudies.uiowa.edu/.htaccess
+++ b/config/africanamericanstudies.uiowa.edu/.htaccess
@@ -1,0 +1,27 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php5.c>
+  php_flag engine off
+</IfModule>
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>

--- a/config/africanamericanstudies.uiowa.edu/config_split.config_split.africanamericanstudies_uiowa_edu.yml
+++ b/config/africanamericanstudies.uiowa.edu/config_split.config_split.africanamericanstudies_uiowa_edu.yml
@@ -1,0 +1,16 @@
+uuid: 580fcc57-49a9-42cf-a2c1-f891e86c7e54
+langcode: en
+status: true
+dependencies: {  }
+id: africanamericanstudies_uiowa_edu
+label: africanamericanstudies.uiowa.edu
+description: 'Site split.'
+folder: ../config/africanamericanstudies.uiowa.edu
+module: {  }
+theme: {  }
+blacklist: {  }
+graylist:
+  - config_split.config_split.africanamericanstudies_uiowa_edu
+graylist_dependents: true
+graylist_skip_equal: true
+weight: 90

--- a/config/americanstudies.uiowa.edu/.htaccess
+++ b/config/americanstudies.uiowa.edu/.htaccess
@@ -1,0 +1,27 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php5.c>
+  php_flag engine off
+</IfModule>
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>

--- a/config/americanstudies.uiowa.edu/config_split.config_split.americanstudies_uiowa_edu.yml
+++ b/config/americanstudies.uiowa.edu/config_split.config_split.americanstudies_uiowa_edu.yml
@@ -1,0 +1,16 @@
+uuid: d05ea993-7772-42b8-8ef3-9130bbccc922
+langcode: en
+status: true
+dependencies: {  }
+id: americanstudies_uiowa_edu
+label: americanstudies.uiowa.edu
+description: 'Site split.'
+folder: ../config/americanstudies.uiowa.edu
+module: {  }
+theme: {  }
+blacklist: {  }
+graylist:
+  - config_split.config_split.americanstudies_uiowa_edu
+graylist_dependents: true
+graylist_skip_equal: true
+weight: 90

--- a/config/anthropology.uiowa.edu/.htaccess
+++ b/config/anthropology.uiowa.edu/.htaccess
@@ -1,0 +1,27 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php5.c>
+  php_flag engine off
+</IfModule>
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>

--- a/config/anthropology.uiowa.edu/config_split.config_split.anthropology_uiowa_edu.yml
+++ b/config/anthropology.uiowa.edu/config_split.config_split.anthropology_uiowa_edu.yml
@@ -1,0 +1,16 @@
+uuid: 2c61451e-8a57-4e02-bb54-ceb4636bbdb2
+langcode: en
+status: true
+dependencies: {  }
+id: anthropology_uiowa_edu
+label: anthropology.uiowa.edu
+description: 'Site split.'
+folder: ../config/anthropology.uiowa.edu
+module: {  }
+theme: {  }
+blacklist: {  }
+graylist:
+  - config_split.config_split.anthropology_uiowa_edu
+graylist_dependents: true
+graylist_skip_equal: true
+weight: 90

--- a/config/nativeamericanstudies.uiowa.edu/.htaccess
+++ b/config/nativeamericanstudies.uiowa.edu/.htaccess
@@ -1,0 +1,27 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php5.c>
+  php_flag engine off
+</IfModule>
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>

--- a/config/nativeamericanstudies.uiowa.edu/config_split.config_split.nativeamericanstudies_uiowa_edu.yml
+++ b/config/nativeamericanstudies.uiowa.edu/config_split.config_split.nativeamericanstudies_uiowa_edu.yml
@@ -1,0 +1,16 @@
+uuid: 4da221f6-e806-48a3-8fb9-05662c178288
+langcode: en
+status: true
+dependencies: {  }
+id: nativeamericanstudies_uiowa_edu
+label: nativeamericanstudies.uiowa.edu
+description: 'Site split.'
+folder: ../config/nativeamericanstudies.uiowa.edu
+module: {  }
+theme: {  }
+blacklist: {  }
+graylist:
+  - config_split.config_split.nativeamericanstudies_uiowa_edu
+graylist_dependents: true
+graylist_skip_equal: true
+weight: 90


### PR DESCRIPTION
Created and enabled site splits for africanamericanstudies.uiowa.edu, americanstudies.uiowa.edu, anthropology.uiowa.edu, and nativeamericanstudies.uiowa.edu. Limited scope and only affects these four new CLAS sites.