### PR TITLE
Globally add pipe character | between University of Iowa and Site Tit…

### DIFF
--- a/config/default/metatag.metatag_defaults.global.yml
+++ b/config/default/metatag.metatag_defaults.global.yml
@@ -9,7 +9,7 @@ label: Global
 tags:
   shortlink: '[current-page:url:unaliased]'
   referrer: no-referrer-when-downgrade
-  title: '[current-page:title] | [site:name] - The University of Iowa'
+  title: '[current-page:title] | [site:name] | The University of Iowa'
   robots: 'index, follow'
   canonical_url: '[current-page:url:absolute]'
   apple_touch_icon: /profiles/custom/sitenow/assets/apple-touch-icon-60x60.png


### PR DESCRIPTION
Fixes #2348. 

Went into default site code and globally changed the "-" to a "|". 

It passed testing on the default site.
