### PR TITLE
Update Draggableviews

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
         "drupal/default_content": "^2.0",
         "drupal/devel": "^2.1",
         "drupal/diff": "^1.0@RC",
-        "drupal/draggableviews": "^1.2",
+        "drupal/draggableviews": "^2.0",
         "drupal/editor_advanced_link": "^1.4",
         "drupal/entity_browser": "^2.4.0",
         "drupal/entity_embed": "^1.0@RC",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c80eec5561020f49686271466f3deb02",
+    "content-hash": "878f2e4325c7d3c3cfa14d4cbf54770a",
     "packages": [
         {
             "name": "acquia/blt",
@@ -222,7 +222,7 @@
             "version": "5.15.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/FortAwesome/Font-Awesome.git",
+                "url": "git@github.com:FortAwesome/Font-Awesome.git",
                 "reference": "57005cea6da7d1c67f3466974aecd25485f60452"
             },
             "dist": {
@@ -4161,20 +4161,20 @@
         },
         {
             "name": "drupal/draggableviews",
-            "version": "1.2.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/draggableviews.git",
-                "reference": "8.x-1.2"
+                "reference": "2.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/draggableviews-8.x-1.2.zip",
-                "reference": "8.x-1.2",
-                "shasum": "0f5e9195ceec209552aa50f8ce3c230692c284db"
+                "url": "https://ftp.drupal.org/files/projects/draggableviews-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "3796f0e478c8119dcd10e1d114c5fcf4492b8a1c"
             },
             "require": {
-                "drupal/core": "*"
+                "drupal/core": "^8 || ^9"
             },
             "require-dev": {
                 "drupal/draggableviews_demo": "*"
@@ -4182,8 +4182,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.2",
-                    "datestamp": "1541518680",
+                    "version": "2.0.0",
+                    "datestamp": "1592329896",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
Resolves #2416 and is D9 ready

It is working now. Before the "show" button did nothing. Adjustments to the weights can be made and the preferences are saved.

<img width="451" alt="Screen Shot 2020-10-29 at 10 49 43 AM" src="https://user-images.githubusercontent.com/4663676/97598169-a52ec900-19d4-11eb-9437-f70bdb61a345.png">


## ToDo
- [x] Remove CSS override in https://github.com/uiowa/uiowa/pull/2401
- [x] Remove known issue once merged