### PR TITLE
Change uip_items field to only allow values 0 or greater

### DIFF
--- a/config/default/field.field.paragraph.articles.field_uip_items.yml
+++ b/config/default/field.field.paragraph.articles.field_uip_items.yml
@@ -18,8 +18,8 @@ default_value:
     value: 10
 default_value_callback: ''
 settings:
-  min: null
-  max: null
+  min: 0
+  max: 50
   prefix: ''
   suffix: ''
 field_type: integer

--- a/config/default/field.field.paragraph.people.field_uip_items.yml
+++ b/config/default/field.field.paragraph.people.field_uip_items.yml
@@ -18,8 +18,8 @@ default_value:
     value: 10
 default_value_callback: ''
 settings:
-  min: null
-  max: null
+  min: 0
+  max: 50
   prefix: ''
   suffix: ''
 field_type: integer


### PR DESCRIPTION
fixes #1968

The 50 limit is to prevent load issues

## To Test

Create an articles block and try to save it with a number of items value of -2.
