### PR TITLE
Require cards be rendered horizontaly if placed in a onecol layout.

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -111,7 +111,7 @@ function _layout_builder_custom_block_validate(array &$form, FormStateInterface 
   $component = $form_state->getFormObject()->getCurrentComponent();
   $block = $component->getPlugin();
 
-  // Disable overriding layout styles if this is onecol card.
+  // Require horizontal style if this is card is in a one column layout.
   if ($section->getLayoutId() == 'layout_onecol' && $block->getPluginId() == 'inline_block:uiowa_card') {
     $styles = $form_state->getValue('layout_builder_style_default');
 

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -28,80 +28,80 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
       $form['layout_builder_style_background']['#multiple'] = FALSE;
     }
   }
-    else {
-      // Override display of layout builder styles.
-      $enabled = FALSE;
+  else {
+    // Override display of layout builder styles.
+    $enabled = FALSE;
 
-      // Loop through layout builder style groups.
-      $groups = LayoutBuilderStyleGroups::getGroups();
+    // Loop through layout builder style groups.
+    $groups = LayoutBuilderStyleGroups::getGroups();
 
-      foreach (array_keys($groups) as $group) {
-        $lbs = 'layout_builder_style_' . $group;
-        if (isset($form[$lbs])) {
+    foreach (array_keys($groups) as $group) {
+      $lbs = 'layout_builder_style_' . $group;
+      if (isset($form[$lbs])) {
 
-          if ($form_id == 'layout_builder_update_block') {
-            // Set enabled flag based on whether a default value exists
-            // for this layout builder style.
-            $enabled = !empty($form[$lbs]['#default_value']);
-          }
-
-          // Set a state for the layout builder style to toggle
-          // based on the value of the override value specified below.
-          $form[$lbs]['#states'] = [
-            'visible' => [
-              ':input[name="layout_builder_block_override"]' => [
-                'checked' => TRUE,
-              ],
-            ],
-          ];
-
-          // Make the background option single select only.
-          if ($group === 'background') {
-            $form[$lbs]['#multiple'] = FALSE;
-          }
+        if ($form_id == 'layout_builder_update_block') {
+          // Set enabled flag based on whether a default value exists
+          // for this layout builder style.
+          $enabled = !empty($form[$lbs]['#default_value']);
         }
-      }
 
-      // Add a checkbox to toggle whether the styles should show.
-      $form['layout_builder_block_override'] = [
-        '#type' => 'checkbox',
-        '#title' => t('Override style options'),
-        '#required' => FALSE,
-        '#default_value' => $enabled,
-        '#weight' => 80,
-      ];
-
-      /** @var \Drupal\layout_builder\Section $section */
-      $section = $form_state->getFormObject()->getCurrentSection();
-
-      /** @var \Drupal\layout_builder\SectionComponent $component */
-      $component = $form_state->getFormObject()->getCurrentComponent();
-      $block = $component->getPlugin();
-
-      // Disable overriding layout styles if this is onecol card.
-      if ($section->getLayoutId() == 'layout_onecol' && $block->getPluginId() == 'inline_block:uiowa_card') {
-        $form['layout_builder_block_override']['#default_value'] = TRUE;
-        $form['layout_builder_block_override']['#disabled'] = TRUE;
-        $form['layout_builder_block_override']['#description'] = t('Cards rendered within a one column layout must be horizontal.');
-
-        $form['layout_builder_style_default']['#default_value'] = [
-          'block_card_style_horizontal' => 'block_card_style_horizontal',
+        // Set a state for the layout builder style to toggle
+        // based on the value of the override value specified below.
+        $form[$lbs]['#states'] = [
+          'visible' => [
+            ':input[name="layout_builder_block_override"]' => [
+              'checked' => TRUE,
+            ],
+          ],
         ];
 
-        $form['layout_builder_style_default']['#disabled'] = TRUE;
+        // Make the background option single select only.
+        if ($group === 'background') {
+          $form[$lbs]['#multiple'] = FALSE;
+        }
       }
-
-      // Always set title field to not be required.
-      $form['settings']['label']['#required'] = FALSE;
-
-      unset($form['settings']['label']);
-      unset($form['settings']['label_display']);
-      unset($form['settings']['admin_label']['#title']);
-
-      $form['settings'] += [
-        '#weight' => 0,
-      ];
     }
+
+    // Add a checkbox to toggle whether the styles should show.
+    $form['layout_builder_block_override'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Override style options'),
+      '#required' => FALSE,
+      '#default_value' => $enabled,
+      '#weight' => 80,
+    ];
+
+    /** @var \Drupal\layout_builder\Section $section */
+    $section = $form_state->getFormObject()->getCurrentSection();
+
+    /** @var \Drupal\layout_builder\SectionComponent $component */
+    $component = $form_state->getFormObject()->getCurrentComponent();
+    $block = $component->getPlugin();
+
+    // Disable overriding layout styles if this is onecol card.
+    if ($section->getLayoutId() == 'layout_onecol' && $block->getPluginId() == 'inline_block:uiowa_card') {
+      $form['layout_builder_block_override']['#default_value'] = TRUE;
+      $form['layout_builder_block_override']['#disabled'] = TRUE;
+      $form['layout_builder_block_override']['#description'] = t('Cards rendered within a one column layout must be horizontal.');
+
+      $form['layout_builder_style_default']['#default_value'] = [
+        'block_card_style_horizontal' => 'block_card_style_horizontal',
+      ];
+
+      $form['layout_builder_style_default']['#disabled'] = TRUE;
+    }
+
+    // Always set title field to not be required.
+    $form['settings']['label']['#required'] = FALSE;
+
+    unset($form['settings']['label']);
+    unset($form['settings']['label_display']);
+    unset($form['settings']['admin_label']['#title']);
+
+    $form['settings'] += [
+      '#weight' => 0,
+    ];
+  }
 }
 
 /**

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -23,6 +23,10 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
     return;
   }
 
+  if ($form_id == 'layout_builder_add_block' || $form_id == 'layout_builder_update_block') {
+    $form['#validate'][] = '_layout_builder_custom_add_block_validate';
+  }
+
   if ($form_id === 'layout_builder_configure_section') {
     if (isset($form['layout_builder_style_background'])) {
       $form['layout_builder_style_background']['#multiple'] = FALSE;
@@ -71,26 +75,6 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
       '#weight' => 80,
     ];
 
-    /** @var \Drupal\layout_builder\Section $section */
-    $section = $form_state->getFormObject()->getCurrentSection();
-
-    /** @var \Drupal\layout_builder\SectionComponent $component */
-    $component = $form_state->getFormObject()->getCurrentComponent();
-    $block = $component->getPlugin();
-
-    // Disable overriding layout styles if this is onecol card.
-    if ($section->getLayoutId() == 'layout_onecol' && $block->getPluginId() == 'inline_block:uiowa_card') {
-      $form['layout_builder_block_override']['#default_value'] = TRUE;
-      $form['layout_builder_block_override']['#disabled'] = TRUE;
-      $form['layout_builder_block_override']['#description'] = t('Cards rendered within a one column layout must be horizontal.');
-
-      $form['layout_builder_style_default']['#default_value'] = [
-        'block_card_style_horizontal' => 'block_card_style_horizontal',
-      ];
-
-      $form['layout_builder_style_default']['#disabled'] = TRUE;
-    }
-
     // Always set title field to not be required.
     $form['settings']['label']['#required'] = FALSE;
 
@@ -109,4 +93,30 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
  */
 function layout_builder_custom_form_node_page_layout_builder_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $form['#attached']['library'][] = 'layout_builder_custom/layout_builder_custom.overrides';
+}
+
+/**
+ * Custom validation for layout_builder_add_block form.
+ *
+ * @param array $form
+ *   The form element.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ */
+function _layout_builder_custom_add_block_validate(array &$form, FormStateInterface $form_state) {
+  /** @var \Drupal\layout_builder\Section $section */
+  $section = $form_state->getFormObject()->getCurrentSection();
+
+  /** @var \Drupal\layout_builder\SectionComponent $component */
+  $component = $form_state->getFormObject()->getCurrentComponent();
+  $block = $component->getPlugin();
+
+  // Disable overriding layout styles if this is onecol card.
+  if ($section->getLayoutId() == 'layout_onecol' && $block->getPluginId() == 'inline_block:uiowa_card') {
+    $styles = $form_state->getValue('layout_builder_style_default');
+
+    if (!isset($styles['block_card_style_horizontal'])) {
+      $form_state->setErrorByName('layout_builder_block_override', t('Cards rendered within a one column layout must have the horizontal style.'));
+    }
+  }
 }

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -28,60 +28,80 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
       $form['layout_builder_style_background']['#multiple'] = FALSE;
     }
   }
-  else {
-    // Override display of layout builder styles.
-    $enabled = FALSE;
+    else {
+      // Override display of layout builder styles.
+      $enabled = FALSE;
 
-    // Loop through layout builder style groups.
-    $groups = LayoutBuilderStyleGroups::getGroups();
+      // Loop through layout builder style groups.
+      $groups = LayoutBuilderStyleGroups::getGroups();
 
-    foreach (array_keys($groups) as $group) {
-      $lbs = 'layout_builder_style_' . $group;
-      if (isset($form[$lbs])) {
+      foreach (array_keys($groups) as $group) {
+        $lbs = 'layout_builder_style_' . $group;
+        if (isset($form[$lbs])) {
 
-        if ($form_id == 'layout_builder_update_block') {
-          // Set enabled flag based on whether a default value exists
-          // for this layout builder style.
-          $enabled = !empty($form[$lbs]['#default_value']);
-        }
+          if ($form_id == 'layout_builder_update_block') {
+            // Set enabled flag based on whether a default value exists
+            // for this layout builder style.
+            $enabled = !empty($form[$lbs]['#default_value']);
+          }
 
-        // Set a state for the layout builder style to toggle
-        // based on the value of the override value specified below.
-        $form[$lbs]['#states'] = [
-          'visible' => [
-            ':input[name="layout_builder_block_override"]' => [
-              'checked' => TRUE,
+          // Set a state for the layout builder style to toggle
+          // based on the value of the override value specified below.
+          $form[$lbs]['#states'] = [
+            'visible' => [
+              ':input[name="layout_builder_block_override"]' => [
+                'checked' => TRUE,
+              ],
             ],
-          ],
-        ];
+          ];
 
-        // Make the background option single select only.
-        if ($group === 'background') {
-          $form[$lbs]['#multiple'] = FALSE;
+          // Make the background option single select only.
+          if ($group === 'background') {
+            $form[$lbs]['#multiple'] = FALSE;
+          }
         }
       }
+
+      // Add a checkbox to toggle whether the styles should show.
+      $form['layout_builder_block_override'] = [
+        '#type' => 'checkbox',
+        '#title' => t('Override style options'),
+        '#required' => FALSE,
+        '#default_value' => $enabled,
+        '#weight' => 80,
+      ];
+
+      /** @var \Drupal\layout_builder\Section $section */
+      $section = $form_state->getFormObject()->getCurrentSection();
+
+      /** @var \Drupal\layout_builder\SectionComponent $component */
+      $component = $form_state->getFormObject()->getCurrentComponent();
+      $block = $component->getPlugin();
+
+      // Disable overriding layout styles if this is onecol card.
+      if ($section->getLayoutId() == 'layout_onecol' && $block->getPluginId() == 'inline_block:uiowa_card') {
+        $form['layout_builder_block_override']['#default_value'] = TRUE;
+        $form['layout_builder_block_override']['#disabled'] = TRUE;
+        $form['layout_builder_block_override']['#description'] = t('Cards rendered within a one column layout must be horizontal.');
+
+        $form['layout_builder_style_default']['#default_value'] = [
+          'block_card_style_horizontal' => 'block_card_style_horizontal',
+        ];
+
+        $form['layout_builder_style_default']['#disabled'] = TRUE;
+      }
+
+      // Always set title field to not be required.
+      $form['settings']['label']['#required'] = FALSE;
+
+      unset($form['settings']['label']);
+      unset($form['settings']['label_display']);
+      unset($form['settings']['admin_label']['#title']);
+
+      $form['settings'] += [
+        '#weight' => 0,
+      ];
     }
-
-    // Add a checkbox to toggle whether the styles should show.
-    $form['layout_builder_block_override'] = [
-      '#type' => 'checkbox',
-      '#title' => t('Override style options'),
-      '#required' => FALSE,
-      '#default_value' => $enabled,
-      '#weight' => 80,
-    ];
-
-    // Always set title field to not be required.
-    $form['settings']['label']['#required'] = FALSE;
-
-    unset($form['settings']['label']);
-    unset($form['settings']['label_display']);
-    unset($form['settings']['admin_label']['#title']);
-
-    $form['settings'] += [
-      '#weight' => 0,
-    ];
-  }
 }
 
 /**

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -24,7 +24,7 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
   }
 
   if ($form_id == 'layout_builder_add_block' || $form_id == 'layout_builder_update_block') {
-    $form['#validate'][] = '_layout_builder_custom_add_block_validate';
+    $form['#validate'][] = '_layout_builder_custom_block_validate';
   }
 
   if ($form_id === 'layout_builder_configure_section') {
@@ -103,7 +103,7 @@ function layout_builder_custom_form_node_page_layout_builder_form_alter(&$form, 
  * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   The form state.
  */
-function _layout_builder_custom_add_block_validate(array &$form, FormStateInterface $form_state) {
+function _layout_builder_custom_block_validate(array &$form, FormStateInterface $form_state) {
   /** @var \Drupal\layout_builder\Section $section */
   $section = $form_state->getFormObject()->getCurrentSection();
 

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -96,7 +96,7 @@ function layout_builder_custom_form_node_page_layout_builder_form_alter(&$form, 
 }
 
 /**
- * Custom validation for layout_builder_add_block form.
+ * Custom validation for layout_builder_add/update_block form.
  *
  * @param array $form
  *   The form element.

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -111,7 +111,7 @@ function _layout_builder_custom_block_validate(array &$form, FormStateInterface 
   $component = $form_state->getFormObject()->getCurrentComponent();
   $block = $component->getPlugin();
 
-  // Require horizontal style if this is card is in a one column layout.
+  // Require horizontal style if this card is in a one column layout.
   if ($section->getLayoutId() == 'layout_onecol' && $block->getPluginId() == 'inline_block:uiowa_card') {
     $styles = $form_state->getValue('layout_builder_style_default');
 

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -7,11 +7,7 @@
  */
 
 use Drupal\block\Entity\Block;
-use Drupal\config\StorageReplaceDataWrapper;
-use Drupal\Core\Config\ConfigException;
-use Drupal\Core\Config\ConfigImporter;
 use Drupal\Core\Config\FileStorage;
-use Drupal\Core\Config\StorageComparer;
 use Drupal\node\Entity\Node;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\user\Entity\User;
@@ -21,8 +17,6 @@ use Drupal\field\Entity\FieldConfig;
 use Drupal\paragraphs\ParagraphInterface;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\filter\Plugin\Filter\FilterHtmlCorrector;
-use Drush\Drupal\Commands\config\ConfigCommands;
-use Webmozart\PathUtil\Path;
 
 /**
  * Update some uiowa_footer settings which are ignored.

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -259,7 +259,6 @@ function uids_base_preprocess_layout(&$variables) {
     }
 
     // Add sitenow library if sitenow_v2 config split is active.
-
     $filters = \Drupal::service('plugin.manager.config_filter')->getDefinitions();
     $collegiate_split = 'config_split:sitenow_v2';
     // This site has the 'collegiate' split enabled.


### PR DESCRIPTION
Resolves #1987. Some PHPCS as well.

### Testing
- Try adding a card to a onecol layout.
  - See the form returns an error.
- Try adding a card to a non-onecol layout.
  - See the form styles can be changed.