### PR TITLE
Move grad split config to grad split dir.

### DIFF
--- a/config/default/field.field.block_content.uiowa_articles.field_uiowa_headline.yml
+++ b/config/default/field.field.block_content.uiowa_articles.field_uiowa_headline.yml
@@ -11,7 +11,7 @@ id: block_content.uiowa_articles.field_uiowa_headline
 field_name: field_uiowa_headline
 entity_type: block_content
 bundle: uiowa_articles
-label: 'Headline'
+label: Headline
 description: ''
 required: false
 translatable: false

--- a/config/default/field.field.block_content.uiowa_collection.field_uiowa_headline.yml
+++ b/config/default/field.field.block_content.uiowa_collection.field_uiowa_headline.yml
@@ -11,7 +11,7 @@ id: block_content.uiowa_collection.field_uiowa_headline
 field_name: field_uiowa_headline
 entity_type: block_content
 bundle: uiowa_collection
-label: 'Headline'
+label: Headline
 description: ''
 required: false
 translatable: true

--- a/config/default/field.field.block_content.uiowa_events.field_uiowa_headline.yml
+++ b/config/default/field.field.block_content.uiowa_events.field_uiowa_headline.yml
@@ -11,7 +11,7 @@ id: block_content.uiowa_events.field_uiowa_headline
 field_name: field_uiowa_headline
 entity_type: block_content
 bundle: uiowa_events
-label: 'Headline'
+label: Headline
 description: ''
 required: false
 translatable: true

--- a/config/default/field.field.block_content.uiowa_image_gallery.field_uiowa_headline.yml
+++ b/config/default/field.field.block_content.uiowa_image_gallery.field_uiowa_headline.yml
@@ -11,7 +11,7 @@ id: block_content.uiowa_image_gallery.field_uiowa_headline
 field_name: field_uiowa_headline
 entity_type: block_content
 bundle: uiowa_image_gallery
-label: 'Headline'
+label: Headline
 description: ''
 required: false
 translatable: true

--- a/config/default/field.field.block_content.uiowa_people.field_uiowa_headline.yml
+++ b/config/default/field.field.block_content.uiowa_people.field_uiowa_headline.yml
@@ -11,7 +11,7 @@ id: block_content.uiowa_people.field_uiowa_headline
 field_name: field_uiowa_headline
 entity_type: block_content
 bundle: uiowa_people
-label: 'Headline'
+label: Headline
 description: ''
 required: false
 translatable: true

--- a/config/default/field.field.block_content.uiowa_slider.field_uiowa_headline.yml
+++ b/config/default/field.field.block_content.uiowa_slider.field_uiowa_headline.yml
@@ -11,7 +11,7 @@ id: block_content.uiowa_slider.field_uiowa_headline
 field_name: field_uiowa_headline
 entity_type: block_content
 bundle: uiowa_slider
-label: 'Headline'
+label: Headline
 description: ''
 required: false
 translatable: true

--- a/config/default/field.field.block_content.uiowa_text_area.field_uiowa_headline.yml
+++ b/config/default/field.field.block_content.uiowa_text_area.field_uiowa_headline.yml
@@ -11,7 +11,7 @@ id: block_content.uiowa_text_area.field_uiowa_headline
 field_name: field_uiowa_headline
 entity_type: block_content
 bundle: uiowa_text_area
-label: 'Headline'
+label: Headline
 description: ''
 required: false
 translatable: true

--- a/config/grad.uiowa.edu/config_split.config_split.site_grad_uiowa_edu.yml
+++ b/config/grad.uiowa.edu/config_split.config_split.site_grad_uiowa_edu.yml
@@ -9,7 +9,8 @@ folder: ../config/grad.uiowa.edu
 module:
   book: 0
 theme: {  }
-blacklist: {  }
+blacklist:
+  - config_split.config_split.site_grad_uiowa_edu
 graylist: {  }
 graylist_dependents: true
 graylist_skip_equal: true

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -1373,3 +1373,17 @@ function sitenow_update_8036() {
     ->clear('uids_base.layout')
     ->save();
 }
+
+/**
+ * Deactivate the grad site split from every site except grad.uiowa.edu.
+ */
+function sitenow_update_8037() {
+  if (\Drupal::service('site.path') != 'sites/grad.uiowa.edu') {
+    \Drupal::configFactory()
+      ->getEditable('config_split.config_split.site_grad_uiowa_edu.settings')
+      ->set('status', FALSE)
+      ->save();
+  }
+
+  drupal_flush_all_caches();
+}

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -1380,7 +1380,7 @@ function sitenow_update_8036() {
 function sitenow_update_8037() {
   if (\Drupal::service('site.path') != 'sites/grad.uiowa.edu') {
     \Drupal::configFactory()
-      ->getEditable('config_split.config_split.site_grad_uiowa_edu.settings')
+      ->getEditable('config_split.config_split.site_grad_uiowa_edu')
       ->set('status', FALSE)
       ->save();
   }


### PR DESCRIPTION
#2373 exported the grad site split config into the default config and activated it. We should be able to move it to the grad split directory. I'm having trouble exporting things correctly locally.

### Testing
`blt dsa`