### PR TITLE
Feature: webform and text area block styles

### DIFF
--- a/config/default/layout_builder_styles.style.block_alignment_center.yml
+++ b/config/default/layout_builder_styles.style.block_alignment_center.yml
@@ -9,6 +9,6 @@ label: Center
 classes: 'element--center '
 type: component
 group: alignment
-weight: -37
+weight: -38
 block_restrictions:
   - 'inline_block:uiowa_spacer_separator'

--- a/config/default/layout_builder_styles.style.block_alignment_flex_row_center.yml
+++ b/config/default/layout_builder_styles.style.block_alignment_flex_row_center.yml
@@ -9,7 +9,7 @@ label: 'Flex row center'
 classes: 'element--flex-center '
 type: component
 group: alignment
-weight: -36
+weight: -37
 block_restrictions:
   - 'inline_block:uiowa_cta'
   - 'inline_block:uiowa_statistic'

--- a/config/default/layout_builder_styles.style.block_alignment_flex_row_left.yml
+++ b/config/default/layout_builder_styles.style.block_alignment_flex_row_left.yml
@@ -9,6 +9,6 @@ label: 'Flex row left'
 classes: element--flex-left
 type: component
 group: alignment
-weight: -35
+weight: -36
 block_restrictions:
   - 'inline_block:uiowa_statistic'

--- a/config/default/layout_builder_styles.style.block_alignment_left.yml
+++ b/config/default/layout_builder_styles.style.block_alignment_left.yml
@@ -9,6 +9,6 @@ label: Left
 classes: element--left
 type: component
 group: alignment
-weight: -34
+weight: -35
 block_restrictions:
   - 'inline_block:uiowa_cta'

--- a/config/default/layout_builder_styles.style.block_background_style_black.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_black.yml
@@ -9,7 +9,7 @@ label: Black
 classes: bg--black
 type: component
 group: background
-weight: -33
+weight: -34
 block_restrictions:
   - 'inline_block:uiowa_banner'
   - 'inline_block:uiowa_cta'

--- a/config/default/layout_builder_styles.style.block_background_style_brain_pattern.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_brain_pattern.yml
@@ -9,6 +9,6 @@ label: 'Brain pattern'
 classes: bg-pattern--brain
 type: component
 group: background
-weight: -31
+weight: -32
 block_restrictions:
   - 'inline_block:uiowa_banner'

--- a/config/default/layout_builder_styles.style.block_background_style_brain_pattern_black.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_brain_pattern_black.yml
@@ -7,7 +7,7 @@ label: 'Brain pattern black'
 classes: bg-pattern--brain-black
 type: component
 group: background
-weight: -30
+weight: -31
 block_restrictions:
   - 'inline_block:uiowa_banner'
   - 'inline_block:uiowa_cta'

--- a/config/default/layout_builder_styles.style.block_background_style_brain_pattern_reversed.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_brain_pattern_reversed.yml
@@ -9,6 +9,6 @@ label: 'Brain pattern reversed'
 classes: bg-pattern--brain-reversed
 type: component
 group: background
-weight: -29
+weight: -30
 block_restrictions:
   - 'inline_block:uiowa_banner'

--- a/config/default/layout_builder_styles.style.block_background_style_gold.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_gold.yml
@@ -9,7 +9,7 @@ label: Gold
 classes: bg--gold
 type: component
 group: background
-weight: -28
+weight: -29
 block_restrictions:
   - 'inline_block:uiowa_banner'
   - 'inline_block:uiowa_cta'

--- a/config/default/layout_builder_styles.style.block_background_style_gray.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_gray.yml
@@ -9,9 +9,10 @@ label: Gray
 classes: bg--gray
 type: component
 group: background
-weight: -27
+weight: -28
 block_restrictions:
+  - 'inline_block:uiowa_banner'
   - 'inline_block:uiowa_cta'
   - 'inline_block:uiowa_card'
   - 'inline_block:uiowa_text_area'
-  - 'inline_block:uiowa_banner'
+  - webform_block

--- a/config/default/layout_builder_styles.style.block_background_style_light.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_light.yml
@@ -7,7 +7,7 @@ label: White
 classes: bg--light
 type: component
 group: background
-weight: -32
+weight: -33
 block_restrictions:
   - 'inline_block:uiowa_banner'
   - 'inline_block:uiowa_spacer_separator'

--- a/config/default/layout_builder_styles.style.block_card_style_border.yml
+++ b/config/default/layout_builder_styles.style.block_card_style_border.yml
@@ -9,6 +9,6 @@ label: 'Card: Border'
 classes: card--enclosed
 type: component
 group: null
-weight: -26
+weight: -27
 block_restrictions:
   - 'inline_block:uiowa_card'

--- a/config/default/layout_builder_styles.style.block_heading_bold_headline.yml
+++ b/config/default/layout_builder_styles.style.block_heading_bold_headline.yml
@@ -9,6 +9,6 @@ label: 'Heading: Bold headline'
 classes: bold-headline--positive
 type: component
 group: null
-weight: -17
+weight: -18
 block_restrictions:
   - 'inline_block:uiowa_heading'

--- a/config/default/layout_builder_styles.style.block_image_gallery_style_masonry.yml
+++ b/config/default/layout_builder_styles.style.block_image_gallery_style_masonry.yml
@@ -7,6 +7,6 @@ label: 'Image gallery: Masonry'
 classes: image-gallery--masonry
 type: component
 group: null
-weight: -16
+weight: -17
 block_restrictions:
   - 'inline_block:uiowa_image_gallery'

--- a/config/default/layout_builder_styles.style.block_margin_bottom.yml
+++ b/config/default/layout_builder_styles.style.block_margin_bottom.yml
@@ -9,7 +9,8 @@ label: Bottom
 classes: block-margin__bottom
 type: component
 group: margin
-weight: -15
+weight: -16
 block_restrictions:
   - 'inline_block:uiowa_spacer_separator'
   - 'inline_block:uiowa_text_area'
+  - webform_block

--- a/config/default/layout_builder_styles.style.block_margin_left.yml
+++ b/config/default/layout_builder_styles.style.block_margin_left.yml
@@ -9,7 +9,8 @@ label: Left
 classes: block-margin__left
 type: component
 group: margin
-weight: -14
+weight: -15
 block_restrictions:
   - 'inline_block:uiowa_spacer_separator'
   - 'inline_block:uiowa_text_area'
+  - webform_block

--- a/config/default/layout_builder_styles.style.block_margin_right.yml
+++ b/config/default/layout_builder_styles.style.block_margin_right.yml
@@ -9,7 +9,8 @@ label: Right
 classes: block-margin__right
 type: component
 group: margin
-weight: -13
+weight: -14
 block_restrictions:
   - 'inline_block:uiowa_spacer_separator'
   - 'inline_block:uiowa_text_area'
+  - webform_block

--- a/config/default/layout_builder_styles.style.block_margin_top.yml
+++ b/config/default/layout_builder_styles.style.block_margin_top.yml
@@ -9,7 +9,8 @@ label: Top
 classes: block-margin__top
 type: component
 group: margin
-weight: -12
+weight: -13
 block_restrictions:
   - 'inline_block:uiowa_spacer_separator'
   - 'inline_block:uiowa_text_area'
+  - webform_block

--- a/config/default/layout_builder_styles.style.block_menu_horizontal.yml
+++ b/config/default/layout_builder_styles.style.block_menu_horizontal.yml
@@ -7,7 +7,7 @@ label: 'Menu: Horizontal'
 classes: "nav \r\nmain--secondary--horizontal"
 type: component
 group: null
-weight: -11
+weight: -12
 block_restrictions:
   - 'system_menu_block:main'
   - 'menu_block:main'

--- a/config/default/layout_builder_styles.style.block_menu_vertical.yml
+++ b/config/default/layout_builder_styles.style.block_menu_vertical.yml
@@ -7,7 +7,7 @@ label: 'Menu: Vertical'
 classes: "nav \r\nmain--secondary--vertical"
 type: component
 group: null
-weight: -10
+weight: -11
 block_restrictions:
   - 'system_menu_block:main'
   - 'menu_block:main'

--- a/config/default/layout_builder_styles.style.block_padding_all.yml
+++ b/config/default/layout_builder_styles.style.block_padding_all.yml
@@ -9,6 +9,7 @@ label: 'All sides'
 classes: block-padding__all
 type: component
 group: padding
-weight: -9
+weight: -10
 block_restrictions:
   - 'inline_block:uiowa_text_area'
+  - webform_block

--- a/config/default/layout_builder_styles.style.block_padding_all_extra.yml
+++ b/config/default/layout_builder_styles.style.block_padding_all_extra.yml
@@ -1,0 +1,13 @@
+uuid: 61da365a-b863-4637-a581-e72c1318844a
+langcode: en
+status: true
+dependencies: {  }
+id: block_padding_all_extra
+label: 'All sides extra'
+classes: block-padding__all--extra
+type: component
+group: padding
+weight: -9
+block_restrictions:
+  - 'inline_block:uiowa_text_area'
+  - webform_block

--- a/config/default/layout_builder_styles.style.card_image_large.yml
+++ b/config/default/layout_builder_styles.style.card_image_large.yml
@@ -7,6 +7,6 @@ label: Large
 classes: card__media--large
 type: component
 group: card_image_size
-weight: -22
+weight: -23
 block_restrictions:
   - 'inline_block:uiowa_card'

--- a/config/default/layout_builder_styles.style.card_image_medium.yml
+++ b/config/default/layout_builder_styles.style.card_image_medium.yml
@@ -7,6 +7,6 @@ label: Medium
 classes: card__media--medium
 type: component
 group: card_image_size
-weight: -21
+weight: -22
 block_restrictions:
   - 'inline_block:uiowa_card'

--- a/config/default/layout_builder_styles.style.card_image_small.yml
+++ b/config/default/layout_builder_styles.style.card_image_small.yml
@@ -7,6 +7,6 @@ label: Small
 classes: card__media--small
 type: component
 group: card_image_size
-weight: -20
+weight: -21
 block_restrictions:
   - 'inline_block:uiowa_card'

--- a/config/default/layout_builder_styles.style.card_media_position_left.yml
+++ b/config/default/layout_builder_styles.style.card_media_position_left.yml
@@ -7,6 +7,6 @@ label: Left
 classes: card--media-left
 type: component
 group: card_media_position
-weight: -24
+weight: -25
 block_restrictions:
   - 'inline_block:uiowa_card'

--- a/config/default/layout_builder_styles.style.card_media_position_right.yml
+++ b/config/default/layout_builder_styles.style.card_media_position_right.yml
@@ -7,6 +7,6 @@ label: Right
 classes: card--media-right
 type: component
 group: card_media_position
-weight: -23
+weight: -24
 block_restrictions:
   - 'inline_block:uiowa_card'

--- a/config/default/layout_builder_styles.style.card_media_position_stacked.yml
+++ b/config/default/layout_builder_styles.style.card_media_position_stacked.yml
@@ -7,6 +7,6 @@ label: 'Stacked (default)'
 classes: card--stacked
 type: component
 group: card_media_position
-weight: -25
+weight: -26
 block_restrictions:
   - 'inline_block:uiowa_card'

--- a/config/default/layout_builder_styles.style.content_alignment_center.yml
+++ b/config/default/layout_builder_styles.style.content_alignment_center.yml
@@ -7,6 +7,6 @@ label: Center
 classes: "card--centered\r\ncard--alignment-center"
 type: component
 group: content_alignment
-weight: -19
+weight: -20
 block_restrictions:
   - 'inline_block:uiowa_card'

--- a/config/default/layout_builder_styles.style.content_alignment_left.yml
+++ b/config/default/layout_builder_styles.style.content_alignment_left.yml
@@ -7,6 +7,6 @@ label: 'Left (default)'
 classes: "card--centered-left\r\ncard--alignment-left"
 type: component
 group: content_alignment
-weight: -18
+weight: -19
 block_restrictions:
   - 'inline_block:uiowa_card'

--- a/docroot/themes/custom/uids_base/scss/admin.scss
+++ b/docroot/themes/custom/uids_base/scss/admin.scss
@@ -247,6 +247,14 @@ form#node-page-layout-builder-form {
     padding: $gutter 0;
   }
 
+  &.block-padding__all--extra {
+    padding: 6rem;
+  }
+
+  &.block-padding__all {
+    padding: 3rem;
+  }
+
   &.bg--gray {
     background: $light;
   }

--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -113,6 +113,10 @@ $imgpath: '../../uids/assets/images';
     &[class*="bg-pattern--"] {
       padding: $desktop-width-gutter;
     }
+    &[class*="bg--"].block-padding__all--extra,
+    &[class*="bg-pattern--"].block-padding__all--extra {
+      padding: 6rem;
+    }
   }
 }
 

--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -213,6 +213,9 @@ body:not(.page-node-type-article, .page-node-type-page).layout-builder-disabled 
   &__all {
     padding: $desktop-width-gutter;
   }
+  &__all--extra {
+    padding: 6rem;
+  }
 }
 
 .block-margin {


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/2492 and resolves https://github.com/uiowa/uiowa/issues/2386. 

Added functionality to add background color and spacing to a webform block. 

<img width="1744" alt="Screen Shot 2020-11-06 at 4 21 51 PM" src="https://user-images.githubusercontent.com/1036433/98420603-2c231780-204d-11eb-9251-49f6a1cea41b.png">

# How to test

- Text area block should have new padding option for "All sides extra" and apply `6rem` padding:

<img width="470" alt="Screen Shot 2020-11-06 at 4 33 42 PM" src="https://user-images.githubusercontent.com/1036433/98420995-fe8a9e00-204d-11eb-9de0-72ac1bd4c8d2.png">


- Webform block should have all of the display options that the text area block has listed below:

<img width="479" alt="Screen Shot 2020-11-06 at 10 27 55 AM" src="https://user-images.githubusercontent.com/1036433/98421003-034f5200-204e-11eb-8765-2db3af79f7f7.png">