### PR TITLE
Feature: Banner background image fix

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/banner.scss
+++ b/docroot/themes/custom/uids_base/scss/components/banner.scss
@@ -211,9 +211,13 @@
 }
 
 
-// Remove contextual position for logged in view of banner image
 .banner__image {
   .contextual-region {
+    // Remove contextual position for logged in view of banner image
     position: unset;
+  }
+  .field--name-field-media-image img {
+    // Override height:auto set in media--type-image.scss
+    height: 100%;
   }
 }


### PR DESCRIPTION
Resolves: https://github.com/uiowa/uiowa/issues/2491. 

# How to test

- `blt ds --site=presidentialsearch.uiowa.edu`
- Verify that background image height on home page banner image covers 100% of banner height