### PR TITLE
Block all autodiscover requests.

### DIFF
--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -17,6 +17,9 @@ class ReplaceCommands extends BltTasks {
    * @hook replace-command artifact:update:drupal:all-sites
    */
   public function replaceDrupalUpdateAll() {
+    // @todo: Remove this if the htaccess change works.
+    return 0;
+
     // Disable alias since we are targeting a specific URI.
     $this->config->set('drush.alias', '');
 

--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -69,6 +69,10 @@ AddEncoding gzip svgz
 <IfModule mod_rewrite.c>
   RewriteEngine on
 
+  # Return a 403 for autodiscover requests.
+  RewriteCond %{REQUEST_URI} /autodiscover/autodiscover.xml [NC]
+  RewriteRule ^ - [F,L]
+
   # Redirect http(s)://www.domain.com to https://domain.com.
   RewriteCond %{HTTP_HOST} !\.acquia-sites\.com [NC]
   RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]


### PR DESCRIPTION
This change returns a 403 Access Denied for all autodiscover.xml requests. This will prevent Drupal from bootstrapping and trying to handle the GET/POST requests for this non-existent service.

Right now, the post-code update/deploy hooks do nothing to make rolling back to the previous release quicker. This will need to be changed in a follow-up release assuming the htaccess change works.