### PR TITLE
Feature: Home page quick links fix

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/menus/quick.scss
+++ b/docroot/themes/custom/uids_base/scss/components/menus/quick.scss
@@ -61,7 +61,12 @@
 }
 
 .search-is-open .region-under-search:after {
-  margin-right: -50%;
+  transform: translateX(calc(49%));
+
+  @include breakpoint(container) {
+    margin-right: -50%;
+    transform: unset;
+  }
 }
 
 .search-is-open .region-under-search:before {

--- a/docroot/themes/custom/uids_base/scss/components/menus/quick.scss
+++ b/docroot/themes/custom/uids_base/scss/components/menus/quick.scss
@@ -6,16 +6,64 @@
   .contextual {
     display: none;
   }
+
   li:first-child a:before {
     content: "\f02e";
     @include fas();
     padding-right: $md;
     color: $grey;
   }
+
   li:nth-child(2) a:before {
     content: "\f007";
     @include fas();
     padding-right: $md;
     color: $grey;
   }
+}
+
+.menu--quick-links {
+  bottom: -116px;
+
+  .scroll-down & {
+    transform: translate3d(0, -100%, 0);
+  }
+}
+
+.region-under-search {
+  transition: transform .4s;
+}
+
+.scroll-down .region-under-search {
+  @include element-invisible;
+}
+
+.search-is-open .region-under-search .menu--quick-links {
+  @include breakpoint(menu) {
+    clip: auto;
+    height: auto;
+    width: auto;
+    overflow: auto;
+    position: absolute !important;
+    background: $secondary;
+  }
+}
+
+.search-is-open .region-under-search:after,
+.search-is-open .region-under-search:before {
+  content: " ";
+  background: $secondary;
+  padding: 20px;
+  position: absolute;
+  top: 80px;
+  width: 100%;
+  left: 0;
+}
+
+.search-is-open .region-under-search:after {
+  margin-right: -50%;
+}
+
+.search-is-open .region-under-search:before {
+  margin-left: -50%;
 }


### PR DESCRIPTION
This is a fix for the regression that occurred in the UIDS 3.0 release which lost the styling for the quick links menu below the header. 

# How to test

`blt frontend` on uiowa.edu and test the search toggle
- verify that links appear in black bar below header
- verify that links still appear on scroll down
- verify that the black bar disappears on scroll up
- verify that quick links don't appear for mobile view