### PR TITLE
Updated default menu path pattern to reflect parent path properly.

### DIFF
--- a/config/default/pathauto.pattern.menu_path.yml
+++ b/config/default/pathauto.pattern.menu_path.yml
@@ -9,7 +9,7 @@ _core:
 id: menu_path
 label: 'Menu path'
 type: 'canonical_entities:node'
-pattern: '[node:menu-link:parents:join-path]/[node:title]'
+pattern: '[node:menu-link:parent:url:path]/[node:title]'
 selection_criteria: {  }
 selection_logic: and
 weight: 0


### PR DESCRIPTION
Updated default menu path pattern to reflect parent path properly. Parent paths were not using custom paths set in nodes when creating child pages underneath these pages.

By setting pathauto pattern to [node:menu-link:parent:url:path]/[node:title], this seems to have fixed this issue.

# How to test

- Set a custom path on any node.
- Create basic page child and grandchild nodes underneath this parent node, using any mixture of custom and automatic URL aliases.
- Make sure proper paths are getting set if automatic URL alias is used, reflecting any custom parent paths.
