### PR TITLE
Remove access to spacer component.

### DIFF
--- a/config/coronavirus.uiowa.edu/core.entity_view_display.node.page.default.yml
+++ b/config/coronavirus.uiowa.edu/core.entity_view_display.node.page.default.yml
@@ -212,8 +212,12 @@ third_party_settings:
           - 'field_block:user:user:uid'
           - 'field_block:user:user:status'
         'Custom block types':
+          - uiowa_page_title_hero
+          - uiowa_spacer_separator
           - uiowa_vertical_video
         'Inline blocks':
+          - 'inline_block:uiowa_page_title_hero'
+          - 'inline_block:uiowa_spacer_separator'
           - 'inline_block:uiowa_vertical_video'
         System:
           - system_messages_block

--- a/config/features/collegiate/core.entity_view_display.node.page.default.yml
+++ b/config/features/collegiate/core.entity_view_display.node.page.default.yml
@@ -184,6 +184,8 @@ third_party_settings:
           - uiowa_spacer_separator
           - uiowa_vertical_video
         'Inline blocks':
+          - 'inline_block:uiowa_page_title_hero'
+          - 'inline_block:uiowa_spacer_separator'
           - 'inline_block:uiowa_vertical_video'
         'Lists (Views)':
           - 'views_block:content_recent-block_1'


### PR DESCRIPTION
This update adds the same restrictions to the spacer and page title hero blocks to the collegiate split and the coronavirus site.