### PR TITLE
Fixed headline display for image gallery block

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/typography/headings.scss
+++ b/docroot/themes/custom/uids_base/scss/components/typography/headings.scss
@@ -23,6 +23,7 @@ body:not(.page-node-type-article, .page-node-type-page) #block-uids-base-page-ti
 .headline.headline--parent {
   font-size: 2.2rem;
   margin-bottom: 2rem;
+  flex-basis: 100%;
 
   .layout--onecol & {
     font-size: 2.3rem;

--- a/docroot/themes/custom/uids_base/scss/components/typography/headings.scss
+++ b/docroot/themes/custom/uids_base/scss/components/typography/headings.scss
@@ -23,7 +23,6 @@ body:not(.page-node-type-article, .page-node-type-page) #block-uids-base-page-ti
 .headline.headline--parent {
   font-size: 2.2rem;
   margin-bottom: 2rem;
-  flex-basis: 100%;
 
   .layout--onecol & {
     font-size: 2.3rem;

--- a/docroot/themes/custom/uids_base/templates/block/block--inline-block--uiowa-image-gallery.html.twig
+++ b/docroot/themes/custom/uids_base/templates/block/block--inline-block--uiowa-image-gallery.html.twig
@@ -32,25 +32,11 @@
     'block-' ~ plugin_id|clean_class,
   ]
 %}
+{{ content.field_uiowa_headline }}
 <div{{ attributes.addClass(classes) }}>
   {{ title_prefix }}
-
-  {% block heading %}
-    {% if content.field_uiowa_gallery_title[0]['#text'] is not empty %}
-      <div class="cta__title">
-      {% include '@uids_base/uids/headline.html.twig' with {
-        "headline_level" : content.field_uiowa_gallery_title[0]['#size'],
-        "headline_class" : 'bold-headline bold-headline--caps',
-        "headline_text" : content.field_uiowa_gallery_title[0]['#text']
-      } %}
-      </div>
-    {% endif %}
-  {% endblock %}
-
   {{ title_suffix }}
   <div class="uiowa-image-gallery">
-  {% block content %}
-    {{ content }}
-  {% endblock %}
+    {{ content|without('field_uiowa_headline') }}
   </div>
 </div>


### PR DESCRIPTION
Closes #2419 

# How to test
1. install default site (blt drupal:install --site=default)
2. Run `blt frontend`
3. Add an image gallery block with a headline and choose the bold, highlighted styling option
4. Inspect the HTML of the image gallery element on the page that is opened up and observe that the headline element is rendered outside the image gallery block. Make sure displays correctly.