### PR TITLE
Feature: Person extended update

### DIFF
--- a/config/default/config_split.config_split.person_extended.yml
+++ b/config/default/config_split.config_split.person_extended.yml
@@ -17,4 +17,4 @@ graylist:
   - taxonomy.vocabulary.research_areas
 graylist_dependents: true
 graylist_skip_equal: true
-weight: 70
+weight: 80

--- a/config/features/person_extended/core.entity_form_display.node.person.default.yml
+++ b/config/features/person_extended/core.entity_form_display.node.person.default.yml
@@ -37,16 +37,6 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  person_pt_faculty_research_areas:
-    weight: 26
-    settings:
-      match_operator: STARTS_WITH
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete_tags
-    region: content
   field_image:
     weight: 4
     settings:
@@ -160,6 +150,16 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  person_pt_faculty_research_areas:
+    weight: 26
+    settings:
+      match_operator: STARTS_WITH
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete_tags
+    region: content
   promote:
     type: boolean_checkbox
     settings:

--- a/config/features/person_extended/core.entity_form_display.node.person.minimal.yml
+++ b/config/features/person_extended/core.entity_form_display.node.person.minimal.yml
@@ -65,7 +65,6 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
-  person_pt_faculty_research_areas: true
   field_image: true
   field_person_bio: true
   field_person_credential: true
@@ -77,6 +76,7 @@ hidden:
   field_tags: true
   field_teaser: true
   path: true
+  person_pt_faculty_research_areas: true
   promote: true
   sticky: true
   title: true

--- a/config/features/person_extended/core.entity_view_display.node.person.default.yml
+++ b/config/features/person_extended/core.entity_view_display.node.person.default.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.node.person.person_pt_faculty_research_areas
     - field.field.node.person.field_image
     - field.field.node.person.field_person_bio
     - field.field.node.person.field_person_credential
@@ -17,6 +16,7 @@ dependencies:
     - field.field.node.person.field_person_website
     - field.field.node.person.field_tags
     - field.field.node.person.field_teaser
+    - field.field.node.person.person_pt_faculty_research_areas
     - node.type.person
   module:
     - link
@@ -74,7 +74,7 @@ content:
     region: content
   field_person_type:
     weight: 1
-    label: above
+    label: hidden
     settings:
       link: true
     third_party_settings: {  }

--- a/config/features/person_extended/core.entity_view_display.node.person.default.yml
+++ b/config/features/person_extended/core.entity_view_display.node.person.default.yml
@@ -33,14 +33,6 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  person_pt_faculty_research_areas:
-    weight: 10
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
   field_image:
     type: entity_reference_entity_view
     weight: 7
@@ -105,6 +97,14 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  person_pt_faculty_research_areas:
+    weight: 10
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
 hidden:
   field_person_credential: true
   field_person_first_name: true

--- a/config/features/person_extended/core.entity_view_display.node.person.teaser.yml
+++ b/config/features/person_extended/core.entity_view_display.node.person.teaser.yml
@@ -81,7 +81,6 @@ content:
     third_party_settings: {  }
 hidden:
   content_moderation_control: true
-  person_pt_faculty_research_areas: true
   field_person_bio: true
   field_person_first_name: true
   field_person_hide: true
@@ -89,3 +88,4 @@ hidden:
   field_person_type: true
   field_person_website: true
   field_tags: true
+  person_pt_faculty_research_areas: true

--- a/config/features/person_extended/field.field.node.person.field_person_website.yml
+++ b/config/features/person_extended/field.field.node.person.field_person_website.yml
@@ -19,5 +19,5 @@ default_value: {  }
 default_value_callback: ''
 settings:
   link_type: 16
-  title: 0
+  title: 1
 field_type: link

--- a/config/features/person_extended/field.field.node.person.person_pt_faculty_research_areas.yml
+++ b/config/features/person_extended/field.field.node.person.person_pt_faculty_research_areas.yml
@@ -24,6 +24,6 @@ settings:
     sort:
       field: name
       direction: asc
-    auto_create: false
+    auto_create: true
     auto_create_bundle: ''
 field_type: entity_reference

--- a/config/features/person_extended/field.storage.node.person_pt_faculty_research_areas.yml
+++ b/config/features/person_extended/field.storage.node.person_pt_faculty_research_areas.yml
@@ -13,7 +13,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false


### PR DESCRIPTION
# Updates
* Fixed issue with config being out of sync for informatics.grad.uiowa.edu.
* Updated person type field to not display on the page.
* Updated research areas field to allow creation of a taxonomy term when creating the person node.

# To test
* `blt ds --site=informatics.grad.uiowa.edu` - Should be no errors related to configuration.
* `drush @gradinformatics.local uli`.
* Create a person, filling out at least first name, last name, and research area - There should be no warning related to "Research area" field.
* Observe that "Person type" field doesn't show up on the page.