### PR TITLE
Update to latest 1.x Composer version in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
   - phpenv config-rm xdebug.ini
   - yes | pecl install memcache
   - composer self-update
+  - composer global require hirak/prestissimo
 
 install:
   - nvm install 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ before_install:
   - phpenv config-rm xdebug.ini
   - yes | pecl install memcache
   - composer self-update
-  - composer global require hirak/prestissimo
 
 install:
   - nvm install 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - chmod 600 $HOME/.ssh/id_rsa
   - phpenv config-rm xdebug.ini
   - yes | pecl install memcache
-  - composer self-update
+  - composer self-update --1
   - composer global require hirak/prestissimo
 
 install:


### PR DESCRIPTION
Composer 2 is out but there is other work needed to upgrade to it. This is a hotfix for failing CI builds to stick with Composer 1 short term.