### PR TITLE
Hotfix: Correctly display page with sidebar layout when not using 'edge-to-edge' container

### DIFF
--- a/config/default/config_split.config_split.sitenow_v2.yml
+++ b/config/default/config_split.config_split.sitenow_v2.yml
@@ -16,6 +16,7 @@ module:
 theme: {  }
 blacklist: {  }
 graylist:
+  - core.entity_view_display.node.page.teaser
   - field.field.node.page.field_page_content_block
   - field.storage.node.field_page_content_block
   - paragraphs.settings

--- a/config/default/core.entity_view_display.node.page.default.yml
+++ b/config/default/core.entity_view_display.node.page.default.yml
@@ -87,6 +87,8 @@ third_party_settings:
         layout_id: layout_page
         layout_settings:
           label: Content
+          layout_builder_styles_style:
+            section_margin_edge_to_edge: section_margin_edge_to_edge
         components:
           c8d974cb-667f-4e0d-8716-d2a77004e0e1:
             uuid: c8d974cb-667f-4e0d-8716-d2a77004e0e1

--- a/config/default/core.entity_view_display.node.page.default.yml
+++ b/config/default/core.entity_view_display.node.page.default.yml
@@ -87,8 +87,6 @@ third_party_settings:
         layout_id: layout_page
         layout_settings:
           label: Content
-          layout_builder_styles_style:
-            section_margin_edge_to_edge: section_margin_edge_to_edge
         components:
           c8d974cb-667f-4e0d-8716-d2a77004e0e1:
             uuid: c8d974cb-667f-4e0d-8716-d2a77004e0e1

--- a/config/features/sitenow_v2/core.entity_view_display.node.page.teaser.yml
+++ b/config/features/sitenow_v2/core.entity_view_display.node.page.teaser.yml
@@ -49,3 +49,4 @@ hidden:
   field_page_content_block: true
   field_publish_options: true
   field_tags: true
+  layout_builder__layout: true

--- a/docroot/themes/custom/uids_base/scss/layouts/page--left-sidebar.scss
+++ b/docroot/themes/custom/uids_base/scss/layouts/page--left-sidebar.scss
@@ -81,3 +81,14 @@
     flex: 0 1 71.75%;
   }
 }
+
+.layout--onecol--no--background+.sidebar-invisible.layout--page--left-sidebar:not(.bg--) .block-field-blocknodepagebody,
+.layout--onecol--background+.sidebar-invisible.layout--page--left-sidebar .block-field-blocknodepagebody,
+.layout--onecol--no--background+.sidebar-invisible.layout--page--left-sidebar .block-inline-blockuiowa-text-area,
+.layout--onecol--background+.sidebar-invisible.layout--page--left-sidebar .block-inline-blockuiowa-text-area,
+.layout--onecol--no--background+.layout--page--left-sidebar.layout--no-sidebar .block-field-blocknodepagebody,
+.layout--onecol--background+.layout--page--left-sidebar.layout--no-sidebar .block-field-blocknodepagebody,
+.layout--onecol--no--background+.layout--page--left-sidebar.layout--no-sidebar .block-inline-blockuiowa-text-area,
+.layout--onecol--background+.layout--page--left-sidebar.layout--no-sidebar .block-inline-blockuiowa-text-area {
+  margin-top: $gutter;
+}

--- a/docroot/themes/custom/uids_base/scss/layouts/page--left-sidebar.scss
+++ b/docroot/themes/custom/uids_base/scss/layouts/page--left-sidebar.scss
@@ -82,13 +82,13 @@
   }
 }
 
-.layout--onecol--no--background+.sidebar-invisible.layout--page--left-sidebar:not(.bg--) .block-field-blocknodepagebody,
-.layout--onecol--background+.sidebar-invisible.layout--page--left-sidebar .block-field-blocknodepagebody,
-.layout--onecol--no--background+.sidebar-invisible.layout--page--left-sidebar .block-inline-blockuiowa-text-area,
-.layout--onecol--background+.sidebar-invisible.layout--page--left-sidebar .block-inline-blockuiowa-text-area,
-.layout--onecol--no--background+.layout--page--left-sidebar.layout--no-sidebar .block-field-blocknodepagebody,
-.layout--onecol--background+.layout--page--left-sidebar.layout--no-sidebar .block-field-blocknodepagebody,
-.layout--onecol--no--background+.layout--page--left-sidebar.layout--no-sidebar .block-inline-blockuiowa-text-area,
-.layout--onecol--background+.layout--page--left-sidebar.layout--no-sidebar .block-inline-blockuiowa-text-area {
+.layout--onecol--no--background+.sidebar-invisible.layout--page--left-sidebar:not([class*="bg--"]) .block-field-blocknodepagebody,
+.layout--onecol--background+.sidebar-invisible.layout--page--left-sidebar:not([class*="bg--"]) .block-field-blocknodepagebody,
+.layout--onecol--no--background+.sidebar-invisible.layout--page--left-sidebar:not([class*="bg--"]) .block-inline-blockuiowa-text-area,
+.layout--onecol--background+.sidebar-invisible.layout--page--left-sidebar:not([class*="bg--"]) .block-inline-blockuiowa-text-area,
+.layout--onecol--no--background+.layout--page--left-sidebar.layout--no-sidebar:not([class*="bg--"]) .block-field-blocknodepagebody,
+.layout--onecol--background+.layout--page--left-sidebar.layout--no-sidebar:not([class*="bg--"]) .block-field-blocknodepagebody,
+.layout--onecol--no--background+.layout--page--left-sidebar.layout--no-sidebar:not([class*="bg--"]) .block-inline-blockuiowa-text-area,
+.layout--onecol--background+.layout--page--left-sidebar.layout--no-sidebar:not([class*="bg--"]) .block-inline-blockuiowa-text-area {
   margin-top: $gutter;
 }

--- a/docroot/themes/custom/uids_base/scss/layouts/page--left-sidebar.scss
+++ b/docroot/themes/custom/uids_base/scss/layouts/page--left-sidebar.scss
@@ -34,8 +34,8 @@
   margin-bottom: 1.5rem;
 }
 
-.content__container .page__container--edge.layout--has-sidebar .lb__container,
-.content__mixed .page__container--edge.layout--has-sidebar .lb__container {
+.content__container .layout--has-sidebar .lb__container,
+.content__mixed .layout--has-sidebar .lb__container {
   display: flex;
   flex-wrap: wrap;
   @extend %container;


### PR DESCRIPTION
Removes a stylesheet constraint that only styles the page with sidebar layout to use `display: flex` when the 'edge-to-edge' container is applied.

# To test
* `blt drupal:install --site=default`
* `drush @default.local uli`
* Visit homepage and click the layout tab.
* Observe that sidebar layout displays correctly.
* Remove 'edge-to-edge' margin style from that section.
* Observe that sidebar layout still displays correctly.
* Try other margin settings, if you like and note any issues.