### PR TITLE
change import format and set allowed formats 

### DIFF
--- a/config/default/field.field.block_content.uiowa_banner.field_uiowa_banner_excerpt.yml
+++ b/config/default/field.field.block_content.uiowa_banner.field_uiowa_banner_excerpt.yml
@@ -6,7 +6,14 @@ dependencies:
     - block_content.type.uiowa_banner
     - field.storage.block_content.field_uiowa_banner_excerpt
   module:
+    - allowed_formats
     - text
+third_party_settings:
+  allowed_formats:
+    minimal: minimal
+    plain_text: plain_text
+    filtered_html: '0'
+    full_html: '0'
 _core:
   default_config_hash: R12wgVOfQanvzxQM2QVSOwZE86dXdnY1K6gGkV-7KlE
 id: block_content.uiowa_banner.field_uiowa_banner_excerpt

--- a/config/default/field.field.block_content.uiowa_card.field_uiowa_card_excerpt.yml
+++ b/config/default/field.field.block_content.uiowa_card.field_uiowa_card_excerpt.yml
@@ -6,7 +6,14 @@ dependencies:
     - block_content.type.uiowa_card
     - field.storage.block_content.field_uiowa_card_excerpt
   module:
+    - allowed_formats
     - text
+third_party_settings:
+  allowed_formats:
+    minimal: minimal
+    plain_text: plain_text
+    filtered_html: '0'
+    full_html: '0'
 _core:
   default_config_hash: d7-oWkJwADXKLY9QldFK28pif5n_srH-0UsqsZrZFrA
 id: block_content.uiowa_card.field_uiowa_card_excerpt

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -332,7 +332,7 @@ function sitenow_update_8018() {
 }
 
 /**
- * Update several fields from plain text to formatted text.
+ * Update several fields from plain text to formatted minimal text.
  */
 function sitenow_update_8019() {
 
@@ -436,7 +436,7 @@ function sitenow_update_8019() {
     if (!is_null($rows)) {
       foreach ($rows as $row) {
         $row = (array) $row;
-        $row[$field['format_col']] = 'filtered_html';
+        $row[$field['format_col']] = 'minimal';
         $database
           ->insert($table)
           ->fields($row)
@@ -446,7 +446,7 @@ function sitenow_update_8019() {
     if (!is_null($revision_rows)) {
       foreach ($revision_rows as $row) {
         $row = (array) $row;
-        $row[$field['format_col']] = 'filtered_html';
+        $row[$field['format_col']] = 'minimal';
         $database
           ->insert($revision_table)
           ->fields($row)

--- a/docroot/themes/custom/uids_base/scss/components/banner.scss
+++ b/docroot/themes/custom/uids_base/scss/components/banner.scss
@@ -9,7 +9,7 @@
 .banner__summary {
   line-height: 1.7;
 
-  div, p {
+  p {
     font-weight: 300;
     font-size: 1.3rem;
     margin-top: 1.05rem;

--- a/docroot/themes/custom/uids_base/scss/components/banner.scss
+++ b/docroot/themes/custom/uids_base/scss/components/banner.scss
@@ -9,7 +9,7 @@
 .banner__summary {
   line-height: 1.7;
 
-  * {
+  div, p {
     font-weight: 300;
     font-size: 1.3rem;
     margin-top: 1.05rem;

--- a/docroot/themes/custom/uids_base/scss/components/banner.scss
+++ b/docroot/themes/custom/uids_base/scss/components/banner.scss
@@ -2,3 +2,26 @@
 @import "assets/scss/_utilities.scss";
 @import "components/banner/_banner.scss";
 
+.banner--reversed *:not(.bttn) {
+  color: #fff;
+}
+
+.banner__summary {
+  line-height: 1.7;
+
+  * {
+    font-weight: 300;
+    font-size: 1.3rem;
+    margin-top: 1.05rem;
+    margin-bottom: 1.875rem;
+  }
+
+  strong {
+    font-weight: $font-weight-medium-bold;
+  }
+
+  a {
+    font-weight: $font-weight-medium;
+  }
+
+}

--- a/docroot/themes/custom/uids_base/templates/uids/banner.html.twig
+++ b/docroot/themes/custom/uids_base/templates/uids/banner.html.twig
@@ -27,7 +27,7 @@
       {% endblock %}
 
       {% if banner_summary is not empty %}
-        <p class="banner__summary">{{ banner_summary }}</p>
+        <div class="banner__summary">{{ banner_summary }}</div>
       {% endif %}
 
       {% if link and link.link_url is not empty %}


### PR DESCRIPTION
Resolves #1831

As a follow up to https://github.com/uiowa/uiowa/pull/1790. All previous test steps apply, but the main thing is that content is imported as minimal instead of filtered_html and the allowed formats for card and banner excerpts are restricted to minimal and plain text.

This also needs to be changed before the next release. No pressure...