### PR TITLE
Change default remote lb-test Drush alias to test env.

### DIFF
--- a/docroot/sites/lb-test.uiowa.edu/blt.yml
+++ b/docroot/sites/lb-test.uiowa.edu/blt.yml
@@ -7,7 +7,7 @@ project:
 drush:
   aliases:
     local: self
-    remote: lb-test.prod
+    remote: lb-test.test
 drupal:
   db:
     database: lb_test_uiowa_edu


### PR DESCRIPTION
I manually installed the lb-test site in the test environment by SSH'ing into uiowa02 and running `./vendor/bin/blt drupal:install --site lb-test.uiowa.edu` from the app root. This will allow you to start working on the site. Running a sync will pull from the test environment after this is merged.