### PR TITLE
Enable Chosen for config-split admin forms

### DIFF
--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -334,9 +334,16 @@ function sitenow_form_views_form_administerusersbyrole_people_page_1_alter(&$for
 function sitenow_form_config_split_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Enable themes to be blacklisted.
   $form['blacklist_fieldset']['theme']['#access'] = TRUE;
-  if (!\Drupal::state()->get('config_split_use_select')) {
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_prepare_form().
+ */
+function sitenow_config_split_prepare_form(EntityInterface $entity, $operation, FormStateInterface $form_state) {
+  // Set a state variable to ensure config_split uses our Chosen
+  // select implementation instead of checkboxes.
+  if ($operation == 'edit' && !\Drupal::state()->get('config_split_use_select')) {
     \Drupal::state()->set('config_split_use_select', TRUE);
-    header('Refresh:0');
   }
 }
 

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -334,6 +334,10 @@ function sitenow_form_views_form_administerusersbyrole_people_page_1_alter(&$for
 function sitenow_form_config_split_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Enable themes to be blacklisted.
   $form['blacklist_fieldset']['theme']['#access'] = TRUE;
+  if (!\Drupal::state()->get('config_split_use_select')) {
+    \Drupal::state()->set('config_split_use_select', TRUE);
+    header('Refresh:0');
+  }
 }
 
 /**

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -342,7 +342,7 @@ function sitenow_form_config_split_edit_form_alter(&$form, FormStateInterface $f
 function sitenow_config_split_prepare_form(EntityInterface $entity, $operation, FormStateInterface $form_state) {
   // Set a state variable to ensure config_split uses our Chosen
   // select implementation instead of checkboxes.
-  if ($operation == 'edit' && !\Drupal::state()->get('config_split_use_select')) {
+  if (!\Drupal::state()->get('config_split_use_select')) {
     \Drupal::state()->set('config_split_use_select', TRUE);
   }
 }


### PR DESCRIPTION
# Problem
Config split edit forms were using checkboxes, which then would not utilize the handy Chosen.js, making using the UI to edit config splits more cumbersome.

Resolves #2385 

# Test
`git pull`
Log into a local site.
Visit an edit form off of /admin/config/development/configuration/config-split
Check that form fields (such as "Modules" under the "Complete Split") appear as select fields with the select list appearing on click.
Save the form and check that any changes were saved correctly.

# Followup
This is a bug fix to allow easier use of the admin form, but doesn't address the fact that Chosen has been deprecated. A followup issue should be created to account for the deprecation, possibly to switch to Select2, but that change is a bigger haul, and not necessary to fix this bug.