### PR TITLE
Omit draggable views tables from table.is-stripped functionality

### DIFF
--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -311,7 +311,6 @@ function uids_base_preprocess_layout(&$variables) {
       }
     }
   }
-  $test = 'thing';
 }
 
 /**

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -458,7 +458,10 @@ function uids_base_preprocess_paragraph(&$variables) {
  * Implements hook_preprocess_HOOK().
  */
 function uids_base_preprocess_views_view_table(&$variables) {
-  $variables['attributes']['class'][] = 'table is-striped';
+  // For all view tables except for draggable view tables.
+  if (!isset($variables["view"]->display_handler->handlers["field"]["draggableviews"])) {
+    $variables['attributes']['class'][] = 'table is-striped';
+  }
 }
 
 /**


### PR DESCRIPTION
Resolves #2118 

## To Test
Any other view table has proper is-stripped styling.
People manual sort view display doesn't have broken is-stripped styling.