### PR TITLE
Hotfix: Pass through event-specific variables.

### DIFF
--- a/docroot/themes/custom/uids_base/templates/misc/sitenow-events-teaser.html.twig
+++ b/docroot/themes/custom/uids_base/templates/misc/sitenow-events-teaser.html.twig
@@ -15,15 +15,17 @@
   'card_title': event.title | render,
   'card_subtitle': event.subtitle | render,
   'card_link_url': event.url,
-  'heading_level': event.heading_size
+  'heading_level': event.heading_size,
+  'event_location': event.location_name|render,
+  'event_virtual': event.virtual,
 } %}
 
 {% embed '@uids_base/uids/card.html.twig' with events_card only %}
   {% block card_content %}
-    {% if event.virtual %}
+    {% if event_virtual %}
       <div class="event-location"><span class="fas fa-map-marker-alt"></span> Virtual Event</div>
-    {% elseif event.location_name is not empty %}
-      <div class="event-location"><span class="fas fa-map-marker-alt"></span> {{ event.location_name }}</div>
+    {% elseif event_location is not empty %}
+      <div class="event-location"><span class="fas fa-map-marker-alt"></span> {{ event_location }}</div>
     {% endif %}
 
     <p>{{ card_text }}</p>


### PR DESCRIPTION
This is a follow up to #2130 and is meant to fix the issue where I broke the event location showing up.