### PR TITLE
Update node body field to default to filtered_html.

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -16,6 +16,7 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
     'layout_builder_update_block',
     'layout_builder_add_block',
     'layout_builder_configure_section',
+    'node_page_form',
   ];
 
   // Only continue if this is one of the above forms.
@@ -89,6 +90,10 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
     $form['settings'] += [
       '#weight' => 0,
     ];
+  }
+  // Set default node.body text format to filtered over minimal.
+  if ($form_id === 'node_page_form') {
+    $form['body']['widget'][0]['#format'] = 'filtered_html';
   }
 }
 


### PR DESCRIPTION
Resolves #2052 -- Sets node body format to filtered_html instead of the site-wide default minimal_html.

# Problem
As a result of #2041, site-wide text format default was changed to minimal_html, with an exception made for Text Area blocks to receive filtered_html as a default. As basic page body fields can be used to quickly add simple pages, this field should also default to filtered_html, and needs an exception made.

# Test
Sync.
Add a new basic page.
Check that body field format defaults to filtered_html.

## Note
General logic will work, but some of this will need to be updated in order to merge with updates in #1986.