### PR TITLE
Add related SSL domains to UMC output.

### DIFF
--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -618,7 +618,7 @@ EOD
 
     // If we did not find any SSL coverage, log an error.
     if (!$has_ssl_coverage) {
-      $this->logger->error("No SSL coverage found on any application for {$host}. Be sure to install new SSL certificate before updating DNS.");
+      $this->logger->error("No SSL coverage found on any application for {$host}. Be sure to check existing SSL certificates for related domains and install a new one before updating DNS.");
     }
 
     $app = $this->askChoice('Which cloud application should be used?', array_keys($applications));

--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -545,7 +545,15 @@ EOD
     $certificates = new SslCertificates($client);
 
     $table = new Table($this->output);
-    $table->setHeaders(['Application', 'DBs', 'SANs', 'SSL - Coverage', 'SSL - Related Domains']);
+
+    $table->setHeaders([
+      'Application',
+      'DBs',
+      'SANs',
+      'SSL - Coverage',
+      'SSL - Related Domains'
+    ]);
+
     $rows = [];
 
     // A boolean to track whether any application covers this domain.

--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -565,7 +565,8 @@ EOD
     $host_parts = explode('.', $host, 2);
     $sans_search = '*.' . $host_parts[1];
 
-    // Consider the parent domain related and search for it.
+    // Consider the parent domain related and search for it since it could
+    // be covered with one SSL SAN while double subdomains cannot.
     $related_search = $host_parts[1];
 
     // If the host is one subdomain off uiowa.edu or a vanity domain,

--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -545,7 +545,7 @@ EOD
     $certificates = new SslCertificates($client);
 
     $table = new Table($this->output);
-    $table->setHeaders(['Application', 'DBs', 'SANs', 'SSL Coverage']);
+    $table->setHeaders(['Application', 'DBs', 'SANs', 'SSL - Coverage', 'SSL - Related Domains']);
     $rows = [];
 
     // A boolean to track whether any application covers this domain.
@@ -556,6 +556,9 @@ EOD
     // Ex. foo.bar.baz.uiowa.edu -> search for *.bar.baz.uiowa.edu.
     $host_parts = explode('.', $host, 2);
     $sans_search = '*.' . $host_parts[1];
+
+    // Consider the parent domain related and search for it.
+    $related_search = $host_parts[1];
 
     // If the host is one subdomain off uiowa.edu or a vanity domain,
     // search for the host instead.
@@ -569,6 +572,9 @@ EOD
       $row = [];
       $row[] = $name;
       $row[] = count($databases->getAll($uuid));
+
+      // Reset related domains for this application.
+      $related = '';
 
       $envs = $environments->getAll($uuid);
 
@@ -587,6 +593,10 @@ EOD
                     $has_ssl_coverage = TRUE;
                     break;
                   }
+
+                  if ($domain == $related_search) {
+                    $related .= $domain;
+                  }
                 }
               }
             }
@@ -594,6 +604,12 @@ EOD
         }
       }
 
+      // Append an empty string so related domains go in the next column.
+      if (!$has_ssl_coverage) {
+        $row[] = '';
+      }
+
+      $row[] = $related;
       $rows[] = $row;
     }
 


### PR DESCRIPTION
Relates to #2496, #2495 

The `blt umc` command does not indicate any related domains that should dictate where a new site should go. This is problematic because the assumption is to put the site on the app with the fewest DBs. This PR adds really quick and basic related domain searching to UMC.

### Testing
Run a few phony sites through the command and then abort.

- blt umc lhpdc.law.uiowa.edu
- blt umc foo.tracers.physics.uiowa.edu
- blt umc foo.pharmacy.uiowa.edu