### PR TITLE
ignore gtag container config

### DIFF
--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -7,6 +7,7 @@ ignored_config_entities:
   - 'config_split.config_split.person_extended:status'
   - 'config_split.config_split.sitenow_migrate:status'
   - google_analytics.settings
+  - 'google_tag.container.*'
   - pathauto.pattern.article
   - pathauto.pattern.person
   - sitenow_events.settings


### PR DESCRIPTION
google tag manager config (e.g. homepage, brand) are getting deleted with deployments. this will ignore similar to google analytics