### PR TITLE
Update accordion ids

### DIFF
--- a/docroot/themes/custom/uids_base/templates/paragraphs/paragraph--uiowa-collection-item--accordion.html.twig
+++ b/docroot/themes/custom/uids_base/templates/paragraphs/paragraph--uiowa-collection-item--accordion.html.twig
@@ -41,7 +41,7 @@
 
 {% set accordion_item = {
   'accordion_h_size': h_size ?: 'h2',
-  'accordion_item_id': 'accordion-single-select-' ~ parent_id ~ '-' ~ delta,
+  'accordion_item_id': 'accordion-item-' ~ parent_id ~ '-' ~ delta,
   'accordion_parent_id': 'accordion-' ~ parent_id,
   'accordion_type': 'single',
   'accordion_item_label': content.field_collection_headline,

--- a/docroot/themes/custom/uids_base/templates/paragraphs/paragraph--uiowa-collection-item--accordion.html.twig
+++ b/docroot/themes/custom/uids_base/templates/paragraphs/paragraph--uiowa-collection-item--accordion.html.twig
@@ -41,7 +41,7 @@
 
 {% set accordion_item = {
   'accordion_h_size': h_size ?: 'h2',
-  'accordion_item_id': 'accordion-' ~ accordion_type ~ '-select-' ~ delta,
+  'accordion_item_id': 'accordion-single-select-' ~ parent_id ~ '-' ~ delta,
   'accordion_parent_id': 'accordion-' ~ parent_id,
   'accordion_type': 'single',
   'accordion_item_label': content.field_collection_headline,

--- a/docroot/themes/custom/uids_base/templates/uids/accordion-item.html.twig
+++ b/docroot/themes/custom/uids_base/templates/uids/accordion-item.html.twig
@@ -5,7 +5,6 @@
   {% set accordion_type = 'single' %}
 {% endif %}
 {% set accordion_h_size = accordion_h_size ?: 'h2' %}
-{% set accordion_item_id = 'accordion-' ~ accordion_type ~ '-select-' ~ delta %}
 
 <!-- Use the accurate heading level to maintain the document outline -->
 <{{ accordion_h_size }} id="{{ accordion_item_id }}-heading" class="accordion__heading">


### PR DESCRIPTION
Resolves #2077 

Accordion items in LB collections not receiving unique IDs. Updated where the accordion-item-id is set, and removed the single/multi-select identifier in the ID, as all accordions are currently multi-select.

## Testing
Sync, blt frontend.
Add at least 2 collections to a page, each with at least 2 items, and view mode set to 'accordion'.
Check that each accordion item within a collection has a unique ID, and that these are unique between the multiple collections.
Check that the "aria-controls" tag of the heading matches the id of the child `<div>`
Check that the "aria-labelledby" tag of the child `<div>` matches the id of the correct heading.
Check that the `<div>` "dataparent" tag matches the parent collection container id.