### PR TITLE
Restrict top links

### DIFF
--- a/config/default/uids_base.settings.yml
+++ b/config/default/uids_base.settings.yml
@@ -13,6 +13,7 @@ header:
   type: inline
   nav_style: toggle
   sticky: 0
+  top_links_limit: 2
 layout:
   container: page__container
 branding:

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -470,3 +470,13 @@ function sitenow_update_8019() {
     }
   }
 }
+
+/**
+ * Set new theme setting.
+ */
+function sitenow_update_8020() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('uids_base.settings');
+  $config->set('header.top_links_limit', 2);
+  $config->save();
+}

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -98,6 +98,25 @@ function sitenow_query_administerusersbyrole_edit_access_alter(AlterableInterfac
 }
 
 /**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function sitenow_form_menu_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  if ($form["id"]["#default_value"] == 'top-links') {
+    $theme = \Drupal::config('system.theme')->get('default');
+    if (in_array($theme, ['uids_base'])) {
+      $limit = theme_get_setting('header.top_links_limit', 'uids_base');
+      if ($limit) {
+        $warning_text = t('Only the top @limit menu items will display.', [
+          '@limit' => $limit,
+        ]);
+        \Drupal::messenger()->addWarning($warning_text);
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  */
 function sitenow_form_block_form_alter(&$form, FormStateInterface $form_state) {

--- a/docroot/sites/uiowa.edu/modules/uiowa_edu_core/uiowa_edu_core.install
+++ b/docroot/sites/uiowa.edu/modules/uiowa_edu_core/uiowa_edu_core.install
@@ -87,6 +87,16 @@ function uiowa_edu_core_update_8003() {
 }
 
 /**
+ * Set new theme setting.
+ */
+function uiowa_edu_core_update_8004() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('uids_base.settings');
+  $config->set('header.top_links_limit', 3);
+  $config->save();
+}
+
+/**
  * Implements hook_uninstall().
  */
 function uiowa_edu_core_uninstall() {

--- a/docroot/themes/custom/uids_base/templates/navigation/menu--top-links.html.twig
+++ b/docroot/themes/custom/uids_base/templates/navigation/menu--top-links.html.twig
@@ -1,0 +1,54 @@
+{#
+/**
+ * @file
+ * Theme override to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import _self as menus %}
+{#
+  We call a macro which calls itself to render the full tree.
+  @see http://twig.sensiolabs.org/doc/tags/macro.html
+#}
+{{ menus.menu_links(items, attributes, 0, _context) }}
+{{ attach_library('uids_base/main-menu') }}
+{% macro menu_links(items, attributes, menu_level, variables) %}
+  {% import _self as menus %}
+  {% if items %}
+    {% if menu_level == 0 %}
+      <ul{{ attributes.addClass('menu') }}>
+    {% else %}
+      <ul class="menu">
+    {% endif %}
+        {% for item in items|slice(0,variables.limit) %}
+      {%
+        set classes = [
+          'menu-item',
+          item.is_expanded ? 'menu-item--expanded',
+          item.is_collapsed ? 'menu-item--collapsed',
+          item.in_active_trail ? 'menu-item--active-trail',
+        ]
+      %}
+      <li{{ item.attributes.addClass(classes) }}>
+        {{ link(item.title, item.url) }}
+        {% if item.below %}
+          {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+        {% endif %}
+      </li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endmacro %}

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -310,6 +310,19 @@ function uids_base_preprocess_block(&$variables) {
 /**
  * Implements hook_preprocess_HOOK().
  */
+function uids_base_preprocess_menu(&$variables) {
+  switch ($variables["menu_name"]) {
+    case 'top-links':
+      $variables['limit'] = theme_get_setting('header.top_links_limit');
+      break;
+
+  }
+
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
 function uids_base_preprocess_paragraph__card(&$variables) {
   $admin_context = \Drupal::service('router.admin_context');
   if (!$admin_context->isAdminRoute()) {


### PR DESCRIPTION
Resolves #1822 

Restricts top links to 2 on all sites except for the homepage where the limit is 3.

## Test

- pull/cr to register code and template
- sync a couple sites (including uiowa.edu) and confirm update hooks run. uiowa_edu_core should run after the sitenow update on uiowa.edu
- turn on uids_base if not already
- on those sites confirm that only two top links show for all sites except the homepage (3) by creating a few more top links.
- go to the top links menu admin form and confirm a message is indicating how many links are displayed.
- switch the theme off uids_base and see that no message is displayed on the top links form.
