### PR TITLE
fix for mismatched entity errors related to person type

### DIFF
--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -1533,3 +1533,15 @@ function sitenow_update_8039() {
     }
   }
 }
+
+/**
+ * Install person type configuration entity (existing module).
+ */
+function sitenow_update_8040() {
+  $type_manager = \Drupal::entityTypeManager();
+  $type_manager->clearCachedDefinitions();
+  $entity_type = $type_manager->getDefinition('person_type');
+  \Drupal::entityDefinitionUpdateManager()->installEntityType($entity_type);
+
+  return t('Installed the person_type entity type');
+}


### PR DESCRIPTION
# To Test
- See mismatched entity errors related to person type in the status report of an existing site.
- pull, ds (update hook), login to view status report. Related error should be gone.
- Use the person type functionality (create a person type, edit existing) to make sure there are no issues with saving/etc.