### PR TITLE
fixing z index for slick dots

### DIFF
--- a/docroot/themes/custom/uids_base/scss/paragraphs/uiowa_paragraphs_carousel.scss
+++ b/docroot/themes/custom/uids_base/scss/paragraphs/uiowa_paragraphs_carousel.scss
@@ -51,6 +51,7 @@ div[data-carousel="carousel"] {
   }
 
   .slick-dots {
+    z-index: 11;
     margin: calc(1.5rem - .15rem) 0.2rem;
     display: flex;
     position: absolute;


### PR DESCRIPTION
This makes sure the slick dots always sit above the arrows on a carousel. The arrows have a full height for easy clicking, so the dots get covered by them. this fixes them possibly getting covered by that large height.
