### PR TITLE
I1723 migrate text format

### DIFF
--- a/docroot/modules/custom/sitenow_migrate/sitenow_migrate.services.yml
+++ b/docroot/modules/custom/sitenow_migrate/sitenow_migrate.services.yml
@@ -9,7 +9,7 @@ services:
       - { name: 'event_subscriber' }
   post_migration_subscriber:
     class: 'Drupal\sitenow_migrate\EventSubscriber\MigratePostImportEvent'
-    arguments: [ '@entity_type.manager', '@logger.channel.sitenow_migrate' ]
+    arguments: [ '@entity_type.manager', '@logger.channel.sitenow_migrate', '@database' ]
     tags:
       - { name: 'event_subscriber' }
   pre_rollback_subscriber:

--- a/docroot/modules/custom/sitenow_migrate/src/EventSubscriber/MigratePostImportEvent.php
+++ b/docroot/modules/custom/sitenow_migrate/src/EventSubscriber/MigratePostImportEvent.php
@@ -112,7 +112,7 @@ class MigratePostImportEvent implements EventSubscriberInterface {
         $this->sourceToDestIds = $this->fetchMapping();
         $this->d7Aliases = $this->fetchAliases(TRUE);
         $this->d8Aliases = $this->fetchAliases();
-        \Drupal::logger('sitenow_migrate')->notice(t('Checking for possible broken links'));
+        $this->logger->notice($this->t('Checking for possible broken links'));
         $candidates = $this->checkForPossibleLinkBreaks();
         $this->updateInternalLinks($candidates);
       case 'd7_file':
@@ -129,7 +129,7 @@ class MigratePostImportEvent implements EventSubscriberInterface {
     // Each candidate is an nid of a page suspected to contain a broken link.
     foreach ($candidates as $candidate) {
 
-      \Drupal::logger('sitenow_migrate')->notice(t('Checking node id @nid', [
+      $this->logger->notice($this->t('Checking node id @nid', [
         '@nid' => $candidate,
       ]));
 
@@ -186,7 +186,7 @@ class MigratePostImportEvent implements EventSubscriberInterface {
    */
   private function linkReplace($match) {
     $old_link = $match[1];
-    \Drupal::logger('sitenow_migrate')->notice(t('Old link found... @old_link', [
+    $this->logger->notice($this->t('Old link found... @old_link', [
       '@old_link' => $old_link,
     ]));
 
@@ -211,10 +211,10 @@ class MigratePostImportEvent implements EventSubscriberInterface {
           // Take the node id.
           $old_nid = $link_parts[$i + 1];
           $new_nid = $this->sourceToDestIds[$old_nid];
-          \Drupal::logger('sitenow_migrate')->notice(t('Old nid... @old_nid', [
+          $this->logger->notice($this->t('Old nid... @old_nid', [
             '@old_nid' => $old_nid,
           ]));
-          \Drupal::logger('sitenow_migrate')->notice(t('New nid... @new_nid', [
+          $this->logger->notice($this->t('New nid... @new_nid', [
             '@new_nid' => $new_nid,
           ]));
           // If we don't have the correct mapping, return the original link.
@@ -229,7 +229,7 @@ class MigratePostImportEvent implements EventSubscriberInterface {
         $d7_nid = $this->d7Aliases[$old_link];
         $new_link = (isset($this->sourceToDestIds[$d7_nid])) ? '<a href="/node/' . $this->sourceToDestIds[$d7_nid] . '"' : $match[0];
       }
-      \Drupal::logger('sitenow_migrate')->notice(t('New link found from /node/ path... @new_link', [
+      $this->logger->notice($this->t('New link found from /node/ path... @new_link', [
         '@new_link' => $new_link . $suffix,
       ]));
 
@@ -242,7 +242,7 @@ class MigratePostImportEvent implements EventSubscriberInterface {
       if (preg_match($pattern, $old_link, $abs_match)) {
         $d7_nid = $this->d7Aliases[$abs_match[4]];
         $new_link = (isset($this->sourceToDestIds[$d7_nid])) ? '<a href="/node/' . $this->sourceToDestIds[$d7_nid] . '"' : '<a href="/' . $abs_match[4] . '"';
-        \Drupal::logger('sitenow_migrate')->notice(t('New link found from absolute path... @new_link', [
+        $this->logger->notice($this->t('New link found from absolute path... @new_link', [
           '@new_link' => $new_link,
         ]));
 
@@ -285,7 +285,7 @@ class MigratePostImportEvent implements EventSubscriberInterface {
     $candidates = array_merge($candidates, $result->fetchCol());
 
     foreach ($candidates as $candidate) {
-      \Drupal::logger('sitenow_migrate')->notice(t('Possible broken link found in node @candidate', [
+      $this->logger->notice($this->t('Possible broken link found in node @candidate', [
         '@candidate' => $candidate,
       ]));
     }

--- a/docroot/modules/custom/sitenow_migrate/src/EventSubscriber/MigratePostImportEvent.php
+++ b/docroot/modules/custom/sitenow_migrate/src/EventSubscriber/MigratePostImportEvent.php
@@ -35,7 +35,7 @@ class MigratePostImportEvent implements EventSubscriberInterface {
 
   /**
    * The database connection.
-   * 
+   *
    * @var \Drupal\Core\Database\Connection
    */
   protected $connection;

--- a/docroot/modules/custom/sitenow_migrate/src/EventSubscriber/MigratePostImportEvent.php
+++ b/docroot/modules/custom/sitenow_migrate/src/EventSubscriber/MigratePostImportEvent.php
@@ -167,6 +167,7 @@ class MigratePostImportEvent implements EventSubscriberInterface {
         case 'page':
           $paragraph->set('field_text_body', [
             'value' => $content,
+            'format' => 'filtered_html'
           ]);
           $paragraph->save();
           break;


### PR DESCRIPTION
Resolves #1723. 

Includes some code cleanup to use dependency injections, avoid using t() and \Drupal calls within classes.