### PR TITLE
Site Improve A11y Fixes

### DIFF
--- a/docroot/modules/custom/sitenow_articles/sitenow_articles.module
+++ b/docroot/modules/custom/sitenow_articles/sitenow_articles.module
@@ -188,7 +188,7 @@ function sitenow_articles_preprocess_node(&$variables) {
           $route_name = $current_route->getRouteName();
           $variables['#cache']['contexts'][] = 'route.name';
           if (strpos($route_name, 'view.articles.') === 0) {
-            $variables['content_heading'] = "h2";
+            $variables['content_heading'] = 'h2';
           }
 
           if ($node->hasField('field_article_source_link_direct')) {

--- a/docroot/modules/custom/sitenow_articles/sitenow_articles.module
+++ b/docroot/modules/custom/sitenow_articles/sitenow_articles.module
@@ -186,6 +186,7 @@ function sitenow_articles_preprocess_node(&$variables) {
           $current_route = \Drupal::routeMatch();
           $route_name = $current_route->getRouteName();
           if (strpos($route_name, 'view.articles.') === 0) {
+            $variables['#cache']['contexts'][] = 'route.name';
             $variables['content_heading'] = "h2";
           }
           if ($node->hasField('field_article_source_link_direct')) {

--- a/docroot/modules/custom/sitenow_articles/sitenow_articles.module
+++ b/docroot/modules/custom/sitenow_articles/sitenow_articles.module
@@ -183,11 +183,14 @@ function sitenow_articles_preprocess_node(&$variables) {
           }
         }
         if ($variables['view_mode'] == 'teaser') {
+          // Heading needs to change based on placement. Defaults to h3 in twig.
           $current_route = \Drupal::routeMatch();
           $route_name = $current_route->getRouteName();
+          $variables['#cache']['contexts'][] = 'route.name';
           if (strpos($route_name, 'view.articles.') === 0) {
             $variables['content_heading'] = "h2";
           }
+
           if ($node->hasField('field_article_source_link_direct')) {
             if ($node->field_article_source_link_direct->value == 1 && !$node->get('field_article_source_link')->isEmpty()) {
               unset($variables["content"]["field_article_source_link"]);

--- a/docroot/modules/custom/sitenow_articles/sitenow_articles.module
+++ b/docroot/modules/custom/sitenow_articles/sitenow_articles.module
@@ -188,7 +188,6 @@ function sitenow_articles_preprocess_node(&$variables) {
           $route_name = $current_route->getRouteName();
           $variables['#cache']['contexts'][] = 'route.name';
           if (strpos($route_name, 'view.articles.') === 0) {
-            $variables['#cache']['contexts'][] = 'route.name';
             $variables['content_heading'] = "h2";
           }
 

--- a/docroot/modules/custom/sitenow_articles/sitenow_articles.module
+++ b/docroot/modules/custom/sitenow_articles/sitenow_articles.module
@@ -186,7 +186,6 @@ function sitenow_articles_preprocess_node(&$variables) {
           $current_route = \Drupal::routeMatch();
           $route_name = $current_route->getRouteName();
           if (strpos($route_name, 'view.articles.') === 0) {
-            $variables['#cache']['contexts'][] = $route_name;
             $variables['content_heading'] = "h2";
           }
           if ($node->hasField('field_article_source_link_direct')) {

--- a/docroot/modules/custom/sitenow_articles/sitenow_articles.module
+++ b/docroot/modules/custom/sitenow_articles/sitenow_articles.module
@@ -183,6 +183,12 @@ function sitenow_articles_preprocess_node(&$variables) {
           }
         }
         if ($variables['view_mode'] == 'teaser') {
+          $current_route = \Drupal::routeMatch();
+          $route_name = $current_route->getRouteName();
+          if (strpos($route_name, 'view.articles.') === 0) {
+            $variables['#cache']['contexts'][] = $route_name;
+            $variables['content_heading'] = "h2";
+          }
           if ($node->hasField('field_article_source_link_direct')) {
             if ($node->field_article_source_link_direct->value == 1 && !$node->get('field_article_source_link')->isEmpty()) {
               unset($variables["content"]["field_article_source_link"]);

--- a/docroot/modules/custom/sitenow_people/sitenow_people.module
+++ b/docroot/modules/custom/sitenow_people/sitenow_people.module
@@ -226,6 +226,7 @@ function sitenow_people_preprocess_node(&$variables) {
             $current_route = \Drupal::routeMatch();
             $route_name = $current_route->getRouteName();
             if (strpos($route_name, 'view.people.') === 0) {
+              $variables['#cache']['contexts'][] = 'route.name';
               $variables['content_heading'] = "h2";
             }
             break;

--- a/docroot/modules/custom/sitenow_people/sitenow_people.module
+++ b/docroot/modules/custom/sitenow_people/sitenow_people.module
@@ -229,9 +229,8 @@ function sitenow_people_preprocess_node(&$variables) {
               $variables['content_heading'] = "h2";
             }
             break;
-
-          break;
         }
+        break;
     }
   }
 

--- a/docroot/modules/custom/sitenow_people/sitenow_people.module
+++ b/docroot/modules/custom/sitenow_people/sitenow_people.module
@@ -228,7 +228,6 @@ function sitenow_people_preprocess_node(&$variables) {
             $route_name = $current_route->getRouteName();
             $variables['#cache']['contexts'][] = 'route.name';
             if (strpos($route_name, 'view.people.') === 0) {
-              $variables['#cache']['contexts'][] = 'route.name';
               $variables['content_heading'] = "h2";
             }
             break;

--- a/docroot/modules/custom/sitenow_people/sitenow_people.module
+++ b/docroot/modules/custom/sitenow_people/sitenow_people.module
@@ -228,7 +228,7 @@ function sitenow_people_preprocess_node(&$variables) {
             $route_name = $current_route->getRouteName();
             $variables['#cache']['contexts'][] = 'route.name';
             if (strpos($route_name, 'view.people.') === 0) {
-              $variables['content_heading'] = "h2";
+              $variables['content_heading'] = 'h2';
             }
             break;
         }

--- a/docroot/modules/custom/sitenow_people/sitenow_people.module
+++ b/docroot/modules/custom/sitenow_people/sitenow_people.module
@@ -223,8 +223,10 @@ function sitenow_people_preprocess_node(&$variables) {
       case 'person':
         switch ($variables['view_mode']) {
           case 'teaser':
+            // Heading needs to change based on placement. Defaults to h3 in twig.
             $current_route = \Drupal::routeMatch();
             $route_name = $current_route->getRouteName();
+            $variables['#cache']['contexts'][] = 'route.name';
             if (strpos($route_name, 'view.people.') === 0) {
               $variables['content_heading'] = "h2";
             }

--- a/docroot/modules/custom/sitenow_people/sitenow_people.module
+++ b/docroot/modules/custom/sitenow_people/sitenow_people.module
@@ -215,6 +215,31 @@ function sitenow_people_preprocess_views_view(&$variables) {
 /**
  * Implements hook_preprocess_HOOK().
  */
+function sitenow_people_preprocess_node(&$variables) {
+  $admin_context = \Drupal::service('router.admin_context');
+  if (!$admin_context->isAdminRoute()) {
+    $node = $variables["node"];
+    switch ($node->getType()) {
+      case 'person':
+        switch ($variables['view_mode']) {
+          case 'teaser':
+            $current_route = \Drupal::routeMatch();
+            $route_name = $current_route->getRouteName();
+            if (strpos($route_name, 'view.people.') === 0) {
+              $variables['content_heading'] = "h2";
+            }
+            break;
+
+          break;
+        }
+    }
+  }
+
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
 function sitenow_people_preprocess_field(&$variables) {
   switch ($variables["element"]["#field_name"]) {
     // Change header class for person position based on view mode.

--- a/docroot/themes/custom/uids_base/scss/components/footer.scss
+++ b/docroot/themes/custom/uids_base/scss/components/footer.scss
@@ -3,6 +3,15 @@
 $imgpath: '../../../../../uids/assets/images/';
 @import "components/branding/footer/footer.scss";
 
+.footer {
+  h2, h3, h4, h5, h6 {
+    color: $white;
+  }
+  .lead {
+    color: $white;
+  }
+}
+
 .uiowa-footer--login-link {
   a {
     &:before {

--- a/docroot/themes/custom/uids_base/templates/content/node--article--teaser.html.twig
+++ b/docroot/themes/custom/uids_base/templates/content/node--article--teaser.html.twig
@@ -87,11 +87,7 @@
   {% set node_link = url %}
 {% endif %}
 
-{% if content_heading %}
-  {% set heading_level = content_heading %}
-{% else %}
-  {% set heading_level = 'h3' %}
-{% endif %}
+{% set heading_level = content_heading ?: 'h3' %}
 
 {{ attach_library('classy/node') }}
 {{ attach_library('uids_base/node-type-article') }}

--- a/docroot/themes/custom/uids_base/templates/content/node--article--teaser.html.twig
+++ b/docroot/themes/custom/uids_base/templates/content/node--article--teaser.html.twig
@@ -87,6 +87,12 @@
   {% set node_link = url %}
 {% endif %}
 
+{% if content_heading %}
+  {% set heading_level = content_heading %}
+{% else %}
+  {% set heading_level = 'h3' %}
+{% endif %}
+
 {{ attach_library('classy/node') }}
 {{ attach_library('uids_base/node-type-article') }}
 {{ attach_library('uids_base/paragraphs-lists') }}
@@ -97,6 +103,7 @@
   'card_title': label,
   'content': content,
   'card_link_url': node_link,
+  'heading_level': heading_level,
 } %}
 
 {% embed '@uids_base/uids/card.html.twig' with article_card only %}

--- a/docroot/themes/custom/uids_base/templates/content/node--person--teaser.html.twig
+++ b/docroot/themes/custom/uids_base/templates/content/node--person--teaser.html.twig
@@ -77,11 +77,7 @@
 ]
 %}
 
-{% if content_heading %}
-  {% set heading_level = content_heading %}
-{% else %}
-  {% set heading_level = 'h3' %}
-{% endif %}
+{% set heading_level = content_heading ?: 'h3' %}
 
 {{ attach_library('classy/node') }}
 {{ attach_library('uids_base/paragraphs-lists') }}

--- a/docroot/themes/custom/uids_base/templates/content/node--person--teaser.html.twig
+++ b/docroot/themes/custom/uids_base/templates/content/node--person--teaser.html.twig
@@ -77,6 +77,12 @@
 ]
 %}
 
+{% if content_heading %}
+  {% set heading_level = content_heading %}
+{% else %}
+  {% set heading_level = 'h3' %}
+{% endif %}
+
 {{ attach_library('classy/node') }}
 {{ attach_library('uids_base/paragraphs-lists') }}
 {{ attach_library('uids_base/node-type-person') }}
@@ -88,7 +94,7 @@
   'card_author': content.field_person_credential.0,
   'card_title': label | render,
   'card_link_url': url,
-  'heading_level': 'h3'
+  'heading_level': heading_level,
 } %}
 
 {% embed '@uids_base/uids/card.html.twig' with person_card only %}{% endembed %}

--- a/docroot/themes/custom/uids_base/templates/layout/header.html.twig
+++ b/docroot/themes/custom/uids_base/templates/layout/header.html.twig
@@ -45,7 +45,7 @@
       'nav--' ~ header_nav,
     ] %}
 
-    <nav{{ nav_attributes.addClass(nav_classes) }}>
+    <nav{{ nav_attributes.addClass(nav_classes) }} aria-label="Primary menu">
       <div class="page__container">
         {{ page.primary_menu }}
       </div>

--- a/docroot/themes/custom/uids_base/templates/navigation/pager.html.twig
+++ b/docroot/themes/custom/uids_base/templates/navigation/pager.html.twig
@@ -1,0 +1,99 @@
+{#
+/**
+ * @file
+ * Theme override to display a pager.
+ *
+ * Available variables:
+ * - heading_id: Pagination heading ID.
+ * - items: List of pager items.
+ *   The list is keyed by the following elements:
+ *   - first: Item for the first page; not present on the first page of results.
+ *   - previous: Item for the previous page; not present on the first page
+ *     of results.
+ *   - next: Item for the next page; not present on the last page of results.
+ *   - last: Item for the last page; not present on the last page of results.
+ *   - pages: List of pages, keyed by page number.
+ *   Sub-sub elements:
+ *   items.first, items.previous, items.next, items.last, and each item inside
+ *   items.pages contain the following elements:
+ *   - href: URL with appropriate query parameters for the item.
+ *   - attributes: A keyed list of HTML attributes for the item.
+ *   - text: The visible text used for the item link, such as "‹ Previous"
+ *     or "Next ›".
+ * - current: The page number of the current page.
+ * - ellipses: If there are more pages than the quantity allows, then an
+ *   ellipsis before or after the listed pages may be present.
+ *   - previous: Present if the currently visible list of pages does not start
+ *     at the first page.
+ *   - next: Present if the visible list of pages ends before the last page.
+ *
+ * @see template_preprocess_pager()
+ */
+#}
+{% if items %}
+  <nav class="pager" role="navigation" aria-labelledby="{{ heading_id }}">
+    <div id="{{ heading_id }}" class="visually-hidden">{{ 'Pagination'|t }}</div>
+    <ul class="pager__items js-pager__items">
+      {# Print first item if we are not on the first page. #}
+      {% if items.first %}
+        <li class="pager__item pager__item--first">
+          <a href="{{ items.first.href }}" title="{{ 'Go to first page'|t }}"{{ items.first.attributes|without('href', 'title') }}>
+            <span class="visually-hidden">{{ 'First page'|t }}</span>
+            <span aria-hidden="true">{{ items.first.text|default('« First'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {# Print previous item if we are not on the first page. #}
+      {% if items.previous %}
+        <li class="pager__item pager__item--previous">
+          <a href="{{ items.previous.href }}" title="{{ 'Go to previous page'|t }}" rel="prev"{{ items.previous.attributes|without('href', 'title', 'rel') }}>
+            <span class="visually-hidden">{{ 'Previous page'|t }}</span>
+            <span aria-hidden="true">{{ items.previous.text|default('‹ Previous'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {# Add an ellipsis if there are further previous pages. #}
+      {% if ellipses.previous %}
+        <li class="pager__item pager__item--ellipsis" role="presentation">&hellip;</li>
+      {% endif %}
+      {# Now generate the actual pager piece. #}
+      {% for key, item in items.pages %}
+        <li class="pager__item{{ current == key ? ' is-active' : '' }}">
+          {% if current == key %}
+            {% set title = 'Current page'|t %}
+          {% else %}
+            {% set title = 'Go to page @key'|t({'@key': key}) %}
+          {% endif %}
+          <a href="{{ item.href }}" title="{{ title }}"{{ item.attributes|without('href', 'title') }}>
+            <span class="visually-hidden">
+              {{ current == key ? 'Current page'|t : 'Page'|t }}
+            </span>
+            {{- key -}}
+          </a>
+        </li>
+      {% endfor %}
+      {# Add an ellipsis if there are further next pages. #}
+      {% if ellipses.next %}
+        <li class="pager__item pager__item--ellipsis" role="presentation">&hellip;</li>
+      {% endif %}
+      {# Print next item if we are not on the last page. #}
+      {% if items.next %}
+        <li class="pager__item pager__item--next">
+          <a href="{{ items.next.href }}" title="{{ 'Go to next page'|t }}" rel="next"{{ items.next.attributes|without('href', 'title', 'rel') }}>
+            <span class="visually-hidden">{{ 'Next page'|t }}</span>
+            <span aria-hidden="true">{{ items.next.text|default('Next ›'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {# Print last item if we are not on the last page. #}
+      {% if items.last %}
+        <li class="pager__item pager__item--last">
+          <a href="{{ items.last.href }}" title="{{ 'Go to last page'|t }}"{{ items.last.attributes|without('href', 'title') }}>
+            <span class="visually-hidden">{{ 'Last page'|t }}</span>
+            <span aria-hidden="true">{{ items.last.text|default('Last »'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+    </ul>
+  </nav>
+{% endif %}

--- a/docroot/themes/custom/uids_base/templates/views/views-mini-pager.html.twig
+++ b/docroot/themes/custom/uids_base/templates/views/views-mini-pager.html.twig
@@ -1,0 +1,42 @@
+{#
+/**
+ * @file
+ * Theme override for a views mini-pager.
+ *
+ * Available variables:
+ * - heading_id: Pagination heading ID.
+ * - items: List of pager items.
+ *
+ * @see template_preprocess_views_mini_pager()
+ */
+#}
+{% if items.previous or items.next %}
+  <nav class="pager" role="navigation" aria-labelledby="{{ heading_id }}">
+    <div id="{{ heading_id }}" class="pager__heading visually-hidden">{{ 'Pagination'|t }}</div>
+    <ul class="pager__items js-pager__items">
+      {% if items.previous %}
+        <li class="pager__item pager__item--previous">
+          <a href="{{ items.previous.href }}" title="{{ 'Go to previous page'|t }}" rel="prev"{{ items.previous.attributes|without('href', 'title', 'rel') }}>
+            <span class="visually-hidden">{{ 'Previous page'|t }}</span>
+            <span aria-hidden="true">{{ items.previous.text|default('‹‹'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {% if items.current %}
+        <li class="pager__item is-active">
+          {% trans %}
+            Page {{ items.current }}
+          {% endtrans %}
+        </li>
+      {% endif %}
+      {% if items.next %}
+        <li class="pager__item pager__item--next">
+          <a href="{{ items.next.href }}" title="{{ 'Go to next page'|t }}" rel="next"{{ items.next.attributes|without('href', 'title', 'rel') }}>
+            <span class="visually-hidden">{{ 'Next page'|t }}</span>
+            <span aria-hidden="true">{{ items.next.text|default('››'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+    </ul>
+  </nav>
+{% endif %}


### PR DESCRIPTION
fixes #1896
relates to #1900 as it doesn't fix basic page or pagination.

relates to #1878 as it just ensures proper contrast colors for headings.

## To Test

- 1896 - With the site improve extension locally, view sites with different primary navigations and confirm that no errors related to navigation are thrown for "Non-distinguishable landmarks" (e.g. brand.local.drupal.uiowa.edu, uiowa.local.drupal.uiowa.edu)
- 1900 - On default.local.drupal.uiowa.edu after a `cr` confirm that the article teasers on the homepage have `<h3 class="card__title">` while the article teasers on /news have `<h2 class="card__title">` which provides the proper header nesting order.
- 1878 Visit a site like brand.local.drupal.uiowa.edu which has a header in their footer. It should now show up with proper contrast ratio.