### PR TITLE
add mailto matcher support in linkit

### DIFF
--- a/config/default/linkit.linkit_profile.default.yml
+++ b/config/default/linkit.linkit_profile.default.yml
@@ -32,3 +32,8 @@ matchers:
       group_by_bundle: false
       substitution_type: media
       limit: 100
+  36a7abf7-f57a-4d95-8d57-cc8d6775ea87:
+    uuid: 36a7abf7-f57a-4d95-8d57-cc8d6775ea87
+    id: email
+    weight: 0
+    settings: {  }


### PR DESCRIPTION
Resolves #969 

## To Test

- type an email address in linkit dialog, see result suggesting mail link, see mailto: prefix.