### PR TITLE
fix view headers on articles, people view pages

### DIFF
--- a/docroot/themes/custom/uids_base/scss/views/view-display-id-page_articles.scss
+++ b/docroot/themes/custom/uids_base/scss/views/view-display-id-page_articles.scss
@@ -4,6 +4,9 @@
 .view-display-id-page_articles {
   display: flex;
   flex-wrap: wrap;
+  .view-header {
+    width: 100%;
+  }
 
   .view-content {
     flex: 1 0 0;

--- a/docroot/themes/custom/uids_base/scss/views/view-display-id-people.scss
+++ b/docroot/themes/custom/uids_base/scss/views/view-display-id-people.scss
@@ -2,6 +2,9 @@
 @import "uids/assets/scss/_utilities.scss";
 
 .view-id-people {
+  .view-header {
+    width: 100%;
+  }
   .view-content {
     @include list-group;
     @include list-group-flush;


### PR DESCRIPTION
resolves #1944

Add a view header and see that it is full-width and not squished as part of the flex behavior.
https://sitenow.local.drupal.uiowa.edu/news