### PR TITLE
Unshift uiowa.edu to top of multisite iteration so it runs first.

### DIFF
--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -24,7 +24,15 @@ class ReplaceCommands extends BltTasks {
     $env = EnvironmentDetector::getAhEnv() ? EnvironmentDetector::getAhEnv() : 'local';
     $multisite_exception = FALSE;
 
-    foreach ($this->getConfigValue('multisites') as $multisite) {
+    // Unshift uiowa.edu to the beginning so it runs first.
+    $multisites = $this->getConfigValue('multisites');
+
+    if ($key = array_search('uiowa.edu', $multisites)) {
+      unset($multisites[$key]);
+      array_unshift($multisites, 'uiowa.edu');
+    }
+
+    foreach ($multisites as $multisite) {
       $this->switchSiteContext($multisite);
       $db = $this->getConfigValue('drupal.db.database');
 


### PR DESCRIPTION
On deployment - this does not affect `blt dsa`. You can set that order yourself in blt.local.yml.

### Testing
Run `blt auda` before and after this PR. See uiowa.edu run first and only once on this branch.