### PR TITLE
Image background hotfix

### DIFF
--- a/config/policy.clas.uiowa.edu/core.entity_view_display.media.image.edgy.yml
+++ b/config/policy.clas.uiowa.edu/core.entity_view_display.media.image.edgy.yml
@@ -1,0 +1,37 @@
+uuid: 127e16b8-9193-4609-bc2e-40a38765d9e8
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.edgy
+    - field.field.media.image.field_media_image
+    - media.type.image
+    - responsive_image.styles.ui_edgy_no_crop
+  module:
+    - lazy
+    - responsive_image
+_core:
+  default_config_hash: HW52IsyizTd9psyOjhjteunTeM7jjttYXkwPB0YAbcU
+id: media.image.edgy
+targetEntityType: media
+bundle: image
+mode: edgy
+content:
+  field_media_image:
+    weight: 0
+    label: hidden
+    settings:
+      responsive_image_style: ui_edgy_no_crop
+      image_link: ''
+    third_party_settings:
+      lazy:
+        lazy_image: '1'
+    type: responsive_image
+    region: content
+hidden:
+  created: true
+  field_media_caption: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -655,13 +655,13 @@ function sitenow_update_8022() {
       $media_manager->create($media_array)
         ->save();
     }
-    // Set the section config to use image and not image_background.
-    $section_config = \Drupal::configFactory()
-      ->getEditable('field.field.paragraph.section.field_section_image');
-    $section_config
-      ->set('settings.handler_settings.target_bundles', [
-        'image' => 'image',
-      ])
-      ->save();
   }
+  // Set the section config to use image and not image_background.
+  $section_config = \Drupal::configFactory()
+    ->getEditable('field.field.paragraph.section.field_section_image');
+  $section_config
+    ->set('settings.handler_settings.target_bundles', [
+      'image' => 'image',
+    ])
+    ->save();
 }


### PR DESCRIPTION
Hotfix for #1888 

## Problem
Resultant errors in policy.clas.uiowa.edu, icsa.uiowa.edu, and possibly others:
`Synchronized configuration: delete field.field.media.image_background.field_media_image_1.
 [error]  The field_section_image entity reference field (entity_type: paragraph, bundle: section) no longer has any valid bundle it can reference. The field is not working correctly anymore and has to be adjusted. 
 [notice] Synchronized configuration: delete media.type.image_background.`

A config update was being missed for sites which did not have any image_background media entities, resulting in config incompatibilities. This update should fix the oversight, and prevent any order-of-operations problems with the config sync.

## Testing
Sync site.
(If you haven't rsynced files, 'file does not exist' errors will be thrown. This is to be expected, and syncing or stage proxy after syncing should still work appropriately.)
Check that image:background is no longer available as an option in media.
If testing a SiteNow(P) site, check that any previous image:background media now appear as regular image media.
Add a section background image using standard image media and check that it renders correctly, with the appropriate styling.
Check that non-background images haven't changed, and are appropriately styled (dimensions appear normal, resolution appears normal)