### PR TITLE
Site: Immunology updates

### DIFF
--- a/config/immuno.grad.uiowa.edu/views.view.person_custom.yml
+++ b/config/immuno.grad.uiowa.edu/views.view.person_custom.yml
@@ -97,7 +97,7 @@ display:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          override: true
+          override: false
           sticky: false
           caption: ''
           summary: ''
@@ -968,7 +968,19 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: boolean
-      sorts: {  }
+      sorts:
+        field_person_last_name_value:
+          id: field_person_last_name_value
+          table: node__field_person_last_name
+          field: field_person_last_name_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: standard
       title: Faculty
       header: {  }
       footer: {  }

--- a/docroot/themes/custom/uids_base/scss/fields/fields.scss
+++ b/docroot/themes/custom/uids_base/scss/fields/fields.scss
@@ -16,3 +16,12 @@
 .field--label-inline>* {
   display: inline;
 }
+
+// Wrap long links by allow them to break mid-word.
+// @todo When #2325 is closed, either delete this comment
+//   or remove the item below if it is no longer necessary.
+.field--type-link {
+  // @todo Add a general mixin for link fields
+  //   and replace this with that.
+  word-break: break-word;
+}


### PR DESCRIPTION
* Adds style rule for link fields to allow them to break mid-word to allow for proper wrapping.
* Updates custom person view to allow for default last name sorting even when another table sort is selected.

# To test
I think this could be passed by review. If folks are interested in testing that the link field rule doesn't break anything, feel free, but I'm not too worried about it.
