### PR TITLE
Route internal domains without ID to default site.

### DIFF
--- a/docroot/sites/default/blt.yml
+++ b/docroot/sites/default/blt.yml
@@ -3,11 +3,11 @@ project:
     hostname: default.local.drupal.uiowa.edu
     protocol: https
   machine_name: default
-  human_name: uiowa
+  human_name: default
 drush:
   aliases:
     local: self
     remote: default.prod
 drupal:
   db:
-    database: uiowa
+    database: default

--- a/docroot/sites/sites.php
+++ b/docroot/sites/sites.php
@@ -8,6 +8,10 @@
  */
 
 // Directory aliases for default site.
+$sites['local.drupal.uiowa.edu'] = 'default';
+$sites['dev.drupal.uiowa.edu'] = 'default';
+$sites['stage.drupal.uiowa.edu'] = 'default';
+$sites['prod.drupal.uiowa.edu'] = 'default';
 $sites['default.local.drupal.uiowa.edu'] = 'default';
 $sites['default.dev.drupal.uiowa.edu'] = 'default';
 $sites['default.stage.drupal.uiowa.edu'] = 'default';


### PR DESCRIPTION
Drupal will go though a subdomain stripping process that will bootstrap a different site if the URL does not have a directory alias. If a multisite is attempted to be accessed via an internal domain that does not exist, it could bootstrap another site. Ex. foo.prod.drupal.uiowa.edu on uiowa01 could bootstrap uiowa.edu if foo.prod.drupal.uiowa.edu does not exist. This PR forces internal domains to route to the default site, stopping that stripping process high up the chain.

### Testing
- Run `blt sync` on the master branch. 
- Notice that the sql:sync steps says "You will destroy data in **uiowa_edu** and replace with..."
- Check out this branch.
- Run `blt sync` again and it should say "You will destroy data in **uiowa** and replace with..."
- Hit other sites like brand.local.drupal.uiowa.edu and ensure the correct site is bootstrapped.

This test also depends on not having a docroot/default/local.drush.yml file with a correct uri option set which I just instructed everyone to do.
