### PR TITLE
Feature: Update research areas field in person_extended split

### DIFF
--- a/config/default/config_split.config_split.person_extended.yml
+++ b/config/default/config_split.config_split.person_extended.yml
@@ -10,7 +10,7 @@ module: {  }
 theme: {  }
 blacklist: {  }
 graylist:
-  - field.storage.node.person_pt_faculty_research_areas
+  - field.storage.node.field_person_research_areas
   - field.storage.node.field_person_type
   - field.storage.node.field_person_website
   - taxonomy.vocabulary.person_types

--- a/config/features/person_extended/core.entity_form_display.node.person.default.yml
+++ b/config/features/person_extended/core.entity_form_display.node.person.default.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.node.person.person_pt_faculty_research_areas
     - field.field.node.person.field_image
     - field.field.node.person.field_person_bio
     - field.field.node.person.field_person_credential
@@ -13,6 +12,7 @@ dependencies:
     - field.field.node.person.field_person_last_name
     - field.field.node.person.field_person_phone
     - field.field.node.person.field_person_position
+    - field.field.node.person.field_person_research_areas
     - field.field.node.person.field_person_type
     - field.field.node.person.field_person_website
     - field.field.node.person.field_tags
@@ -106,6 +106,16 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  field_person_research_areas:
+    weight: 27
+    settings:
+      match_operator: STARTS_WITH
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete_tags
+    region: content
   field_person_type:
     weight: 0
     settings: {  }
@@ -150,16 +160,6 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  person_pt_faculty_research_areas:
-    weight: 26
-    settings:
-      match_operator: STARTS_WITH
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete_tags
-    region: content
   promote:
     type: boolean_checkbox
     settings:

--- a/config/features/person_extended/core.entity_form_display.node.person.minimal.yml
+++ b/config/features/person_extended/core.entity_form_display.node.person.minimal.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - core.entity_form_mode.node.minimal
-    - field.field.node.person.person_pt_faculty_research_areas
     - field.field.node.person.field_image
     - field.field.node.person.field_person_bio
     - field.field.node.person.field_person_credential
@@ -14,6 +13,7 @@ dependencies:
     - field.field.node.person.field_person_last_name
     - field.field.node.person.field_person_phone
     - field.field.node.person.field_person_position
+    - field.field.node.person.field_person_research_areas
     - field.field.node.person.field_person_type
     - field.field.node.person.field_person_website
     - field.field.node.person.field_tags
@@ -71,12 +71,12 @@ hidden:
   field_person_email: true
   field_person_phone: true
   field_person_position: true
+  field_person_research_areas: true
   field_person_type: true
   field_person_website: true
   field_tags: true
   field_teaser: true
   path: true
-  person_pt_faculty_research_areas: true
   promote: true
   sticky: true
   title: true

--- a/config/features/person_extended/core.entity_view_display.node.person.default.yml
+++ b/config/features/person_extended/core.entity_view_display.node.person.default.yml
@@ -12,11 +12,11 @@ dependencies:
     - field.field.node.person.field_person_last_name
     - field.field.node.person.field_person_phone
     - field.field.node.person.field_person_position
+    - field.field.node.person.field_person_research_areas
     - field.field.node.person.field_person_type
     - field.field.node.person.field_person_website
     - field.field.node.person.field_tags
     - field.field.node.person.field_teaser
-    - field.field.node.person.person_pt_faculty_research_areas
     - node.type.person
   module:
     - link
@@ -72,6 +72,14 @@ content:
     third_party_settings: {  }
     type: string
     region: content
+  field_person_research_areas:
+    weight: 10
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
   field_person_type:
     type: entity_reference_label
     weight: 9
@@ -97,14 +105,6 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  person_pt_faculty_research_areas:
-    weight: 8
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
 hidden:
   field_person_credential: true
   field_person_first_name: true

--- a/config/features/person_extended/core.entity_view_display.node.person.teaser.yml
+++ b/config/features/person_extended/core.entity_view_display.node.person.teaser.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
-    - field.field.node.person.person_pt_faculty_research_areas
     - field.field.node.person.field_image
     - field.field.node.person.field_person_bio
     - field.field.node.person.field_person_credential
@@ -14,6 +13,7 @@ dependencies:
     - field.field.node.person.field_person_last_name
     - field.field.node.person.field_person_phone
     - field.field.node.person.field_person_position
+    - field.field.node.person.field_person_research_areas
     - field.field.node.person.field_person_type
     - field.field.node.person.field_person_website
     - field.field.node.person.field_tags
@@ -85,7 +85,7 @@ hidden:
   field_person_first_name: true
   field_person_hide: true
   field_person_last_name: true
+  field_person_research_areas: true
   field_person_type: true
   field_person_website: true
   field_tags: true
-  person_pt_faculty_research_areas: true

--- a/config/features/person_extended/field.field.node.person.field_person_research_areas.yml
+++ b/config/features/person_extended/field.field.node.person.field_person_research_areas.yml
@@ -1,13 +1,13 @@
-uuid: 8bbf3418-f2ef-4fdb-a4c7-d88eae5e1088
+uuid: 7909f964-0a85-44c4-9707-250188360c6f
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.person_pt_faculty_research_areas
+    - field.storage.node.field_person_research_areas
     - node.type.person
     - taxonomy.vocabulary.research_areas
-id: node.person.person_pt_faculty_research_areas
-field_name: person_pt_faculty_research_areas
+id: node.person.field_person_research_areas
+field_name: field_person_research_areas
 entity_type: node
 bundle: person
 label: 'Research areas'

--- a/config/features/person_extended/field.storage.node.field_person_research_areas.yml
+++ b/config/features/person_extended/field.storage.node.field_person_research_areas.yml
@@ -1,12 +1,12 @@
-uuid: 21cb30bf-939a-4afd-a87d-c55ebbad5b34
+uuid: 7026e65e-0abe-4f39-b965-b382a675f765
 langcode: en
 status: true
 dependencies:
   module:
     - node
     - taxonomy
-id: node.person_pt_faculty_research_areas
-field_name: person_pt_faculty_research_areas
+id: node.field_person_research_areas
+field_name: field_person_research_areas
 entity_type: node
 type: entity_reference
 settings:

--- a/docroot/modules/custom/sitenow_people/sitenow_people.install
+++ b/docroot/modules/custom/sitenow_people/sitenow_people.install
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @file
+ */
+
 use Drupal\Core\Config\FileStorage;
 use Drupal\node\Entity\Node;
 
@@ -17,31 +21,24 @@ function sitenow_people_update_8001() {
     $config_path = DRUPAL_ROOT . '/../config/features/person_extended';
     $source = new FileStorage($config_path);
 
-    // Create the split in active config and import config_ignore settings
-    // otherwise the status will be imported as false (and everything will be
-    // deleted on cim) since that is what exists in the default split config.
-//    $config_storage = \Drupal::service('config.storage');
-//    $config_storage->write('field.field.node.person.field_person_research_areas', $source->read('field.field.node.person.field_person_research_areas'));
-//    $config_storage->write('field.storage.node.field_person_research_areas', $source->read('field.field.node.person.field_person_research_areas'));
-
-    // Obtain the storage manager for field storage bases
-    // Create a new field from the yaml configuration and save
+    // Create field storage from new config.
     \Drupal::entityTypeManager()->getStorage('field_storage_config')
       ->create($source->read('field.storage.node.field_person_research_areas'))
       ->save();
 
-    // Obtain the storage manager for field instances
-    // Create a new field instance from the yaml configuration and save
+    // Create field instance from new config.
     \Drupal::entityTypeManager()->getStorage('field_config')
       ->create($source->read('field.field.node.person.field_person_research_areas'))
       ->save();
 
+    // Get all the person nodes.
     $nids = \Drupal::entityQuery('node')
       ->condition('type', 'person')
       ->execute();
 
     $nodes = Node::loadMultiple($nids);
 
+    // Update the new field to the value of the old field.
     foreach ($nodes as $node) {
       $research_areas = $node->get('person_pt_faculty_research_areas')->getValue();
       $node

--- a/docroot/modules/custom/sitenow_people/sitenow_people.install
+++ b/docroot/modules/custom/sitenow_people/sitenow_people.install
@@ -2,13 +2,16 @@
 
 /**
  * @file
+ * Install hooks for sitenow_people.
  */
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\node\Entity\Node;
 
 /**
- * Implements hook_update_8001().
+ * Updates any site with 'person_extended' split.
+ *
+ * Converts the research areas field to use a new field name.
  */
 function sitenow_people_update_8001() {
   /** @var \Drupal\Core\Plugin\DefaultPluginManager $filters */

--- a/docroot/modules/custom/sitenow_people/sitenow_people.install
+++ b/docroot/modules/custom/sitenow_people/sitenow_people.install
@@ -1,0 +1,52 @@
+<?php
+
+use Drupal\Core\Config\FileStorage;
+use Drupal\node\Entity\Node;
+
+/**
+ * Implements hook_update_8001().
+ */
+function sitenow_people_update_8001() {
+  /** @var \Drupal\Core\Plugin\DefaultPluginManager $filters */
+  $filters = \Drupal::service('plugin.manager.config_filter')->getDefinitions();
+  $split = 'config_split:person_extended';
+
+  // This site has the 'person_extended' split enabled.
+  if (isset($filters[$split]) && $filters[$split]['status']) {
+    // This site does not have the 'collegiate' split enabled.
+    $config_path = DRUPAL_ROOT . '/../config/features/person_extended';
+    $source = new FileStorage($config_path);
+
+    // Create the split in active config and import config_ignore settings
+    // otherwise the status will be imported as false (and everything will be
+    // deleted on cim) since that is what exists in the default split config.
+//    $config_storage = \Drupal::service('config.storage');
+//    $config_storage->write('field.field.node.person.field_person_research_areas', $source->read('field.field.node.person.field_person_research_areas'));
+//    $config_storage->write('field.storage.node.field_person_research_areas', $source->read('field.field.node.person.field_person_research_areas'));
+
+    // Obtain the storage manager for field storage bases
+    // Create a new field from the yaml configuration and save
+    \Drupal::entityTypeManager()->getStorage('field_storage_config')
+      ->create($source->read('field.storage.node.field_person_research_areas'))
+      ->save();
+
+    // Obtain the storage manager for field instances
+    // Create a new field instance from the yaml configuration and save
+    \Drupal::entityTypeManager()->getStorage('field_config')
+      ->create($source->read('field.field.node.person.field_person_research_areas'))
+      ->save();
+
+    $nids = \Drupal::entityQuery('node')
+      ->condition('type', 'person')
+      ->execute();
+
+    $nodes = Node::loadMultiple($nids);
+
+    foreach ($nodes as $node) {
+      $research_areas = $node->get('person_pt_faculty_research_areas')->getValue();
+      $node
+        ->set('field_person_research_areas', $research_areas)
+        ->save();
+    }
+  }
+}


### PR DESCRIPTION
Resolves #1975 

# To test

## Target site: `informatics.grad.uiowa.edu`
* `blt ds --site=informatics.grad.uiowa.edu`
* `drush @gradinformatics.local uli`
* Check existing person record to see that research area is set: https://gradinformatics.local.drupal.uiowa.edu/people/jason-rantanen
* Check that person type is using new version of the research areas field (field_person_research_areas): https://gradinformatics.local.drupal.uiowa.edu/admin/structure/types/manage/person/fields

## Another site: `gis.sites.uiowa.edu`
* `blt ds --site=gis.sites.uiowa.edu`
* `drush @sitesgis.local uli`
* Check existing person record to see that it is not modified: https://sitesgis.local.drupal.uiowa.edu/node/151/edit
* Check that person type does not contain research areas field (field_person_research_areas): https://sitesgis.local.drupal.uiowa.edu/admin/structure/types/manage/person/fields
