### PR TITLE
Limit webform upload file size and allowed extensions.

### DIFF
--- a/config/default/webform.settings.yml
+++ b/config/default/webform.settings.yml
@@ -133,13 +133,12 @@ element:
   default_description_display: ''
   default_more_title: More
   default_section_title_tag: h2
+  default_algolia_places_app_id: ''
+  default_algolia_places_api_key: ''
   default_empty_option: true
   default_empty_option_required: ''
   default_empty_option_optional: ''
-  default_algolia_places_app_id: ''
-  default_algolia_places_api_key: ''
   excluded_elements:
-    captcha: captcha
     color: color
     container: container
     entity_autocomplete: entity_autocomplete
@@ -159,8 +158,6 @@ element:
     value: value
     webform_address: webform_address
     webform_audio_file: webform_audio_file
-    webform_buttons: webform_buttons
-    webform_buttons_other: webform_buttons_other
     webform_codemirror: webform_codemirror
     webform_computed_token: webform_computed_token
     webform_computed_twig: webform_computed_twig
@@ -185,29 +182,25 @@ element:
     webform_telephone: webform_telephone
     webform_term_checkboxes: webform_term_checkboxes
     webform_term_select: webform_term_select
-    webform_toggle: webform_toggle
-    webform_toggles: webform_toggles
     webform_video_file: webform_video_file
-  default_icheck: ''
-  default_google_maps_api_key: ''
 html_editor:
+  tidy: true
   disabled: false
   element_format: ''
   mail_format: ''
-  tidy: true
   make_unused_managed_files_temporary: true
 file:
+  make_unused_managed_files_temporary: true
+  delete_temporary_managed_files: true
   file_public: false
   file_private_redirect: true
   file_private_redirect_message: 'Please login to access the uploaded file.'
-  default_max_filesize: ''
-  default_managed_file_extensions: 'gif jpg png bmp eps tif pict psd txt rtf html odf pdf doc docx ppt pptx xls xlsx xml avi mov mp3 ogg wav bz2 dmg gz jar rar sit svg tar zip'
+  default_max_filesize: '50 MB'
+  default_managed_file_extensions: 'gif jpg png bmp eps tif pict psd txt rtf html odf pdf doc docx ppt pptx xls xlsx avi mov mp3 ogg wav bz2 gz sit svg tar zip'
   default_audio_file_extensions: 'mp3 ogg wav'
   default_document_file_extensions: 'txt rtf pdf doc docx odt ppt pptx odp xls xlsx ods'
   default_image_file_extensions: 'gif jpg png'
   default_video_file_extensions: 'avi mov mp4 ogg wav webm'
-  make_unused_managed_files_temporary: true
-  delete_temporary_managed_files: true
 format: {  }
 mail:
   default_to_mail: '[site:mail]'

--- a/config/default/webform.settings.yml
+++ b/config/default/webform.settings.yml
@@ -133,11 +133,11 @@ element:
   default_description_display: ''
   default_more_title: More
   default_section_title_tag: h2
-  default_algolia_places_app_id: ''
-  default_algolia_places_api_key: ''
   default_empty_option: true
   default_empty_option_required: ''
   default_empty_option_optional: ''
+  default_algolia_places_app_id: ''
+  default_algolia_places_api_key: ''
   excluded_elements:
     color: color
     container: container
@@ -184,14 +184,12 @@ element:
     webform_term_select: webform_term_select
     webform_video_file: webform_video_file
 html_editor:
-  tidy: true
   disabled: false
   element_format: ''
   mail_format: ''
+  tidy: true
   make_unused_managed_files_temporary: true
 file:
-  make_unused_managed_files_temporary: true
-  delete_temporary_managed_files: true
   file_public: false
   file_private_redirect: true
   file_private_redirect_message: 'Please login to access the uploaded file.'
@@ -201,6 +199,8 @@ file:
   default_document_file_extensions: 'txt rtf pdf doc docx odt ppt pptx odp xls xlsx ods'
   default_image_file_extensions: 'gif jpg png'
   default_video_file_extensions: 'avi mov mp4 ogg wav webm'
+  make_unused_managed_files_temporary: true
+  delete_temporary_managed_files: true
 format: {  }
 mail:
   default_to_mail: '[site:mail]'

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -421,6 +421,10 @@ function sitenow_form_alter(&$form, FormStateInterface $form_state, $form_id) {
         $form['properties']['markup']['message_storage']['#access'] = FALSE;
         $form['properties']['markup']['message_id']['#access'] = FALSE;
 
+        // Remove access to change allowed file upload extensions.
+        if (isset($form['properties']['file'])) {
+          $form['properties']['file']['file_extensions']['#access'] = FALSE;
+        }
       }
       break;
   }

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -411,15 +411,16 @@ function sitenow_form_alter(&$form, FormStateInterface $form_state, $form_id) {
     case 'webform_ui_element_form':
       if (!sitenow_is_user_admin(\Drupal::currentUser())) {
         // Remove access to wrapper, element, label attributes.
-        $form["properties"]["wrapper_attributes"]['#access'] = FALSE;
-        $form["properties"]["element_attributes"]['#access'] = FALSE;
-        $form["properties"]["label_attributes"]['#access'] = FALSE;
+        $form['properties']['wrapper_attributes']['#access'] = FALSE;
+        $form['properties']['element_attributes']['#access'] = FALSE;
+        $form['properties']['label_attributes']['#access'] = FALSE;
 
         // Remove access to message close fields. Conflicts with BS alert close.
-        $form["properties"]["markup"]["message_close"]['#access'] = FALSE;
-        $form["properties"]["markup"]["message_close_effect"]['#access'] = FALSE;
-        $form["properties"]["markup"]["message_storage"]['#access'] = FALSE;
-        $form["properties"]["markup"]["message_id"]['#access'] = FALSE;
+        $form['properties']['markup']['message_close']['#access'] = FALSE;
+        $form['properties']['markup']['message_close_effect']['#access'] = FALSE;
+        $form['properties']['markup']['message_storage']['#access'] = FALSE;
+        $form['properties']['markup']['message_id']['#access'] = FALSE;
+
       }
       break;
   }

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -409,7 +409,7 @@ function sitenow_form_alter(&$form, FormStateInterface $form_state, $form_id) {
       break;
 
     case 'webform_ui_element_form':
-      if (\Drupal::currentUser()->hasPermission('administer webforms') === FALSE) {
+      if (!sitenow_is_user_admin(\Drupal::currentUser())) {
         // Remove access to wrapper, element, label attributes.
         $form["properties"]["wrapper_attributes"]['#access'] = FALSE;
         $form["properties"]["element_attributes"]['#access'] = FALSE;


### PR DESCRIPTION
Resolves #1664 

The max upload config set limits individual elements but the allowed extensions do not. This PR limits file uploads to 50 MB, reduces the allowed upload extensions to a limited set and removes access from webmasters to change that per element.

### Testing
- Check out this branch and `blt dsa`.
- Masquerade as a webmaster.
- Create or edit a webform with a file upload field.
- Try to increase file upload size and add additional extensions. (exe, dmg, etc.)