### PR TITLE
Feature: immuno.grad.uiowa.edu site split + slight change to person_extended

### DIFF
--- a/config/features/person_extended/core.entity_view_display.node.person.default.yml
+++ b/config/features/person_extended/core.entity_view_display.node.person.default.yml
@@ -74,7 +74,7 @@ content:
     region: content
   field_person_research_areas:
     weight: 10
-    label: above
+    label: hidden
     settings:
       link: true
     third_party_settings: {  }

--- a/config/immuno.grad.uiowa.edu/.htaccess
+++ b/config/immuno.grad.uiowa.edu/.htaccess
@@ -1,0 +1,27 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php5.c>
+  php_flag engine off
+</IfModule>
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>

--- a/config/immuno.grad.uiowa.edu/config_split.config_split.immuno_grad_uiowa_edu.yml
+++ b/config/immuno.grad.uiowa.edu/config_split.config_split.immuno_grad_uiowa_edu.yml
@@ -1,0 +1,18 @@
+uuid: 27c7b465-6971-4b17-9ef4-f1c0136ea7a2
+langcode: en
+status: true
+dependencies: {  }
+id: immuno_grad_uiowa_edu
+label: immuno.grad.uiowa.edu
+description: 'Site split for immuno.grad.uiowa.edu. Some fields build on ''person_extended'' feature split.'
+folder: ../config/immuno.grad.uiowa.edu
+module: {  }
+theme: {  }
+blacklist: {  }
+graylist:
+  - config_split.config_split.immuno_grad_uiowa_edu
+  - field.storage.node.field_pt_faculty_type
+  - taxonomy.vocabulary.faculty_type
+graylist_dependents: true
+graylist_skip_equal: true
+weight: 90

--- a/config/immuno.grad.uiowa.edu/core.entity_form_display.node.person.default.yml
+++ b/config/immuno.grad.uiowa.edu/core.entity_form_display.node.person.default.yml
@@ -1,0 +1,207 @@
+uuid: 796b0a22-68b5-4d0b-a2c0-b5ce90c6e1bb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.person.field_image
+    - field.field.node.person.field_person_bio
+    - field.field.node.person.field_person_credential
+    - field.field.node.person.field_person_email
+    - field.field.node.person.field_person_first_name
+    - field.field.node.person.field_person_hide
+    - field.field.node.person.field_person_last_name
+    - field.field.node.person.field_person_phone
+    - field.field.node.person.field_person_position
+    - field.field.node.person.field_person_type
+    - field.field.node.person.field_person_website
+    - field.field.node.person.field_pt_faculty_type
+    - field.field.node.person.field_tags
+    - field.field.node.person.field_teaser
+    - field.field.node.person.person_pt_faculty_research_areas
+    - node.type.person
+    - workflows.workflow.editorial
+  module:
+    - content_moderation
+    - link
+    - media_library
+    - path
+    - telephone
+    - text
+id: node.person.default
+targetEntityType: node
+bundle: person
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 12
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_image:
+    weight: 5
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    type: media_library_widget
+    region: content
+  field_person_bio:
+    weight: 9
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  field_person_credential:
+    weight: 4
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_person_email:
+    type: email_default
+    weight: 7
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_person_first_name:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_person_hide:
+    weight: 21
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_person_last_name:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_person_phone:
+    type: telephone_default
+    weight: 8
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_person_position:
+    weight: 6
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_person_type:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_person_website:
+    weight: 10
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_pt_faculty_type:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_tags:
+    weight: 13
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    third_party_settings: {  }
+    type: entity_reference_autocomplete_tags
+    region: content
+  field_teaser:
+    weight: 20
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  moderation_state:
+    type: moderation_state_default
+    weight: 19
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 16
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  person_pt_faculty_research_areas:
+    weight: 22
+    settings:
+      match_operator: STARTS_WITH
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete_tags
+    region: content
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 14
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 18
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 11
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+  url_redirects:
+    weight: 17
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  title: true

--- a/config/immuno.grad.uiowa.edu/core.entity_form_display.node.person.default.yml
+++ b/config/immuno.grad.uiowa.edu/core.entity_form_display.node.person.default.yml
@@ -12,12 +12,12 @@ dependencies:
     - field.field.node.person.field_person_last_name
     - field.field.node.person.field_person_phone
     - field.field.node.person.field_person_position
+    - field.field.node.person.field_person_research_areas
     - field.field.node.person.field_person_type
     - field.field.node.person.field_person_website
     - field.field.node.person.field_pt_faculty_type
     - field.field.node.person.field_tags
     - field.field.node.person.field_teaser
-    - field.field.node.person.person_pt_faculty_research_areas
     - node.type.person
     - workflows.workflow.editorial
   module:
@@ -107,6 +107,16 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  field_person_research_areas:
+    weight: 27
+    settings:
+      match_operator: STARTS_WITH
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete_tags
+    region: content
   field_person_type:
     weight: 0
     settings: {  }
@@ -157,16 +167,6 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  person_pt_faculty_research_areas:
-    weight: 22
-    settings:
-      match_operator: STARTS_WITH
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete_tags
-    region: content
   promote:
     type: boolean_checkbox
     settings:

--- a/config/immuno.grad.uiowa.edu/core.entity_form_display.node.person.minimal.yml
+++ b/config/immuno.grad.uiowa.edu/core.entity_form_display.node.person.minimal.yml
@@ -1,0 +1,86 @@
+uuid: d63a5af5-4caf-47ca-8251-ad98e467930a
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.node.minimal
+    - field.field.node.person.field_image
+    - field.field.node.person.field_person_bio
+    - field.field.node.person.field_person_credential
+    - field.field.node.person.field_person_email
+    - field.field.node.person.field_person_first_name
+    - field.field.node.person.field_person_hide
+    - field.field.node.person.field_person_last_name
+    - field.field.node.person.field_person_phone
+    - field.field.node.person.field_person_position
+    - field.field.node.person.field_person_type
+    - field.field.node.person.field_person_website
+    - field.field.node.person.field_pt_faculty_type
+    - field.field.node.person.field_tags
+    - field.field.node.person.field_teaser
+    - field.field.node.person.person_pt_faculty_research_areas
+    - node.type.person
+    - workflows.workflow.editorial
+  module:
+    - content_moderation
+id: node.person.minimal
+targetEntityType: node
+bundle: person
+mode: minimal
+content:
+  field_person_first_name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_person_hide:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_person_last_name:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 3
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden:
+  created: true
+  field_image: true
+  field_person_bio: true
+  field_person_credential: true
+  field_person_email: true
+  field_person_phone: true
+  field_person_position: true
+  field_person_type: true
+  field_person_website: true
+  field_pt_faculty_type: true
+  field_tags: true
+  field_teaser: true
+  path: true
+  person_pt_faculty_research_areas: true
+  promote: true
+  sticky: true
+  title: true
+  uid: true
+  url_redirects: true

--- a/config/immuno.grad.uiowa.edu/core.entity_form_display.node.person.minimal.yml
+++ b/config/immuno.grad.uiowa.edu/core.entity_form_display.node.person.minimal.yml
@@ -13,12 +13,12 @@ dependencies:
     - field.field.node.person.field_person_last_name
     - field.field.node.person.field_person_phone
     - field.field.node.person.field_person_position
+    - field.field.node.person.field_person_research_areas
     - field.field.node.person.field_person_type
     - field.field.node.person.field_person_website
     - field.field.node.person.field_pt_faculty_type
     - field.field.node.person.field_tags
     - field.field.node.person.field_teaser
-    - field.field.node.person.person_pt_faculty_research_areas
     - node.type.person
     - workflows.workflow.editorial
   module:
@@ -72,13 +72,13 @@ hidden:
   field_person_email: true
   field_person_phone: true
   field_person_position: true
+  field_person_research_areas: true
   field_person_type: true
   field_person_website: true
   field_pt_faculty_type: true
   field_tags: true
   field_teaser: true
   path: true
-  person_pt_faculty_research_areas: true
   promote: true
   sticky: true
   title: true

--- a/config/immuno.grad.uiowa.edu/core.entity_view_display.node.person.default.yml
+++ b/config/immuno.grad.uiowa.edu/core.entity_view_display.node.person.default.yml
@@ -1,0 +1,116 @@
+uuid: 29543f90-b99a-4bcb-8508-764401e20f22
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.person.field_image
+    - field.field.node.person.field_person_bio
+    - field.field.node.person.field_person_credential
+    - field.field.node.person.field_person_email
+    - field.field.node.person.field_person_first_name
+    - field.field.node.person.field_person_hide
+    - field.field.node.person.field_person_last_name
+    - field.field.node.person.field_person_phone
+    - field.field.node.person.field_person_position
+    - field.field.node.person.field_person_type
+    - field.field.node.person.field_person_website
+    - field.field.node.person.field_pt_faculty_type
+    - field.field.node.person.field_tags
+    - field.field.node.person.field_teaser
+    - field.field.node.person.person_pt_faculty_research_areas
+    - node.type.person
+  module:
+    - link
+    - telephone
+    - text
+    - user
+id: node.person.default
+targetEntityType: node
+bundle: person
+mode: default
+content:
+  content_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_image:
+    type: entity_reference_entity_view
+    weight: 6
+    region: content
+    label: hidden
+    settings:
+      view_mode: large__square
+      link: false
+    third_party_settings: {  }
+  field_person_bio:
+    weight: 4
+    label: visually_hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_person_email:
+    type: email_mailto
+    weight: 2
+    region: content
+    label: inline
+    settings: {  }
+    third_party_settings: {  }
+  field_person_phone:
+    weight: 3
+    label: inline
+    settings:
+      title: ''
+    third_party_settings: {  }
+    type: telephone_link
+    region: content
+  field_person_position:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_person_type:
+    type: entity_reference_label
+    weight: 9
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  field_person_website:
+    weight: 7
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link_separate
+    region: content
+  links:
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  person_pt_faculty_research_areas:
+    weight: 8
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+hidden:
+  field_person_credential: true
+  field_person_first_name: true
+  field_person_hide: true
+  field_person_last_name: true
+  field_pt_faculty_type: true
+  field_tags: true
+  field_teaser: true

--- a/config/immuno.grad.uiowa.edu/core.entity_view_display.node.person.default.yml
+++ b/config/immuno.grad.uiowa.edu/core.entity_view_display.node.person.default.yml
@@ -12,12 +12,12 @@ dependencies:
     - field.field.node.person.field_person_last_name
     - field.field.node.person.field_person_phone
     - field.field.node.person.field_person_position
+    - field.field.node.person.field_person_research_areas
     - field.field.node.person.field_person_type
     - field.field.node.person.field_person_website
     - field.field.node.person.field_pt_faculty_type
     - field.field.node.person.field_tags
     - field.field.node.person.field_teaser
-    - field.field.node.person.person_pt_faculty_research_areas
     - node.type.person
   module:
     - link
@@ -73,6 +73,14 @@ content:
     third_party_settings: {  }
     type: string
     region: content
+  field_person_research_areas:
+    weight: 10
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
   field_person_type:
     type: entity_reference_label
     weight: 9
@@ -98,14 +106,6 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  person_pt_faculty_research_areas:
-    weight: 8
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
 hidden:
   field_person_credential: true
   field_person_first_name: true

--- a/config/immuno.grad.uiowa.edu/core.entity_view_display.node.person.teaser.yml
+++ b/config/immuno.grad.uiowa.edu/core.entity_view_display.node.person.teaser.yml
@@ -1,0 +1,93 @@
+uuid: cd0dc47a-a721-4842-a61f-0af8e2d74a64
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.person.field_image
+    - field.field.node.person.field_person_bio
+    - field.field.node.person.field_person_credential
+    - field.field.node.person.field_person_email
+    - field.field.node.person.field_person_first_name
+    - field.field.node.person.field_person_hide
+    - field.field.node.person.field_person_last_name
+    - field.field.node.person.field_person_phone
+    - field.field.node.person.field_person_position
+    - field.field.node.person.field_person_type
+    - field.field.node.person.field_person_website
+    - field.field.node.person.field_pt_faculty_type
+    - field.field.node.person.field_tags
+    - field.field.node.person.field_teaser
+    - field.field.node.person.person_pt_faculty_research_areas
+    - node.type.person
+  module:
+    - telephone
+    - user
+id: node.person.teaser
+targetEntityType: node
+bundle: person
+mode: teaser
+content:
+  field_image:
+    type: entity_reference_entity_view
+    weight: 6
+    region: content
+    label: hidden
+    settings:
+      view_mode: large__square
+      link: false
+    third_party_settings: {  }
+  field_person_credential:
+    type: string
+    weight: 0
+    region: content
+    label: visually_hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  field_person_email:
+    type: email_mailto
+    weight: 2
+    region: content
+    label: inline
+    settings: {  }
+    third_party_settings: {  }
+  field_person_phone:
+    weight: 3
+    label: inline
+    settings:
+      title: ''
+    third_party_settings: {  }
+    type: telephone_link
+    region: content
+  field_person_position:
+    type: string
+    weight: 1
+    region: content
+    label: visually_hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  field_teaser:
+    type: basic_string
+    weight: 4
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  links:
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  content_moderation_control: true
+  field_person_bio: true
+  field_person_first_name: true
+  field_person_hide: true
+  field_person_last_name: true
+  field_person_type: true
+  field_person_website: true
+  field_pt_faculty_type: true
+  field_tags: true
+  person_pt_faculty_research_areas: true

--- a/config/immuno.grad.uiowa.edu/core.entity_view_display.node.person.teaser.yml
+++ b/config/immuno.grad.uiowa.edu/core.entity_view_display.node.person.teaser.yml
@@ -13,12 +13,12 @@ dependencies:
     - field.field.node.person.field_person_last_name
     - field.field.node.person.field_person_phone
     - field.field.node.person.field_person_position
+    - field.field.node.person.field_person_research_areas
     - field.field.node.person.field_person_type
     - field.field.node.person.field_person_website
     - field.field.node.person.field_pt_faculty_type
     - field.field.node.person.field_tags
     - field.field.node.person.field_teaser
-    - field.field.node.person.person_pt_faculty_research_areas
     - node.type.person
   module:
     - telephone
@@ -86,8 +86,8 @@ hidden:
   field_person_first_name: true
   field_person_hide: true
   field_person_last_name: true
+  field_person_research_areas: true
   field_person_type: true
   field_person_website: true
   field_pt_faculty_type: true
   field_tags: true
-  person_pt_faculty_research_areas: true

--- a/config/immuno.grad.uiowa.edu/field.field.node.person.field_pt_faculty_type.yml
+++ b/config/immuno.grad.uiowa.edu/field.field.node.person.field_pt_faculty_type.yml
@@ -1,0 +1,33 @@
+uuid: e924c71b-700a-4ce2-b4dc-2afd5c5f0ef5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_pt_faculty_type
+    - node.type.person
+    - taxonomy.vocabulary.faculty_type
+  content:
+    - 'taxonomy_term:faculty_type:69de3b86-c032-4d7f-b704-e3b02892ee8f'
+id: node.person.field_pt_faculty_type
+field_name: field_pt_faculty_type
+entity_type: node
+bundle: person
+label: 'Faculty type'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    target_uuid: 69de3b86-c032-4d7f-b704-e3b02892ee8f
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      faculty_type: faculty_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/immuno.grad.uiowa.edu/field.storage.node.field_pt_faculty_type.yml
+++ b/config/immuno.grad.uiowa.edu/field.storage.node.field_pt_faculty_type.yml
@@ -1,0 +1,20 @@
+uuid: 555c4f10-727c-4b89-9d85-554c3eaceea1
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_pt_faculty_type
+field_name: field_pt_faculty_type
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/immuno.grad.uiowa.edu/taxonomy.vocabulary.faculty_type.yml
+++ b/config/immuno.grad.uiowa.edu/taxonomy.vocabulary.faculty_type.yml
@@ -1,0 +1,8 @@
+uuid: 94bbbe50-f11f-4d9d-8ad9-ff04dc989664
+langcode: en
+status: true
+dependencies: {  }
+name: 'Faculty type'
+vid: faculty_type
+description: 'Different classifications of faculty.'
+weight: 0

--- a/docroot/modules/custom/sitenow_people/sitenow_people.module
+++ b/docroot/modules/custom/sitenow_people/sitenow_people.module
@@ -45,7 +45,7 @@ function sitenow_people_form_alter(&$form, FormStateInterface $form_state, $form
           // If the field name matches the pattern for person type
           // specific fields, make it not required and set it to
           // not be visible.
-          if (strpos($field_name, 'person_pt_') !== FALSE) {
+          if (strpos($field_name, '_pt_') !== FALSE) {
             $form[$field_name]['#widget']['#required'] = FALSE;
             $form[$field_name]['#access'] = FALSE;
           }
@@ -57,7 +57,7 @@ function sitenow_people_form_alter(&$form, FormStateInterface $form_state, $form
           // Loop through fields.
           foreach (Element::children($form) as $field_name) {
             // Check for match of term name (lower-cased) in the field name.
-            if (strpos($field_name, 'person_pt_' . strtolower($term->name)) !== FALSE) {
+            if (strpos($field_name, '_pt_' . strtolower($term->name)) !== FALSE) {
               // Add '#states' condition to matching fields to be visible
               // when tid is selected in field_person_type.
               // @todo Do we need to account for the possibility of changing


### PR DESCRIPTION
# Updates
* Adds a site split for immuno.grad.uiowa.edu
* Slight tweak to 'person_extended' functionality in sitenow_person module to allow for more flexible naming of conditional fields.

# To test
* `blt ds --site=immuno.grad.uiowa.edu`
* Enable site split: `drush @gradimmuno.local cim --source ../config/immuno.grad.uiowa.edu --partial`
* Add 'Faculty' and 'Student' terms to Person types vocab: https://gradimmuno.local.drupal.uiowa.edu/admin/structure/taxonomy/manage/person_types/overview
* Add 'Program' and 'Resource' terms to Faculty types vocab: https://gradimmuno.local.drupal.uiowa.edu/admin/structure/taxonomy/manage/faculty_type/overview
* Visit the add person page: https://gradimmuno.local.drupal.uiowa.edu/node/add/person
* Select 'Faculty' as the person type and observe that the Faculty type options appear.
* Review code change to `sitenow_person.module`: https://github.com/uiowa/uiowa/pull/1984/files?file-filters%5B%5D=.module#diff-26cdaeb7e76a383b1d0f9389a5fbed9cL45-L63