### PR TITLE
Paragraphs bg hotfix

### DIFF
--- a/docroot/themes/custom/uids_base/scss/paragraphs/_uiowa_paragraphs_background_overrides.scss
+++ b/docroot/themes/custom/uids_base/scss/paragraphs/_uiowa_paragraphs_background_overrides.scss
@@ -419,7 +419,13 @@
         color: $white;
 
         a:not(.btn):not(.bttn):not(.button) {
-            color: $white;
+            color: $secondary;
+            text-decoration: underline;
+
+            &:hover,
+            &:focus {
+                text-decoration: none;
+            }
         }
 
         .alert a {

--- a/docroot/themes/custom/uids_base/scss/paragraphs/_uiowa_paragraphs_background_overrides.scss
+++ b/docroot/themes/custom/uids_base/scss/paragraphs/_uiowa_paragraphs_background_overrides.scss
@@ -419,12 +419,18 @@
         color: $white;
 
         a:not(.btn):not(.bttn):not(.button) {
-            color: $secondary;
-            text-decoration: underline;
+            color: $white;
+        }
 
-            &:hover,
-            &:focus {
-                text-decoration: none;
+        .card__body {
+            a:not(.btn):not(.bttn):not(.button) {
+                color: $secondary;
+                text-decoration: underline;
+    
+                &:hover,
+                &:focus {
+                    text-decoration: none;
+                }
             }
         }
 
@@ -738,6 +744,18 @@
 
 .paragraph.bg-dark,
 .paragraph.bg-black {
+    .card__body {
+        a:not(.btn):not(.bttn):not(.button) {
+            color: $secondary;
+            text-decoration: underline;
+
+            &:hover,
+            &:focus {
+                text-decoration: none;
+            }
+        }
+    }
+
     .paragraph--type--articles.list,
     .paragraph--type--people.list {
 


### PR DESCRIPTION
Resolves #1997, relates to IR2298379.

Also adjusted link text colors for bg-black (had been gold on white, with not a high enough contrast ratio).

<img width="1373" alt="Screen Shot 2020-07-28 at 12 00 08 PM" src="https://user-images.githubusercontent.com/4663676/88697286-f673a780-d0c9-11ea-96f7-c67a5681d929.png">