### PR TITLE
Feature: Footer nav heading adjustments

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/footer.scss
+++ b/docroot/themes/custom/uids_base/scss/components/footer.scss
@@ -6,6 +6,7 @@ $imgpath: '../../../../../uids/assets/images/';
 .footer {
   h2, h3, h4, h5, h6 {
     color: $white;
+    font-weight: $font-weight-normal;
   }
   .lead {
     color: $white;
@@ -56,5 +57,17 @@ $imgpath: '../../../../../uids/assets/images/';
     position: absolute;
     width: 1px;
     margin-right: 0.5rem;
+  }
+}
+
+.footer__links--nav {
+  flex-wrap: wrap;
+  align-content: start;
+  h2 {
+    font-weight: $font-weight-bold;
+    font-size: $h5-font-size;
+  }
+  > * {
+    flex-basis: 100%;
   }
 }


### PR DESCRIPTION
Resolves #1878

# How to test

<img width="600" alt="Screen Shot 2020-07-17 at 2 39 18 PM" src="https://user-images.githubusercontent.com/1036433/87824678-569d5a80-c83b-11ea-80f8-b73fbaeed231.png">

Check the "Display Title" checkbox on a footer menu block and verify that the heading displays on top of the menu.  Previously, the heading would collapse into a column next to the menu. 

Also adjusted font-weight of footer headings.