### PR TITLE
Hotfix: Allow some self-closing tags in check for whether a region is empty

### DIFF
--- a/docroot/themes/custom/uids_base/templates/layouts/layout.html.twig
+++ b/docroot/themes/custom/uids_base/templates/layouts/layout.html.twig
@@ -19,7 +19,7 @@
   {% if content[region] %}
     {% set region_rendered = content[region]|render %}
 
-    {% if region_rendered|striptags|trim %}
+    {% if region_rendered|striptags('<embed><hr><iframe><img><input>')|trim %}
       {% set render_sections = render_sections|merge({ (region): region_rendered }) %}
     {% endif %}
   {% endif %}


### PR DESCRIPTION
This is to fix issues from #2076 

The change is to a check that attempts to determine whether a region is empty. Previously we were stripping all tags, which meant that in cases where there was content that was only rendered as tags, it was getting skipped by the check.