### PR TITLE
Add parent accordion id. Add accordion item heading id.

### DIFF
--- a/docroot/themes/custom/uids_base/templates/field/paragraphs/field--paragraph--field-accordion-item.html.twig
+++ b/docroot/themes/custom/uids_base/templates/field/paragraphs/field--paragraph--field-accordion-item.html.twig
@@ -38,11 +38,9 @@
  */
 #}
 
-{#
-{{ 'accordion-' ~ parent_id }}
-#}
+{% set id = 'accordion-' ~ parent_id %}
 
-<div class="uids-accordion" role="tablist" aria-multiselectable="true" id="accordion-No1">
+<div class="uids-accordion" role="tablist" aria-multiselectable="true" id="{{ id }}">
   {% for item in items %}
     {{ item }}
   {% endfor %}

--- a/docroot/themes/custom/uids_base/templates/paragraphs/accordion/paragraph--accordion-item--default.html.twig
+++ b/docroot/themes/custom/uids_base/templates/paragraphs/accordion/paragraph--accordion-item--default.html.twig
@@ -43,7 +43,7 @@
 {% set id = 'pid' ~ id %}
 
 
-<h2 {{ attributes.addClass(["uids-accordion__heading"]) }}>
+<h2 {{ attributes.addClass(["uids-accordion__heading"]) }} id="{{ label }}">
 	<button class="uids-accordion__button" role="tab" aria-selected="false" aria-expanded="false" aria-controls="{{ id }}">
 
 {{ content.field_accordion_item_title }}


### PR DESCRIPTION
Resolves #1857

## Problems addressed
Accordions weren't receiving unique ids to be referenced by data-parent attributes on accordion items.
Accordion item headings weren't receiving unique ids to be referenced by aria-labelledby attributes on their expanded content.

## Test
Sync a paragraphs site. Change theme to uids_base. `blt frontend`.
Create/check at least two accordions. 
Check that they receive unique ids which match their items' data-parent attributes.
Check that each accordion item's heading has a unique heading id which matches its respective expanded content aria-labelledby attribute.