### PR TITLE
Update drupal/coder to most recent version and fix new PHPCS errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,5 +17,5 @@ insert_final_newline = true
 [Makefile]
 indent_style = tab
 
-[composer.json]
+[composer.{json,lock}]
 indent_size = 4

--- a/composer.lock
+++ b/composer.lock
@@ -222,7 +222,7 @@
             "version": "5.14.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/FortAwesome/Font-Awesome.git",
+                "url": "git@github.com:FortAwesome/Font-Awesome.git",
                 "reference": "c38da7f63e45b7ba12fb33539a4e54677f8e63aa"
             },
             "dist": {
@@ -651,20 +651,6 @@
                 "semver",
                 "validation",
                 "versioning"
-            ],
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-09-09T09:34:06+00:00"
         },
@@ -2325,20 +2311,6 @@
                 "orm",
                 "persistence"
             ],
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fpersistence",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-06-20T12:56:16+00:00"
         },
         {
@@ -2461,6 +2433,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Composer Plugin for updating the Drupal scaffold files when using drupal/core",
+            "abandoned": "drupal/core-composer-scaffold",
             "time": "2019-03-30T10:41:38+00:00"
         },
         {
@@ -2814,6 +2787,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-1.0-beta4",
                     "datestamp": "1576069085",
@@ -2875,6 +2851,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-1.2",
                     "datestamp": "1524046435",
@@ -2946,20 +2925,21 @@
         },
         {
             "name": "drupal/coder",
-            "version": "8.3.9",
+            "version": "8.3.10",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/coder.git",
-                "reference": "d51e0b8c6561e21c0545d04b5410a7bed7ee7c6b"
+                "reference": "e1d71c6bb75b94f9ed00dceb2f4f6cb7e044723d"
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": ">=7.0.8",
-                "squizlabs/php_codesniffer": "^3.5.5",
+                "sirbrillig/phpcs-variable-analysis": "^2.8",
+                "squizlabs/php_codesniffer": "^3.5.6",
                 "symfony/yaml": ">=2.0.5"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.12.5",
+                "phpstan/phpstan": "^0.12.31",
                 "phpunit/phpunit": "^6.0 || ^7.0"
             },
             "type": "phpcodesniffer-standard",
@@ -2971,7 +2951,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "GPL-2.0+"
+                "GPL-2.0-or-later"
             ],
             "description": "Coder is a library to review Drupal code.",
             "homepage": "https://www.drupal.org/project/coder",
@@ -2980,7 +2960,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-05-08T10:20:59+00:00"
+            "time": "2020-09-03T19:59:53+00:00"
         },
         {
             "name": "drupal/colorbox",
@@ -3179,6 +3159,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-2.2",
                     "datestamp": "1576528386",
@@ -3666,6 +3649,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-2.1",
                     "datestamp": "1585251827",
@@ -4138,6 +4124,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-1.0",
                     "datestamp": "1578322688",
@@ -4220,7 +4209,7 @@
                 "shasum": "0f5e9195ceec209552aa50f8ce3c230692c284db"
             },
             "require": {
-                "drupal/core": "^8"
+                "drupal/core": "*"
             },
             "require-dev": {
                 "drupal/draggableviews_demo": "*"
@@ -4424,7 +4413,7 @@
             "extra": {
                 "drupal": {
                     "version": "8.x-2.5",
-                    "datestamp": "1588015429",
+                    "datestamp": "1588015347",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4587,6 +4576,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-1.8",
                     "datestamp": "1583961846",
@@ -4698,6 +4690,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-2.0-beta3",
                     "datestamp": "1585145909",
@@ -5380,10 +5375,13 @@
                 "shasum": "dd4f041441d2096f0b9b6979a1f11a58c7c18958"
             },
             "require": {
-                "drupal/core": "^8"
+                "drupal/core": "*"
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-1.2",
                     "datestamp": "1579607283",
@@ -5435,6 +5433,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-3.1",
                     "datestamp": "1581420882",
@@ -6335,6 +6336,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-2.4",
                     "datestamp": "1585646747",
@@ -6926,12 +6930,16 @@
             ],
             "authors": [
                 {
-                    "name": "drupalspoons",
-                    "homepage": "https://www.drupal.org/user/3647684"
+                    "name": "heddn",
+                    "homepage": "https://www.drupal.org/user/1463982"
                 },
                 {
                     "name": "mikeryan",
                     "homepage": "https://www.drupal.org/user/4420"
+                },
+                {
+                    "name": "moshe weitzman",
+                    "homepage": "https://www.drupal.org/user/23"
                 }
             ],
             "description": "Tools to assist in developing and running migrations.",
@@ -7534,6 +7542,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-1.4",
                     "datestamp": "1585290535",
@@ -7890,6 +7901,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-1.2",
                     "datestamp": "1581970320",
@@ -8073,6 +8087,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "8.x-1.0",
                     "datestamp": "1576526880",
@@ -10015,12 +10032,6 @@
                 "feed",
                 "laminas"
             ],
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
             "time": "2020-08-18T13:45:04+00:00"
         },
         {
@@ -10143,12 +10154,6 @@
                 "laminas",
                 "stdlib"
             ],
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
             "time": "2020-08-25T09:08:16+00:00"
         },
         {
@@ -10248,12 +10253,6 @@
                 "autoloading",
                 "laminas",
                 "zf"
-            ],
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
             ],
             "time": "2020-09-14T14:23:00+00:00"
         },
@@ -11997,17 +11996,65 @@
             "time": "2018-12-19T17:14:59+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.5.5",
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "00b4fa3130faa26762c929989e3d958086c627f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/00b4fa3130faa26762c929989e3d958086c627f1",
+                "reference": "00b4fa3130faa26762c929989e3d958086c627f1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5 || ^0.6",
+                "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
+                "sirbrillig/phpcs-import-detection": "^1.1"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "time": "2020-07-11T23:32:06+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
                 "shasum": ""
             },
             "require": {
@@ -12045,7 +12092,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-04-17T01:09:41+00:00"
+            "time": "2020-08-10T04:50:15+00:00"
         },
         {
             "name": "stack/builder",
@@ -12264,20 +12311,6 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-08-09T11:28:08+00:00"
         },
         {
@@ -12414,20 +12447,6 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-08-09T08:16:57+00:00"
         },
         {
@@ -12484,20 +12503,6 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-08-09T08:13:48+00:00"
         },
         {
@@ -12569,20 +12574,6 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-08-10T07:13:15+00:00"
         },
         {
@@ -12646,20 +12637,6 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-08-12T14:55:37+00:00"
         },
         {
@@ -12813,20 +12790,6 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-08-12T14:55:37+00:00"
         },
         {
@@ -12917,20 +12880,6 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-08-31T05:53:42+00:00"
         },
         {
@@ -12992,20 +12941,6 @@
                 "ctype",
                 "polyfill",
                 "portable"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-07-14T12:35:20+00:00"
         },
@@ -13069,20 +13004,6 @@
                 "polyfill",
                 "portable",
                 "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-07-14T12:35:20+00:00"
         },
@@ -13345,20 +13266,6 @@
                 "portable",
                 "shim"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-07-14T12:35:20+00:00"
         },
         {
@@ -13421,20 +13328,6 @@
                 "polyfill",
                 "portable",
                 "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-07-14T12:35:20+00:00"
         },
@@ -13617,20 +13510,6 @@
                 "polyfill",
                 "shim"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-07-14T12:35:20+00:00"
         },
         {
@@ -13680,20 +13559,6 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-07-16T09:41:49+00:00"
         },
         {
@@ -13835,20 +13700,6 @@
                 "uri",
                 "url"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-08-09T11:28:08+00:00"
         },
         {
@@ -13928,20 +13779,6 @@
             ],
             "description": "Symfony Serializer Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-08-16T08:23:32+00:00"
         },
         {
@@ -14012,20 +13849,6 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-08-10T07:13:15+00:00"
         },
         {
@@ -14203,20 +14026,6 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-08-19T04:26:06+00:00"
         },
         {
@@ -14353,20 +14162,6 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-08-26T06:32:27+00:00"
         },
         {
@@ -14430,16 +14225,6 @@
             "homepage": "https://twig.symfony.com",
             "keywords": [
                 "templating"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-08-05T15:05:05+00:00"
         },
@@ -18188,6 +17973,5 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform-dev": []
 }

--- a/docroot/modules/custom/entity_types/entity_types.module
+++ b/docroot/modules/custom/entity_types/entity_types.module
@@ -27,7 +27,7 @@ function entity_types_help($route_name, RouteMatchInterface $route_match) {
         return NULL;
       }
 
-      /* @var \Drupal\Core\Extension\ModuleHandler $moduleHandler*/
+      /** @var \Drupal\Core\Extension\ModuleHandler $moduleHandler */
       $moduleHandler = \Drupal::service('module_handler');
       if ($moduleHandler->moduleExists('markdown')) {
         $filters = $moduleHandler->invoke('markdown', 'filter_info');

--- a/docroot/modules/custom/entity_types/entity_types_article/entity_types_article.module
+++ b/docroot/modules/custom/entity_types/entity_types_article/entity_types_article.module
@@ -27,7 +27,7 @@ function entity_types_article_help($route_name, RouteMatchInterface $route_match
         return NULL;
       }
 
-      /* @var \Drupal\Core\Extension\ModuleHandler $moduleHandler*/
+      /** @var \Drupal\Core\Extension\ModuleHandler $moduleHandler */
       $moduleHandler = \Drupal::service('module_handler');
       if ($moduleHandler->moduleExists('markdown')) {
         $filters = $moduleHandler->invoke('markdown', 'filter_info');

--- a/docroot/modules/custom/entity_types/entity_types_deadline/entity_types_deadline.module
+++ b/docroot/modules/custom/entity_types/entity_types_deadline/entity_types_deadline.module
@@ -27,7 +27,7 @@ function entity_types_deadline_help($route_name, RouteMatchInterface $route_matc
         return NULL;
       }
 
-      /* @var \Drupal\Core\Extension\ModuleHandler $moduleHandler*/
+      /** @var \Drupal\Core\Extension\ModuleHandler $moduleHandler */
       $moduleHandler = \Drupal::service('module_handler');
       if ($moduleHandler->moduleExists('markdown')) {
         $filters = $moduleHandler->invoke('markdown', 'filter_info');

--- a/docroot/modules/custom/entity_types/entity_types_event/entity_types_event.module
+++ b/docroot/modules/custom/entity_types/entity_types_event/entity_types_event.module
@@ -27,7 +27,7 @@ function entity_types_event_help($route_name, RouteMatchInterface $route_match) 
         return NULL;
       }
 
-      /* @var \Drupal\Core\Extension\ModuleHandler $moduleHandler*/
+      /** @var \Drupal\Core\Extension\ModuleHandler $moduleHandler */
       $moduleHandler = \Drupal::service('module_handler');
       if ($moduleHandler->moduleExists('markdown')) {
         $filters = $moduleHandler->invoke('markdown', 'filter_info');

--- a/docroot/modules/custom/entity_types/entity_types_person/entity_types_person.module
+++ b/docroot/modules/custom/entity_types/entity_types_person/entity_types_person.module
@@ -30,7 +30,7 @@ function entity_types_person_help($route_name, RouteMatchInterface $route_match)
         return NULL;
       }
 
-      /* @var \Drupal\Core\Extension\ModuleHandler $moduleHandler*/
+      /** @var \Drupal\Core\Extension\ModuleHandler $moduleHandler */
       $moduleHandler = \Drupal::service('module_handler');
       if ($moduleHandler->moduleExists('markdown')) {
         $filters = $moduleHandler->invoke('markdown', 'filter_info');

--- a/docroot/modules/custom/entity_types/entity_types_seminar/entity_types_seminar.module
+++ b/docroot/modules/custom/entity_types/entity_types_seminar/entity_types_seminar.module
@@ -27,7 +27,7 @@ function entity_types_seminar_help($route_name, RouteMatchInterface $route_match
         return NULL;
       }
 
-      /* @var \Drupal\Core\Extension\ModuleHandler $moduleHandler*/
+      /** @var \Drupal\Core\Extension\ModuleHandler $moduleHandler */
       $moduleHandler = \Drupal::service('module_handler');
       if ($moduleHandler->moduleExists('markdown')) {
         $filters = $moduleHandler->invoke('markdown', 'filter_info');

--- a/docroot/modules/custom/layout_builder_custom/src/EventSubscriber/SectionComponentSubscriber.php
+++ b/docroot/modules/custom/layout_builder_custom/src/EventSubscriber/SectionComponentSubscriber.php
@@ -17,7 +17,10 @@ class SectionComponentSubscriber implements EventSubscriberInterface {
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() {
-    $events[LayoutBuilderEvents::SECTION_COMPONENT_BUILD_RENDER_ARRAY] = ['onBuildRender', 50];
+    $events[LayoutBuilderEvents::SECTION_COMPONENT_BUILD_RENDER_ARRAY] = [
+      'onBuildRender',
+      50,
+    ];
     return $events;
   }
 

--- a/docroot/modules/custom/sitenow_articles/src/Form/SettingsForm.php
+++ b/docroot/modules/custom/sitenow_articles/src/Form/SettingsForm.php
@@ -222,7 +222,7 @@ class SettingsForm extends ConfigFormBase {
     $title = $form_state->getValue('sitenow_articles_title');
     $path = $form_state->getValue('sitenow_articles_path');
     $header_content = $form_state->getValue('sitenow_articles_header_content');
-    $show_archive = $form_state->getValue('sitenow_articles_archive');;
+    $show_archive = $form_state->getValue('sitenow_articles_archive');
 
     // Clean path.
     $path = $this->aliasCleaner->cleanString($path);

--- a/docroot/modules/custom/sitenow_dcv/src/Controller/SitenowDcvController.php
+++ b/docroot/modules/custom/sitenow_dcv/src/Controller/SitenowDcvController.php
@@ -43,7 +43,7 @@ class SitenowDcvController extends ControllerBase {
    * Returns file content.
    */
   public function dcvFile($filename) {
-    /* @var \Drupal\file\Entity\File[] $file */
+    /** @var \Drupal\file\Entity\File[] $file */
     $file = $this->entityTypeManager
       ->getStorage('file')
       ->loadByProperties(['filename' => $filename]);

--- a/docroot/modules/custom/sitenow_dcv/src/Form/SitenowDcvFileForm.php
+++ b/docroot/modules/custom/sitenow_dcv/src/Form/SitenowDcvFileForm.php
@@ -102,10 +102,12 @@ class SitenowDcvFileForm extends FormBase {
       '#value' => $this->t('Submit'),
     ];
 
-    /* @var \Drupal\file\Entity\File[] $file */
+    /** @var \Drupal\file\Entity\File[] $file */
     $file = $this->entityTypeManager
       ->getStorage('file')
-      ->loadByProperties(['filename' => $this->state->get('sitenow_dcv_filename', '')]);
+      ->loadByProperties([
+        'filename' => $this->state->get('sitenow_dcv_filename', ''),
+      ]);
 
     // There can be only one (file replaced on upload).
     $file = array_pop($file);

--- a/docroot/modules/custom/sitenow_events/sitenow_events.module
+++ b/docroot/modules/custom/sitenow_events/sitenow_events.module
@@ -7,7 +7,6 @@
 
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\field\Entity\FieldStorageConfig;
 use GuzzleHttp\Exception\RequestException;
@@ -91,7 +90,12 @@ function sitenow_events_preprocess_block(&$variables) {
  * @return array
  *   An array of data.
  */
-function sitenow_events_load(array $params = ['display_id' => 'events'], array $args = ['views', 'event_instances_api.json'], $cache = TRUE) {
+function sitenow_events_load(array $params = [
+  'display_id' => 'events',
+], array $args = [
+  'views',
+  'event_instances_api.json',
+], $cache = TRUE) {
   $config = \Drupal::config('sitenow_events.settings');
   $endpoint = $config->get('base_endpoint');
 
@@ -265,7 +269,12 @@ function _sitenow_events_get_filter_field_options(FieldStorageConfig $definition
   switch ($definition->getName()) {
     case 'field_events_department':
     case 'field_uiowa_events_department':
-      $data = sitenow_events_load(['display_id' => 'filters'], ['views', 'filters_api.json']);
+      $data = sitenow_events_load([
+        'display_id' => 'filters',
+      ], [
+        'views',
+        'filters_api.json',
+      ]);
       $tree = _sitenow_events_build_options_tree($data['departments']);
       $options = _sitenow_events_build_options_list($tree);
 
@@ -273,7 +282,12 @@ function _sitenow_events_get_filter_field_options(FieldStorageConfig $definition
 
     case 'field_events_audiences':
     case 'field_uiowa_events_audiences':
-      $data = sitenow_events_load(['display_id' => 'filters'], ['views', 'filters_api.json']);
+      $data = sitenow_events_load([
+        'display_id' => 'filters',
+      ], [
+        'views',
+        'filters_api.json',
+      ]);
       $tree = _sitenow_events_build_options_tree($data['event_audience']);
       $options = _sitenow_events_build_options_list($tree);
 
@@ -281,7 +295,12 @@ function _sitenow_events_get_filter_field_options(FieldStorageConfig $definition
 
     case 'field_events_gen_interests':
     case 'field_uiowa_events_interests':
-      $data = sitenow_events_load(['display_id' => 'filters'], ['views', 'filters_api.json']);
+      $data = sitenow_events_load([
+        'display_id' => 'filters'
+      ], [
+        'views',
+        'filters_api.json',
+      ]);
       $tree = _sitenow_events_build_options_tree($data['event_general_interest']);
       $options = _sitenow_events_build_options_list($tree);
 
@@ -289,7 +308,12 @@ function _sitenow_events_get_filter_field_options(FieldStorageConfig $definition
 
     case 'field_events_event_types':
     case 'field_uiowa_events_types':
-      $data = sitenow_events_load(['display_id' => 'filters'], ['views', 'filters_api.json']);
+      $data = sitenow_events_load([
+        'display_id' => 'filters'
+      ], [
+        'views',
+        'filters_api.json',
+      ]);
       $tree = _sitenow_events_build_options_tree($data['event_types']);
       $options = _sitenow_events_build_options_list($tree);
 
@@ -297,7 +321,12 @@ function _sitenow_events_get_filter_field_options(FieldStorageConfig $definition
 
     case 'field_events_keywords':
     case 'field_uiowa_events_keywords':
-      $data = sitenow_events_load(['display_id' => 'keywords'], ['views', 'filters_api.json']);
+      $data = sitenow_events_load([
+        'display_id' => 'keywords'
+      ], [
+        'views',
+        'filters_api.json',
+      ]);
 
       $options = [];
 
@@ -309,7 +338,12 @@ function _sitenow_events_get_filter_field_options(FieldStorageConfig $definition
 
     case 'field_events_place':
     case 'field_uiowa_events_place':
-      $data = sitenow_events_load(['display_id' => 'places'], ['views', 'places_api.json']);
+      $data = sitenow_events_load([
+        'display_id' => 'places'
+      ], [
+        'views',
+        'places_api.json',
+      ]);
       $options = [];
 
       foreach ($data['places'] as $place) {

--- a/docroot/modules/custom/sitenow_migrate/src/EventSubscriber/MigratePostImportEvent.php
+++ b/docroot/modules/custom/sitenow_migrate/src/EventSubscriber/MigratePostImportEvent.php
@@ -171,7 +171,10 @@ class MigratePostImportEvent implements EventSubscriberInterface {
 
       }
 
-      $content = preg_replace_callback('|<a href="(.*?)">|i', [$this, 'linkReplace'], $content);
+      $content = preg_replace_callback('|<a href="(.*?)">|i', [
+        $this,
+        'linkReplace',
+      ], $content);
 
       // Depending on content type, need to set it differently.
       switch ($node->getType()) {

--- a/docroot/modules/custom/sitenow_migrate/src/Plugin/migrate/source/Articles.php
+++ b/docroot/modules/custom/sitenow_migrate/src/Plugin/migrate/source/Articles.php
@@ -130,7 +130,10 @@ class Articles extends SqlBase {
 
     // Search for D7 inline embeds and replace with D8 inline entities.
     $content = $row->getSourceProperty('field_article_body_value');
-    $content = preg_replace_callback("|\[\[\{.*?\"fid\":\"(.*?)\".*?\]\]|", [$this, 'entityReplace'], $content);
+    $content = preg_replace_callback("|\[\[\{.*?\"fid\":\"(.*?)\".*?\]\]|", [
+      $this,
+      'entityReplace',
+    ], $content);
     $row->setSourceProperty('field_article_body_value', $content);
 
     // Check summary, and create one if none exists.

--- a/docroot/modules/custom/sitenow_migrate/src/Plugin/migrate/source/Pages.php
+++ b/docroot/modules/custom/sitenow_migrate/src/Plugin/migrate/source/Pages.php
@@ -121,7 +121,10 @@ class Pages extends SqlBase {
 
     // Search for D7 inline embeds and replace with D8 inline entities.
     $content = $row->getSourceProperty('body_value');
-    $content = preg_replace_callback("|\[\[\{.*?\"fid\":\"(.*?)\".*?\]\]|", [$this, 'entityReplace'], $content);
+    $content = preg_replace_callback("|\[\[\{.*?\"fid\":\"(.*?)\".*?\]\]|", [
+      $this,
+      'entityReplace',
+    ], $content);
     $row->setSourceProperty('body_value', $content);
 
     // Check summary, and create one if none exists.

--- a/docroot/modules/custom/uiowa_alerts/src/Form/SettingsForm.php
+++ b/docroot/modules/custom/uiowa_alerts/src/Form/SettingsForm.php
@@ -100,7 +100,10 @@ class SettingsForm extends ConfigFormBase {
     $this->config('uiowa_alerts.settings')
       ->set('custom_alert.display', $form_state->getValue('custom_alert_display'))
       ->set('custom_alert.level', $form_state->getValue('custom_alert_level'))
-      ->set('custom_alert.message', $form_state->getValue(['custom_alert_message', 'value']))
+      ->set('custom_alert.message', $form_state->getValue([
+        'custom_alert_message',
+        'value',
+      ]))
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/docroot/modules/custom/uiowa_book/uiowa_book.module
+++ b/docroot/modules/custom/uiowa_book/uiowa_book.module
@@ -27,7 +27,7 @@ function uiowa_book_help($route_name, RouteMatchInterface $route_match) {
         return NULL;
       }
 
-      /* @var \Drupal\Core\Extension\ModuleHandler $moduleHandler*/
+      /** @var \Drupal\Core\Extension\ModuleHandler $moduleHandler */
       $moduleHandler = \Drupal::service('module_handler');
       if ($moduleHandler->moduleExists('markdown')) {
         $filters = $moduleHandler->invoke('markdown', 'filter_info');

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -33,7 +33,10 @@ function sitenow_preprocess_html(&$variables) {
     ],
   ];
 
-  $variables['page']['#attached']['html_head'][] = [$meta_web_author, 'web-author'];
+  $variables['page']['#attached']['html_head'][] = [
+    $meta_web_author,
+    'web-author',
+  ];
   $variables['page']['#attached']['library'][] = 'sitenow/global-scripts';
   $variables['page']['#attached']['drupalSettings']['sitenow']['version'] = $version;
 }
@@ -501,7 +504,10 @@ function sitenow_form_system_site_information_settings_alter(&$form, FormStateIn
       $menu_link = Url::fromRoute('entity.menu.edit_form', ['menu' => $social_media_menu])->toString();
       $form['uiowa_footer_menus']['uiowa_footer_social_media_menu_help'] = [
         '#type' => 'item',
-        '#markup' => t('Links in the social media section are managed via the <a href="@menu_link">@menu_name menu</a>.', ['@menu_link' => $menu_link, '@menu_name' => $menus[$social_media_menu]]),
+        '#markup' => t('Links in the social media section are managed via the <a href="@menu_link">@menu_name menu</a>.', [
+          '@menu_link' => $menu_link,
+          '@menu_name' => $menus[$social_media_menu],
+        ]),
       ];
     }
 
@@ -510,7 +516,10 @@ function sitenow_form_system_site_information_settings_alter(&$form, FormStateIn
       $menu_link = Url::fromRoute('entity.menu.edit_form', ['menu' => $custom_menu])->toString();
       $form['uiowa_footer_menus']['uiowa_footer_custom_menu_help'] = [
         '#type' => 'item',
-        '#markup' => t('Links in the left column are managed via the <a href="@menu_link">@menu_name menu</a>.', ['@menu_link' => $menu_link, '@menu_name' => $menus[$custom_menu]]),
+        '#markup' => t('Links in the left column are managed via the <a href="@menu_link">@menu_name menu</a>.', [
+          '@menu_link' => $menu_link,
+          '@menu_name' => $menus[$custom_menu],
+        ]),
       ];
     }
 
@@ -519,7 +528,10 @@ function sitenow_form_system_site_information_settings_alter(&$form, FormStateIn
       $menu_link = Url::fromRoute('entity.menu.edit_form', ['menu' => $custom_menu_2])->toString();
       $form['uiowa_footer_menus']['uiowa_footer_custom_menu_2_help'] = [
         '#type' => 'item',
-        '#markup' => t('Links in the middle column are managed via the <a href="@menu_link">@menu_name menu</a>.', ['@menu_link' => $menu_link, '@menu_name' => $menus[$custom_menu_2]]),
+        '#markup' => t('Links in the middle column are managed via the <a href="@menu_link">@menu_name menu</a>.', [
+          '@menu_link' => $menu_link,
+          '@menu_name' => $menus[$custom_menu_2],
+        ]),
       ];
     }
 
@@ -528,7 +540,10 @@ function sitenow_form_system_site_information_settings_alter(&$form, FormStateIn
       $menu_link = Url::fromRoute('entity.menu.edit_form', ['menu' => $custom_menu_3])->toString();
       $form['uiowa_footer_menus']['uiowa_footer_custom_menu_3_help'] = [
         '#type' => 'item',
-        '#markup' => t('Links in the right column are managed via the <a href="@menu_link">@menu_name menu</a>.', ['@menu_link' => $menu_link, '@menu_name' => $menus[$custom_menu_3]]),
+        '#markup' => t('Links in the right column are managed via the <a href="@menu_link">@menu_name menu</a>.', [
+          '@menu_link' => $menu_link,
+          '@menu_name' => $menus[$custom_menu_3],
+        ]),
       ];
     }
 
@@ -541,7 +556,10 @@ function sitenow_form_system_site_information_settings_alter(&$form, FormStateIn
       $menu_link = Url::fromRoute('entity.menu.edit_form', ['menu' => $social_media_menu])->toString();
       $form['uiowa_footer']['uiowa_footer_menus']['uiowa_footer_social_media_menu_help'] = [
         '#type' => 'item',
-        '#markup' => t('Links in the social media section are managed via the <a href="@menu_link">@menu_name menu</a>.', ['@menu_link' => $menu_link, '@menu_name' => $menus[$social_media_menu]]),
+        '#markup' => t('Links in the social media section are managed via the <a href="@menu_link">@menu_name menu</a>.', [
+          '@menu_link' => $menu_link,
+          '@menu_name' => $menus[$social_media_menu],
+        ]),
       ];
     }
 
@@ -550,7 +568,10 @@ function sitenow_form_system_site_information_settings_alter(&$form, FormStateIn
       $menu_link = Url::fromRoute('entity.menu.edit_form', ['menu' => $custom_menu])->toString();
       $form['uiowa_footer']['uiowa_footer_menus']['uiowa_footer_custom_menu_help'] = [
         '#type' => 'item',
-        '#markup' => t('Links in the left column are managed via the <a href="@menu_link">@menu_name menu</a>.', ['@menu_link' => $menu_link, '@menu_name' => $menus[$custom_menu]]),
+        '#markup' => t('Links in the left column are managed via the <a href="@menu_link">@menu_name menu</a>.', [
+          '@menu_link' => $menu_link,
+          '@menu_name' => $menus[$custom_menu],
+        ]),
       ];
     }
 
@@ -559,7 +580,10 @@ function sitenow_form_system_site_information_settings_alter(&$form, FormStateIn
       $menu_link = Url::fromRoute('entity.menu.edit_form', ['menu' => $custom_menu_2])->toString();
       $form['uiowa_footer']['uiowa_footer_menus']['uiowa_footer_custom_menu_2_help'] = [
         '#type' => 'item',
-        '#markup' => t('Links in the right column are managed via the <a href="@menu_link">@menu_name menu</a>.', ['@menu_link' => $menu_link, '@menu_name' => $menus[$custom_menu_2]]),
+        '#markup' => t('Links in the right column are managed via the <a href="@menu_link">@menu_name menu</a>.', [
+          '@menu_link' => $menu_link,
+          '@menu_name' => $menus[$custom_menu_2],
+        ]),
       ];
     }
   }

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -289,13 +289,19 @@ function uids_base_preprocess_block(&$variables) {
   if (isset($variables['elements']['#id'])) {
     $region = Block::load($variables['elements']['#id'])->getRegion();
 
-    if ($region === 'footer_second' && in_array($variables['base_plugin_id'], ['system_menu_block', 'menu_block'])) {
+    if ($region === 'footer_second' && in_array($variables['base_plugin_id'], [
+      'system_menu_block',
+      'menu_block',
+    ])) {
       $variables['attributes']['class'][] = 'footer__links';
       $variables['attributes']['class'][] = 'footer__links--nav';
     }
   }
 
-  if (in_array($variables['base_plugin_id'], ['system_menu_block', 'menu_block'])) {
+  if (in_array($variables['base_plugin_id'], [
+    'system_menu_block',
+    'menu_block',
+  ])) {
     switch ($variables['derivative_plugin_id']) {
       case 'external-quick-links':
         $variables['attributes']['class'][] = 'menu--group';
@@ -417,7 +423,6 @@ function uids_base_preprocess_paragraph(&$variables) {
  * Implements hook_preprocess_HOOK().
  */
 function uids_base_preprocess_views_view_table(&$variables) {
-  $view = $variables['view'];
   $variables['attributes']['class'][] = 'table is-striped';
 }
 
@@ -425,7 +430,6 @@ function uids_base_preprocess_views_view_table(&$variables) {
  * Implements hook_theme_suggestions_HOOK().
  */
 function uids_base_theme_suggestions_field_alter(array &$suggestions, array $variables) {
-
   $element = $variables['element'];
   $suggestions[] = 'field__' . $element['#entity_type'] . '__' . $element['#field_name'] . '__' . $element['#bundle'] . '__' . $element['#view_mode'];
 }


### PR DESCRIPTION
As part of the process of getting ready for Drupal 9, `drupal/coder` will be updated, which introduces some new PHPCS sniff rules. These new rules will cause builds to break. I discovered this in #2160. This PR is an effort to preemptively fix those issues before we have to, to simplify the future process and testing.

# To test
This PR shouldn't change any functionality in our custom code. Please review the [code changes](https://github.com/uiowa/uiowa/pull/2216/files) and test as you see fit.