### PR TITLE
Styling of <a> tags with no href attribute

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/typography/paragraph.scss
+++ b/docroot/themes/custom/uids_base/scss/components/typography/paragraph.scss
@@ -19,3 +19,9 @@
   line-height: $sm-md!important;
   font-family: Arial, Helvetica, sans-serif;
 }
+
+
+a:not([href]) {
+  color: inherit;
+  text-decoration: none;
+}

--- a/docroot/themes/custom/uids_base/scss/components/typography/paragraph.scss
+++ b/docroot/themes/custom/uids_base/scss/components/typography/paragraph.scss
@@ -20,7 +20,6 @@
   font-family: Arial, Helvetica, sans-serif;
 }
 
-
 a:not([href]) {
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
Resolves #1808 

In uiowa_bootstrap, no:href <a> tags remove extra text decoration. Primary use I'm aware of for these are for anchor links created manually by SiteNow users. 

## Testing
### Desired result
Created <a> tags which do not include an href attribute should not be styled as clickable links.

### Undesirable result
<a> tags which include an href attribute should not be affected.