### PR TITLE
Fixed Tour button contrast issue

### DIFF
--- a/docroot/themes/custom/uids_base/scss/admin.scss
+++ b/docroot/themes/custom/uids_base/scss/admin.scss
@@ -968,14 +968,18 @@ ul.dropbutton li {
 // Set above admin toolbar and superfish.
 .joyride-tip-guide {
   z-index: 550;
+  
+  a {
+    background: transparent;
 
-  a.btn.btn-primary.btn-block {
-    color: $secondary;
-    margin-bottom: $md;
-
-    &:hover,
-    &:focus {
+    .btn.btn-primary.btn-block {
       color: $secondary;
+      margin-bottom: $md;
+
+      &:hover,
+      &:focus {
+        color: $secondary;
+      }
     }
   }
 }


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->
Closes #2480 
Set tour button background to transparent. Works for v2 and v3 sites

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test
1. Install a default v2 site (ex: michaelewright.lab.uiowa.edu)
2. Run `blt frontend`
3. View a tour on a page (http://labmichaelewright.local.drupal.uiowa.edu/areas-exploration) and make sure the 'Next' button has a transparent background
<!-- Include detailed steps for how to test this PR. -->
