### PR TITLE
more coverage for spans inside of buttons

### DIFF
--- a/docroot/themes/custom/uids_base/scss/paragraphs/_uiowa_paragraphs_background_overrides.scss
+++ b/docroot/themes/custom/uids_base/scss/paragraphs/_uiowa_paragraphs_background_overrides.scss
@@ -20,6 +20,9 @@
             &:after {
                 background-color: $primary;
             }
+            span {
+              color: $white !important;
+            }
         }
 
         a.btn:not(.btn-primary) {
@@ -29,6 +32,9 @@
 
             &:after {
                 background-color: $primary;
+            }
+            span {
+              color: $white !important;
             }
         }
 
@@ -248,6 +254,9 @@
             &:after {
                 background-color: $secondary;
             }
+            span {
+              color: $secondary !important;
+            }
         }
 
         a.btn:not(.btn-primary) {
@@ -257,6 +266,9 @@
 
             &:after {
                 background-color: $secondary;
+            }
+            span {
+              color: $secondary !important;
             }
         }
 
@@ -426,12 +438,18 @@
             &:after {
                 background-color: $secondary;
             }
+            span {
+              color: $secondary !important;
+            }
         }
 
         a.btn:not(.btn-primary) {
             @include bttn--secondary;
             border: 1px solid $secondary;
             @include bttn--focus;
+            span {
+              color: $white !important;
+            }
         }
 
         label {
@@ -586,12 +604,18 @@
             &:after {
                 background-color: $secondary;
             }
+            span {
+              color: $secondary !important;
+            }
         }
 
         a.btn:not(.btn-primary) {
             @include bttn--secondary;
             border: 1px solid $secondary;
             @include bttn--focus;
+            span {
+              color: $white !important;
+            }
         }
 
         label {

--- a/docroot/themes/custom/uids_base/scss/paragraphs/uiowa-paragraphs-card.scss
+++ b/docroot/themes/custom/uids_base/scss/paragraphs/uiowa-paragraphs-card.scss
@@ -27,7 +27,7 @@
                 background-color: $secondary;
             }
            span {
-            color: $secondary;
+            color: $secondary !important;
            }
         }
 
@@ -36,7 +36,7 @@
             border: 1px solid $secondary;
            @include bttn--focus;
            span {
-            color: $white;
+            color: $white !important;
            }
         }
     }

--- a/docroot/themes/custom/uids_base/scss/paragraphs/uiowa-paragraphs-card.scss
+++ b/docroot/themes/custom/uids_base/scss/paragraphs/uiowa-paragraphs-card.scss
@@ -35,6 +35,9 @@
            @include bttn--secondary;
             border: 1px solid $secondary;
            @include bttn--focus;
+           span {
+            color: $white;
+           }
         }
     }
 

--- a/docroot/themes/custom/uids_base/scss/paragraphs/uiowa_paragraphs_accordion.scss
+++ b/docroot/themes/custom/uids_base/scss/paragraphs/uiowa_paragraphs_accordion.scss
@@ -41,6 +41,9 @@
                @include bttn--secondary;
                 border: 1px solid $secondary;
                @include bttn--focus;
+               span {
+                color: $white;
+               }
             }
         }
     }

--- a/docroot/themes/custom/uids_base/scss/paragraphs/uiowa_paragraphs_accordion.scss
+++ b/docroot/themes/custom/uids_base/scss/paragraphs/uiowa_paragraphs_accordion.scss
@@ -33,7 +33,7 @@
                     background-color: $secondary;
                 }
                 span {
-                  color: $secondary;
+                  color: $secondary !important;
                 }
             }
 
@@ -42,7 +42,7 @@
                 border: 1px solid $secondary;
                @include bttn--focus;
                span {
-                color: $white;
+                color: $white !important;
                }
             }
         }

--- a/docroot/themes/custom/uids_base/scss/sitenow.scss
+++ b/docroot/themes/custom/uids_base/scss/sitenow.scss
@@ -445,6 +445,9 @@ figure.caption .embedded-entity+figcaption {
   @include bttn--secondary;
   border: 1px solid $secondary;
   @include bttn--focus;
+  span {
+    color: $white;
+  }
 }
 
 .btn-primary,
@@ -455,5 +458,8 @@ figure.caption .embedded-entity+figcaption {
 
   &:after {
     background-color: $secondary;
+  }
+  span {
+    color: $secondary;
   }
 }


### PR DESCRIPTION
Color contrast spans for buttons!

In an effort remedy a `.bg-black .bg-light .btn.btn-secondary span`, I took it further to cover more spans within buttons.

https://diversity.local.drupal.uiowa.edu/about/dei-across-campus
