### PR TITLE
Add dependency on jquery.cookie to LBC library.

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.libraries.yml
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.libraries.yml
@@ -4,6 +4,7 @@ layout_builder_custom.overrides:
   dependencies:
     - core/jquery
     - core/jquery.once
+    - core/jquery.cookie
   css:
     theme:
       css/layout_builder_custom.overrides.css: {}


### PR DESCRIPTION
When editing a layout, there is a console error regarding jquery.cookie not being available: `Uncaught TypeError: $.cookie is not a function`. This PR adds a dependency to the module library to prevent it. I'm not sure how this didn't crop up earlier. Maybe the update to Drupal 8.9 removed the library from somehow.

### Testing
- Go to a layout enabled page and open the console.
- Edit the layout and trigger the off-canvas dialog (add a block for example). See error.
- Check out this branch. Rebuild the cache. Refresh the page.
- Repeat steps above and notice the error is gone.

