### PR TITLE
Headline field fix

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/src/Plugin/Field/FieldFormatter/UiowaHeadlineFormatter.php
+++ b/docroot/modules/custom/layout_builder_custom/src/Plugin/Field/FieldFormatter/UiowaHeadlineFormatter.php
@@ -31,12 +31,14 @@ class UiowaHeadlineFormatter extends FormatterBase {
         'headline_bold_serif_underline' => 'headline bold-headline bold-headline--serif bold-headline--underline',
       ];
       $hidden = ($item->get('hide_headline')->getValue()) ? ' sr-only' : '';
+      $item_style = isset($styles[$item->get('headline_style')->getValue()]) ?
+        $styles[$item->get('headline_style')->getValue()] . $hidden : $hidden;
 
       $element[$delta] = [
         '#theme' => 'uiowa_headline_field_type',
         '#text' => strip_tags($item->get('headline')->getValue()),
         '#size' => $item->get('heading_size')->getValue(),
-        '#styles' => $styles[$item->get('headline_style')->getValue()] . $hidden,
+        '#styles' => $item_style,
       ];
     }
 

--- a/docroot/themes/custom/uids_base/templates/layout/page.html.twig
+++ b/docroot/themes/custom/uids_base/templates/layout/page.html.twig
@@ -54,6 +54,7 @@
   {% set content_classes = content_classes|merge(['content__container']) %}
 {% else %}
   {{ attach_library('uids_base/sitenow') }}
+  {% set content_classes = content_classes|merge(['page__container']) %}
   {# Add sticky classes #}
   {% if sticky_classes %}
     {% set content_classes = content_classes|merge(sticky_classes) %}

--- a/docroot/themes/custom/uids_base/templates/layout/page.html.twig
+++ b/docroot/themes/custom/uids_base/templates/layout/page.html.twig
@@ -54,7 +54,6 @@
   {% set content_classes = content_classes|merge(['content__container']) %}
 {% else %}
   {{ attach_library('uids_base/sitenow') }}
-  {% set content_classes = content_classes|merge(['page__container']) %}
   {# Add sticky classes #}
   {% if sticky_classes %}
     {% set content_classes = content_classes|merge(sticky_classes) %}


### PR DESCRIPTION
In testing another PR, ran into an error on local copy of https://folland.lab.uiowa.edu/ -- undefined index in UiowaHeadlineFormatter.php.

This is a quick fix that checks the style option is available as an index, and skips if not.

# Test
`blt ds --site=folland.lab.uiowa.edu`
`drush @labfolland.local uli`
Go to homepage, check that there are no index errors
Create a block with a headline field (Articles, Text Area, etc.) and check that it saves and that any applied headline styles are functioning correctly)