### PR TITLE
Feature: Exclude .htaccess from being copied

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -262,7 +262,10 @@
             "initial": {
                 "sites/default/default.services.yml": "sites/default/services.yml",
                 "sites/default/default.settings.php": "sites/default/settings.php"
-            }
+            },
+            "excludes": [
+                ".htaccess"
+            ]
         }
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be4577204ee6bdfa93d3429282780fc2",
+    "content-hash": "8e252ef6afa0554c6dfc03c124a0dd4f",
     "packages": [
         {
             "name": "acquia/blt",
@@ -237,7 +237,7 @@
             "version": "5.2.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/aFarkas/lazysizes.git",
+                "url": "git@github.com:aFarkas/lazysizes.git",
                 "reference": "bce35e58dc3cdd6793ecd4cf47349ede240199e6"
             },
             "dist": {


### PR DESCRIPTION
This update adds the `.htaccess` file to an exclusion list so that it is not copied offer when file scaffolding happens during an update to drupal/core. Previously, it was necessary to compare the `.htaccess` file against its previous version to copy redirection rules back into it.

# To test
I'm not sure if there is an easy way to test this. One idea would be to pull down the branch, then make some change to the `composer.json` file, like removing a patch from `drupal/core` and then run `composer update --lock`. This will cause `drupal/core` to be removed and re-added so that patches can be re-applied. I think that would trigger the scaffolding command to run and you can then view that the `.htaccess` file remains unchanged. However, I'm not 100% sure that is how it works.