### PR TITLE
Visual/a11y indication of unpublished content on content teasers

### DIFF
--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -592,7 +592,7 @@ function sitenow_preprocess_node(&$variables) {
           'e',
           'i',
           'o',
-          'u'
+          'u',
         ]) ? 'n' : '');
         $warning_text = t('This content is currently in a@pre_vowel @moderation_state state.', [
           '@pre_vowel' => $pre_vowel,

--- a/docroot/themes/custom/uids_base/scss/components/badge.scss
+++ b/docroot/themes/custom/uids_base/scss/components/badge.scss
@@ -1,0 +1,37 @@
+@import "assets/scss/_variables.scss";
+
+.badge {
+  display: inline-block;
+  padding: 0 .75em;
+  line-height: 1.67;
+  font-size: 75%;
+  font-weight: $font-weight-medium;
+  color: $white;
+  border: 1px solid transparent;
+  border-radius: 1em;
+}
+
+.badge--primary {
+  background: $primary;
+  color: $blk;
+}
+
+.badge--secondary {
+  background: $secondary;
+}
+
+.badge--cool-gray {
+  background: $brand-cool-gray;
+}
+
+.badge--blue {
+  background: $info;
+}
+
+.badge--green {
+  background: $success;
+}
+
+.badge--orange {
+  background: $danger;
+}

--- a/docroot/themes/custom/uids_base/uids_base.libraries.yml
+++ b/docroot/themes/custom/uids_base/uids_base.libraries.yml
@@ -32,7 +32,6 @@ global-styling:
       assets/css/components/menus/quick.css: {}
       assets/css/components/uiowa-bar.css: {}
       assets/css/components/image-gallery-block.css: {}
-      assets/css/components/badge.css: {}
     theme:
       assets/css/theme/print.css: { media: print }
   dependencies:
@@ -245,6 +244,7 @@ admin:
   css:
     component:
       assets/css/admin.css: { weight: 200 }
+      assets/css/components/badge.css: {}
 
 # CSS libraries for Layout plugins.
 onecol:

--- a/docroot/themes/custom/uids_base/uids_base.libraries.yml
+++ b/docroot/themes/custom/uids_base/uids_base.libraries.yml
@@ -32,6 +32,7 @@ global-styling:
       assets/css/components/menus/quick.css: {}
       assets/css/components/uiowa-bar.css: {}
       assets/css/components/image-gallery-block.css: {}
+      assets/css/components/badge.css: {}
     theme:
       assets/css/theme/print.css: { media: print }
   dependencies:


### PR DESCRIPTION
Resolves #1137 

Pulled approved styles from https://github.com/uiowa/uids/pull/253 until a new uids release can be made.

## Test

- pull/blt frontend/cr
- on a site, check a draft/review/archived piece of content and check to see if the status message is still displaying on render and that it isn't displaying/breaking things in preview mode:
<img width="478" alt="Screen Shot 2020-06-24 at 1 49 32 PM" src="https://user-images.githubusercontent.com/4663676/85615254-90ef4f80-b621-11ea-8e92-f5fd088d05d4.png">
- using the featured content paragraph, pull in a published page, article and person. duplicate twice and change the featured content settings to render list/grid/masonry.
- going to each page, article and person, change the state of the content. archived, draft, review. for review, you must first transition to a draft state.
- back on the featured content, you should see a badge indicating the non-published state of the content and the aria-description should properly describe the label you see.

<img width="1264" alt="Screen Shot 2020-06-23 at 10 29 35 PM" src="https://user-images.githubusercontent.com/4663676/85564653-10662a00-b5f4-11ea-8fe6-9d14fccb7b87.png">
<img width="964" alt="Screen Shot 2020-06-23 at 10 29 00 PM" src="https://user-images.githubusercontent.com/4663676/85564664-122fed80-b5f4-11ea-9451-1bd460ca5abb.png">

