### PR TITLE
Feature: IE11 Fixes for card display variations and tertiary header

### DIFF
--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -39,8 +39,30 @@ $imgpath: '../../uids/assets/images';
     height: 100px !important;
   }
 
-  .logo-icon {
+  .header--primary .logo-icon,
+  .header--secondary .logo-icon {
     height: auto !important;
+  }
+
+  .header--tertiary .logo-icon {
+    height: 30px !important;
+  }
+
+  .header--tertiary .bttn--drawer {
+    top: 0 !important;
+  }
+
+  .search-is-open .header--tertiary .logo-icon--tab {
+    display: block !important;
+  }
+
+  .header--tertiary .uiowa-bar .page__container {
+    justify-content: flex-start !important;
+  }
+
+  .header--tertiary .uiowa-bar__slogan {
+    align-items: flex-start;
+    margin: 20px 0 0 0;
   }
 
   .card__body {
@@ -81,7 +103,7 @@ $imgpath: '../../uids/assets/images';
 
 // Neither Paragraphs or Layout Builder.
 body:not(.page-node-type-article, .page-node-type-page).layout-builder-disabled main.page__container {
-  margin-bottom : 1.25rem;
+  margin-bottom: 1.25rem;
 }
 
 // SiteNow Paragraphs Page

--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -65,9 +65,38 @@ $imgpath: '../../uids/assets/images';
     margin: 20px 0 0 0;
   }
 
+
   .card__body {
     flex: auto !important;
   }
+
+  .card.card--horizontal .card__body {
+    flex: 1 !important;
+    flex-direction: column;
+  }
+
+  .card.card--horizontal>* {
+    flex-direction: unset;
+    display: block !important;
+  }
+
+  .paragraph--type--articles.list .card__body,
+  .paragraph--type--people.list .card__body,
+  .paragraph--type--events.list .card__body,
+  .view-display-id-page_articles .card__body,
+  .paragraph--type--featured-content.list .card__body,
+  .view-display-id-page_articles .view-content {
+    flex: 1 !important;
+  }
+
+
+  .paragraph--type--articles.list .view-content,
+  .paragraph--type--people.list .view-content,
+  .view-display-id-page_articles .view-content,
+  .paragraph--type--featured-content.list .field--name-field-featured-content {
+    display: block !important;
+  }
+
 
   #superfish-main-accordion {
     position: relative !important;

--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -85,6 +85,7 @@ $imgpath: '../../uids/assets/images';
   .paragraph--type--events.list .card__body,
   .view-display-id-page_articles .card__body,
   .paragraph--type--featured-content.list .card__body,
+  .view-id-people .card__body,
   .view-display-id-page_articles .view-content {
     flex: 1 !important;
   }
@@ -97,11 +98,16 @@ $imgpath: '../../uids/assets/images';
     display: block !important;
   }
 
+  .view-id-people .card--list,
+  .view-id-people .node--type-article {
+    display: flex !important;
+  }
 
   #superfish-main-accordion {
     position: relative !important;
   }
 }
+
 
 .layout--twocol.layout,
 .layout--twocol.layout .lb__container {

--- a/docroot/themes/custom/uids_base/scss/paragraphs/uiowa-paragraphs-lists.scss
+++ b/docroot/themes/custom/uids_base/scss/paragraphs/uiowa-paragraphs-lists.scss
@@ -112,7 +112,8 @@
   }
 
   .field--name-field-teaser {
-    @include card-paragraph margin-top: $gutter;
+    @include card-paragraph;
+    margin-top: $gutter;
   }
 
   .media-body {
@@ -197,6 +198,11 @@
   table td,
   table th {
     padding: 0;
+  }
+
+  .field--name-field-teaser {
+    @include card-paragraph;
+    margin-top: $gutter;
   }
 
   tr {
@@ -645,6 +651,7 @@
 }
 
 .paragraph--type--section.bg-light {
+
   .paragraph--type--articles.list,
   .paragraph--type--people.list {
 
@@ -690,6 +697,7 @@
 }
 
 .paragraph--type--section.bg-yellow {
+
   .paragraph--type--articles.list,
   .paragraph--type--featured-content.list {
     .article-created-date {
@@ -703,6 +711,7 @@
   .paragraph--type--articles.list,
   .paragraph--type--people.list,
   .paragraph--type--featured-content.list {
+
     .card,
     .node--view-mode-teaser {
       @include bg-yellow;

--- a/docroot/themes/custom/uids_base/scss/paragraphs/uiowa-paragraphs-lists.scss
+++ b/docroot/themes/custom/uids_base/scss/paragraphs/uiowa-paragraphs-lists.scss
@@ -742,3 +742,23 @@
     }
   }
 }
+
+
+
+@media all and (-ms-high-contrast: none),
+(-ms-high-contrast: active) {
+  .paragraph--type--articles.list .card__body,
+  .paragraph--type--people.list .card__body,
+  .paragraph--type--events.list .card__body,
+  .view-display-id-page_articles .card__body,
+  .paragraph--type--featured-content.list .card__body,
+  .view-display-id-page_articles .view-content {
+    flex: 1 !important;
+  }
+  .paragraph--type--articles.list .view-content,
+  .paragraph--type--people.list .view-content,
+  .view-display-id-page_articles .view-content,
+  .paragraph--type--featured-content.list .field--name-field-featured-content {
+    display: block !important;
+  }
+}

--- a/docroot/themes/custom/uids_base/scss/paragraphs/uiowa-paragraphs-lists.scss
+++ b/docroot/themes/custom/uids_base/scss/paragraphs/uiowa-paragraphs-lists.scss
@@ -742,23 +742,3 @@
     }
   }
 }
-
-
-
-@media all and (-ms-high-contrast: none),
-(-ms-high-contrast: active) {
-  .paragraph--type--articles.list .card__body,
-  .paragraph--type--people.list .card__body,
-  .paragraph--type--events.list .card__body,
-  .view-display-id-page_articles .card__body,
-  .paragraph--type--featured-content.list .card__body,
-  .view-display-id-page_articles .view-content {
-    flex: 1 !important;
-  }
-  .paragraph--type--articles.list .view-content,
-  .paragraph--type--people.list .view-content,
-  .view-display-id-page_articles .view-content,
-  .paragraph--type--featured-content.list .field--name-field-featured-content {
-    display: block !important;
-  }
-}


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/1786
Resolves https://github.com/uiowa/uiowa/issues/1787

# How to test

Using an IE11 emulator like https://live.browserstack.com/. 
`blt ds --site=hawkeyemarchingband.uiowa.edu`
`blt ds --site=uiowa.edu`
`blt frontend` 

Switch theme to `uids_base` 

**Tertiary Header https://github.com/uiowa/uiowa/issues/1786**
- Adjust theme settings to use "Display below Iowa bar" in theme settings. 
- Test https://hawkeyemarchingband.local.drupal.uiowa.edu
- Test search toggle

**Card https://github.com/uiowa/uiowa/issues/1787**

- Check https://hawkeyemarchingband.local.drupal.uiowa.edu/people-0
- Check https://hawkeyemarchingband.local.drupal.uiowa.edu/people
- Check https://hawkeyemarchingband.local.drupal.uiowa.edu/news
- Add events feed to the home page
- Test grid and masonry variations of People, Articles, Events, and Featured Content
- Also check out `card--horizontal` list on https://uiowa.local.drupal.uiowa.edu/admissions

