### PR TITLE
Remove hawk alert behat test.

### DIFF
--- a/tests/behat/features/Alerts.feature
+++ b/tests/behat/features/Alerts.feature
@@ -15,12 +15,3 @@ Feature: Alerts
     And I am on the homepage
     Then I should see the heading "TEST"
     And I should see "This is a custom alert."
-
-  @drush
-  @api
-  @javascript
-  Scenario: Configure the module for a test Hawk Alert
-    Given I run drush "config:set uiowa_alerts.settings hawk_alert.source 'https://emergency.stage.drupal.uiowa.edu/api/active.json'"
-    And I am on the homepage
-    And I wait for AJAX to finish
-    Then I should see the warning message "Hawk Alert"

--- a/tests/behat/features/bootstrap/Drupal/FeatureContext.php
+++ b/tests/behat/features/bootstrap/Drupal/FeatureContext.php
@@ -77,7 +77,6 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   public static function alertsTearDown(AfterFeatureScope $scope) {
     \Drupal::configFactory()->getEditable('uiowa_alerts.settings')
       ->set('custom_alert.display', false)
-      ->set('hawk_alert.source', 'https://emergency.uiowa.edu/api/active.json')
       ->save();
   }
 }


### PR DESCRIPTION
Resolves #2203 

I tried upgrading drupal/drupal-extension and increasing the AJAX timeout but this test is probably not a good idea. The module should be refactored to allow mocking a hawk alert instead of attempting a network connection. We may still run into AJAX timeout issues eventually though with other JS tests.