### PR TITLE
Export collegiate config after failed admissions sync.

### DIFF
--- a/config/default/field.field.block_content.uiowa_statistic.field_uiowa_statistic_title_suf.yml
+++ b/config/default/field.field.block_content.uiowa_statistic.field_uiowa_statistic_title_suf.yml
@@ -11,7 +11,7 @@ id: block_content.uiowa_statistic.field_uiowa_statistic_title_suf
 field_name: field_uiowa_statistic_title_suf
 entity_type: block_content
 bundle: uiowa_statistic
-label: 'Suffix'
+label: Suffix
 description: ''
 required: false
 translatable: false

--- a/config/features/collegiate/core.entity_view_display.node.page.default.yml
+++ b/config/features/collegiate/core.entity_view_display.node.page.default.yml
@@ -32,7 +32,7 @@ third_party_settings:
             section_margin_remove_default_margins: section_margin_remove_default_margins
             0: ''
         components:
-          051b1326-800c-40ca-b518-98ce13ca4e6f:
+          -
             uuid: 051b1326-800c-40ca-b518-98ce13ca4e6f
             region: content
             configuration:
@@ -60,7 +60,7 @@ third_party_settings:
             section_margin_edge_to_edge: section_margin_edge_to_edge
             0: ''
         components:
-          40b768ff-6e34-4257-9398-d83430b061e8:
+          -
             uuid: 40b768ff-6e34-4257-9398-d83430b061e8
             region: content
             configuration:
@@ -71,7 +71,7 @@ third_party_settings:
               context_mapping: {  }
             additional: {  }
             weight: 0
-          56a58312-d93e-4d32-84a0-39b2a2fc89fb:
+          -
             uuid: 56a58312-d93e-4d32-84a0-39b2a2fc89fb
             region: content
             configuration:
@@ -90,7 +90,7 @@ third_party_settings:
                 view_mode: view_mode
             additional: {  }
             weight: 1
-          b444f835-62e1-4e31-b433-22fe88ef3372:
+          -
             uuid: b444f835-62e1-4e31-b433-22fe88ef3372
             region: background
             configuration:
@@ -123,7 +123,7 @@ third_party_settings:
         layout_settings:
           label: 'Main content'
         components:
-          a1d1b5c4-e9c0-4117-aa69-95747061ebbc:
+          -
             uuid: a1d1b5c4-e9c0-4117-aa69-95747061ebbc
             region: content
             configuration:


### PR DESCRIPTION
Working through #aggregator, I ran into an error syncing admissions. I think this config needs to be exported to match a recent change to default config. I think this is what errored on a recent deployment.

### Testing
- Sync various collegiate sites.
- Test any related functionality.

Does this PR need to include updates to other splits with this config?
