### PR TITLE
Update drupal/layout_builder_lock to 1.0.0.0-RC5.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5636,17 +5636,17 @@
         },
         {
             "name": "drupal/layout_builder_lock",
-            "version": "1.0.0-rc4",
+            "version": "1.0.0-rc5",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/layout_builder_lock.git",
-                "reference": "8.x-1.0-rc4"
+                "reference": "8.x-1.0-rc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/layout_builder_lock-8.x-1.0-rc4.zip",
-                "reference": "8.x-1.0-rc4",
-                "shasum": "e2c58419218e1e4757f3781faf1c81bf66312fe7"
+                "url": "https://ftp.drupal.org/files/projects/layout_builder_lock-8.x-1.0-rc5.zip",
+                "reference": "8.x-1.0-rc5",
+                "shasum": "b6ef7039429cf231d6e7d7dfd49091d9f4f23167"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
@@ -5654,8 +5654,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.0-rc4",
-                    "datestamp": "1591963417",
+                    "version": "8.x-1.0-rc5",
+                    "datestamp": "1601451487",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."


### PR DESCRIPTION
Resolves #2269 

### Testing
- On a stock v3 site, e.g. `blt dupal:install` the default site.
- As an admin, add a block to the header section (which is locked) of a page.
- Add a webmaster user and masquerade as that user.
- Edit the layout of the test page and see that the Configure button is visible.
- Open the console and click configure.

Repeat the steps above on this branch after running `composer install` and see the Configure button is no longer visible.