### PR TITLE
Fix event image alt text.

### DIFF
--- a/docroot/modules/custom/sitenow_events/includes/sitenow_events.single_event.inc
+++ b/docroot/modules/custom/sitenow_events/includes/sitenow_events.single_event.inc
@@ -135,9 +135,9 @@ function template_preprocess_sitenow_events_single_event(array &$variables) {
       '#theme' => 'imagecache_external_responsive',
       '#uri' => $variables['event']['media'][0]['original_image'],
       '#responsive_image_style_id' => 'large__square',
-      '#alt' => t('@title promotional image', ['@title' => $variables['event']['title']]),
       '#attributes' => [
         'data-lazy' => TRUE,
+        '#alt' => t('@title promotional image', ['@title' => $variables['event']['title']]),
       ],
     ];
   }

--- a/docroot/modules/custom/sitenow_events/includes/sitenow_events.single_event.inc
+++ b/docroot/modules/custom/sitenow_events/includes/sitenow_events.single_event.inc
@@ -137,7 +137,7 @@ function template_preprocess_sitenow_events_single_event(array &$variables) {
       '#responsive_image_style_id' => 'large__square',
       '#attributes' => [
         'data-lazy' => TRUE,
-        '#alt' => t('@title promotional image', ['@title' => $variables['event']['title']]),
+        'alt' => t('@title promotional image', ['@title' => $variables['event']['title']]),
       ],
     ];
   }

--- a/docroot/modules/custom/sitenow_events/includes/sitenow_events.teaser.inc
+++ b/docroot/modules/custom/sitenow_events/includes/sitenow_events.teaser.inc
@@ -33,7 +33,7 @@ function template_preprocess_sitenow_events_teaser(array &$variables) {
       '#responsive_image_style_id' => 'large__square',
       '#attributes' => [
         'data-lazy' => TRUE,
-        '#alt' => t('@title promotional image', ['@title' => $variables['event']['title']]),
+        'alt' => t('@title promotional image', ['@title' => $variables['event']['title']]),
       ],
     ];
   }

--- a/docroot/modules/custom/sitenow_events/includes/sitenow_events.teaser.inc
+++ b/docroot/modules/custom/sitenow_events/includes/sitenow_events.teaser.inc
@@ -31,9 +31,9 @@ function template_preprocess_sitenow_events_teaser(array &$variables) {
       '#theme' => 'imagecache_external_responsive',
       '#uri' => $variables['event']['media'][0]['original_image'],
       '#responsive_image_style_id' => 'large__square',
-      '#alt' => t('@title promotional image', ['@title' => $variables['event']['title']]),
       '#attributes' => [
         'data-lazy' => TRUE,
+        '#alt' => t('@title promotional image', ['@title' => $variables['event']['title']]),
       ],
     ];
   }


### PR DESCRIPTION
No issue. Just noticed this wasn't working.

### Testing
- Go to https://default.prod.drupal.uiowa.edu/event/54216/0. No alt text.
- On this branch locally, go to https://default.local.drupal.uiowa.edu/event/54216/0. See alt text.

Modify the default content to display images to test teasers.