### PR TITLE
Feature: Fix for embedded video with a figcaption

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/video/video-utilities.scss
+++ b/docroot/themes/custom/uids_base/scss/components/video/video-utilities.scss
@@ -6,6 +6,9 @@
   @extend .embed-responsive;
   @extend .embed-responsive-16by9;
 
+  &.media--view-mode-image-large,
+  &.media--view-mode-image-medium,
+  &.media--view-mode-image-small,
   figure.caption & {
     @include breakpoint(sm) {
       padding-bottom: 0;
@@ -13,7 +16,10 @@
   }
 }
 
-figure.caption .media--type-remote-video iframe {
+figure.caption .media--type-remote-video iframe,
+.media--type-remote-video.media--view-mode-image-medium iframe,
+.media--type-remote-video.media--view-mode-image-large iframe,
+.media--type-remote-video.media--view-mode-image-small iframe {
   @include breakpoint(sm) {
     position: unset;
     display: inherit;
@@ -25,21 +31,24 @@ figure.caption .media--type-remote-video iframe {
 }
 
 figure.caption .media--type-remote-video.media--view-mode-image-large iframe,
-figure.caption .media--type-remote-video.media--view-mode-full iframe {
+figure.caption .media--type-remote-video.media--view-mode-full iframe,
+.media--type-remote-video.media--view-mode-image-large iframe {
   @include breakpoint(sm) {
     width: 854px;
     height: 480px;
   }
 }
 
-figure.caption .media--type-remote-video.media--view-mode-image-medium iframe {
+figure.caption .media--type-remote-video.media--view-mode-image-medium iframe,
+.media--type-remote-video.media--view-mode-image-medium iframe {
   @include breakpoint(sm) {
     width: 640px;
     height: 360px;
   }
 }
 
-figure.caption .media--type-remote-video.media--view-mode-image-small iframe {
+figure.caption .media--type-remote-video.media--view-mode-image-small iframe,
+.media--type-remote-video.media--view-mode-image-small iframe {
   @include breakpoint(sm) {
     width: 426px;
     height: 240px;

--- a/docroot/themes/custom/uids_base/scss/components/video/video-utilities.scss
+++ b/docroot/themes/custom/uids_base/scss/components/video/video-utilities.scss
@@ -5,6 +5,45 @@
 .media--type-remote-video {
   @extend .embed-responsive;
   @extend .embed-responsive-16by9;
+
+  figure.caption & {
+    @include breakpoint(sm) {
+      padding-bottom: 0;
+    }
+  }
+}
+
+figure.caption .media--type-remote-video iframe {
+  @include breakpoint(sm) {
+    position: unset;
+    display: inherit;
+    width: auto;
+    height: auto;
+    padding: 0;
+    overflow: auto;
+  }
+}
+
+figure.caption .media--type-remote-video.media--view-mode-image-large iframe,
+figure.caption .media--type-remote-video.media--view-mode-full iframe {
+  @include breakpoint(sm) {
+    width: 854px;
+    height: 480px;
+  }
+}
+
+figure.caption .media--type-remote-video.media--view-mode-image-medium iframe {
+  @include breakpoint(sm) {
+    width: 640px;
+    height: 360px;
+  }
+}
+
+figure.caption .media--type-remote-video.media--view-mode-image-small iframe {
+  @include breakpoint(sm) {
+    width: 426px;
+    height: 240px;
+  }
 }
 
 .media--type-remote-video.media--view-mode-small__ultrawide,

--- a/docroot/themes/custom/uids_base/scss/media/embedded-entity.scss
+++ b/docroot/themes/custom/uids_base/scss/media/embedded-entity.scss
@@ -26,7 +26,12 @@
 }
 
 figure.caption {
-  display: table;
+  display: block;
+
+  @include breakpoint(sm) {
+    display: table;
+  }
+
   margin: 0;
   margin-bottom: .5rem;
 
@@ -36,7 +41,12 @@ figure.caption {
   }
 
   figcaption {
-    display: table-caption;
+    display: block;
+
+    @include breakpoint(sm) {
+      display: table-caption;
+    }
+
     max-width: none;
     caption-side: bottom;
   }


### PR DESCRIPTION
# Problem

Embedded video with a `<figcaption>` displays weird:

<img width="307" alt="Screen Shot 2020-07-14 at 8 28 49 AM" src="https://user-images.githubusercontent.com/1036433/87431398-31df8380-c5ac-11ea-883c-e8d2bd5330e2.png">

# Solution within this PR:

I targeted the display modes for each embedded video size above the `sm` breakpoint so that the videos will display with a caption below it. 

# How to test

- Embed a video with a caption and test at mobile and full breakpoints
- Embed an image with a caption and test at all breakpoints
- Try this on a SiteNow site
- This issue will still need to be fixed for uiowa.ecu
