### PR TITLE
Disable account activation notifications and export other default config changes.

### DIFF
--- a/config/default/administerusersbyrole.settings.yml
+++ b/config/default/administerusersbyrole.settings.yml
@@ -1,9 +1,7 @@
 roles:
-  authenticated: safe
-  editor: safe
-  webmaster: safe
-  administrator: unsafe
   viewer: safe
+  editor: safe
   publisher: safe
+  webmaster: safe
 _core:
   default_config_hash: qJ-7MDpKO6kYnQNZJWk4mtQ2LEErKL7sTlNJYr0lcIU

--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -1,7 +1,5 @@
 ignored_config_entities:
-  - 'acquia_connector.settings:spi.site_uuid'
-  - 'acquia_connector.settings:spi.site_environment'
-  - 'acquia_connector.settings:spi.site_machine_name'
+  - acquia_connector.settings
   - 'block.block.main_navigation__superfish__horizontal:status'
   - 'block.block.main_navigation__superfish__toggle:status'
   - 'block.block.main_navigation__superfish__mega:status'

--- a/config/default/user.mail.yml
+++ b/config/default/user.mail.yml
@@ -1,29 +1,29 @@
 cancel_confirm:
-  body: "[user:display-name],\n\nA request to cancel your account has been made at [site:name].\n\nYou may now cancel your account on [site:url-brief] by clicking this link or copying and pasting it into your browser:\n\n[user:cancel-url]\n\nNOTE: The cancellation of your account is not reversible.\n\nThis link expires in one day and nothing will happen if it is not used.\n\n--  [site:name] team"
+  body: "[user:display-name],\r\n\r\nA request to cancel your account has been made at [site:name].\r\n\r\nYou may now cancel your account on [site:url-brief] by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:cancel-url]\r\n\r\nNOTE: The cancellation of your account is not reversible.\r\n\r\nThis link expires in one day and nothing will happen if it is not used.\r\n\r\n--  [site:name] team"
   subject: 'Account cancellation request for [user:display-name] at [site:name]'
 password_reset:
-  body: "[user:display-name],\n\nA request to reset the password for your account has been made at [site:name].\n\nYou may now log in by clicking this link or copying and pasting it into your browser:\n\n[user:one-time-login-url]\n\nThis link can only be used once to log in and will lead you to a page where you can set your password. It expires after one day and nothing will happen if it's not used.\n\n--  [site:name] team"
+  body: "[user:display-name],\r\n\r\nA request to reset the password for your account has been made at [site:name].\r\n\r\nYou may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password. It expires after one day and nothing will happen if it's not used.\r\n\r\n--  [site:name] team"
   subject: 'Replacement login information for [user:display-name] at [site:name]'
 register_admin_created:
-  body: "[user:display-name],\n\nA site administrator at [site:name] has created an account for you. You may now log in by clicking this link or copying and pasting it into your browser:\n\n[user:one-time-login-url]\n\nThis link can only be used once to log in and will lead you to a page where you can set your password.\n\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\n\nusername: [user:name]\npassword: Your password\n\n--  [site:name] team"
+  body: "[user:display-name],\r\n\r\nA site administrator at [site:name] has created an account for you. You may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\r\n\r\nusername: [user:name]\r\npassword: Your password\r\n\r\n--  [site:name] team"
   subject: 'An administrator created an account for you at [site:name]'
 register_no_approval_required:
-  body: "[user:display-name],\n\nThank you for registering at [site:name]. You may now log in by clicking this link or copying and pasting it into your browser:\n\n[user:one-time-login-url]\n\nThis link can only be used once to log in and will lead you to a page where you can set your password.\n\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\n\nusername: [user:name]\npassword: Your password\n\n--  [site:name] team"
+  body: "[user:display-name],\r\n\r\nThank you for registering at [site:name]. You may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\r\n\r\nusername: [user:name]\r\npassword: Your password\r\n\r\n--  [site:name] team"
   subject: 'Account details for [user:display-name] at [site:name]'
 register_pending_approval:
-  body: "[user:display-name],\n\nThank you for registering at [site:name]. Your application for an account is currently pending approval. Once it has been approved, you will receive another email containing information about how to log in, set your password, and other details.\n\n--  [site:name] team"
+  body: "[user:display-name],\r\n\r\nThank you for registering at [site:name]. Your application for an account is currently pending approval. Once it has been approved, you will receive another email containing information about how to log in, set your password, and other details.\r\n\r\n--  [site:name] team"
   subject: 'Account details for [user:display-name] at [site:name] (pending admin approval)'
 register_pending_approval_admin:
-  body: "[user:display-name] has applied for an account.\n\n[user:edit-url]"
+  body: "[user:display-name] has applied for an account.\r\n\r\n[user:edit-url]"
   subject: 'Account details for [user:display-name] at [site:name] (pending admin approval)'
 status_activated:
-  body: "[user:display-name],\n\nYour account at [site:name] has been activated.\n\nYou may now log in by clicking this link or copying and pasting it into your browser:\n\n[user:one-time-login-url]\n\nThis link can only be used once to log in and will lead you to a page where you can set your password.\n\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\n\nusername: [user:account-name]\npassword: Your password\n\n--  [site:name] team"
+  body: "[user:display-name],\r\n\r\nYour account at [site:name] has been activated.\r\n\r\nYou may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\r\n\r\nusername: [user:account-name]\r\npassword: Your password\r\n\r\n--  [site:name] team"
   subject: 'Account details for [user:display-name] at [site:name] (approved)'
 status_blocked:
-  body: "[user:display-name],\n\nYour account on [site:name] has been blocked.\n\n--  [site:name] team"
+  body: "[user:display-name],\r\n\r\nYour account on [site:name] has been blocked.\r\n\r\n--  [site:name] team"
   subject: 'Account details for [user:display-name] at [site:name] (blocked)'
 status_canceled:
-  body: "[user:display-name],\n\nYour account on [site:name] has been canceled.\n\n--  [site:name] team"
+  body: "[user:display-name],\r\n\r\nYour account on [site:name] has been canceled.\r\n\r\n--  [site:name] team"
   subject: 'Account details for [user:display-name] at [site:name] (canceled)'
 langcode: en
 _core:

--- a/config/default/user.settings.yml
+++ b/config/default/user.settings.yml
@@ -3,7 +3,7 @@ verify_mail: true
 notify:
   cancel_confirm: true
   password_reset: true
-  status_activated: true
+  status_activated: false
   status_blocked: false
   status_canceled: false
   register_admin_created: true


### PR DESCRIPTION
Resolves #1652 

The administerusersbyrole config changes must've been overlooked from the last update. Doesn't seem to affect anything. I tested our current setup. I think it treats admin as always unsafe and authenticated probably wasn't valid to begin with.

I didn't change anything with the messages but it exported anyway.

Changing config_ignore to ignore all of acquia_connector.settings as individual items don't seem to work with export filtering. It wanted to export those.