### PR TITLE
update todo comments based on updated coding standards

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -303,8 +303,8 @@ function _layout_builder_custom_block_submit(array &$form, FormStateInterface $f
         if ($background_option === 'image') {
           if (!$form_state->getValue($form_media_selection)) {
             // If an image wasn't uploaded, revert to default of 'black'.
-            // @todo: Add feedback for user that they didn't upload an image.
-            // @todo: Add validation to check whether image uploaded or not.
+            // @todo Add feedback for user that they didn't upload an image.
+            // @todo Add validation to check whether image uploaded or not.
             $background_option = 'block_background_style_black';
           }
 

--- a/docroot/modules/custom/sitenow_events/sitenow_events.module
+++ b/docroot/modules/custom/sitenow_events/sitenow_events.module
@@ -245,7 +245,7 @@ function sitenow_events_format_instance(array $event_instance) {
 /**
  * Implements hook_field_widget_WIDGET_TYPE_form_alter().
  *
- * @todo: Remove this after sitenow_events_paragraph is uninstalled.
+ * @todo Remove this after sitenow_events_paragraph is uninstalled.
  */
 function sitenow_events_field_widget_paragraphs_form_alter(&$element, &$form_state, $context) {
   if ($element['#paragraph_type'] == 'events') {
@@ -387,7 +387,7 @@ function _sitenow_events_get_filter_field_options(FieldStorageConfig $definition
  * @return array
  *   Returns an associative array options tree.
  *
- * @todo: Replace with an API endpoint that outputs an entire vocabulary tree.
+ * @todo Replace with an API endpoint that outputs an entire vocabulary tree.
  */
 function _sitenow_events_build_options_tree(array $data, $parent = 0) {
   $tree = [];
@@ -421,7 +421,7 @@ function _sitenow_events_build_options_tree(array $data, $parent = 0) {
  * @return array
  *   Returns options with children prefixed with dashes.
  *
- * @todo: Replace with an API endpoint that outputs an entire vocabulary tree.
+ * @todo Replace with an API endpoint that outputs an entire vocabulary tree.
  */
 function _sitenow_events_build_options_list(array $tree, $r = 0, $p = NULL, array &$options = []) {
   foreach ($tree as $t) {

--- a/docroot/modules/custom/uiowa_alerts/src/Form/SettingsForm.php
+++ b/docroot/modules/custom/uiowa_alerts/src/Form/SettingsForm.php
@@ -73,7 +73,7 @@ class SettingsForm extends ConfigFormBase {
       ],
     ];
 
-    // @todo: Figure out why required state results in console error on submit.
+    // @todo Figure out why required state results in console error on submit.
     $form['custom_alert_message'] = [
       '#type' => 'text_format',
       '#title' => $this->t('Custom Alert Message'),

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -82,7 +82,7 @@ function sitenow_preprocess_select(&$variables) {
  */
 function sitenow_module_implements_alter(&$implementations, $hook) {
   // Unset administerusersbyrole query alter which over-filters the people page.
-  // @todo: Refactor this to move sitenow last and then alter the altered query.
+  // @todo Refactor this to move sitenow last and then alter the altered query.
   if ($hook == 'query_alter' && isset($implementations['administerusersbyrole'])) {
     unset($implementations['administerusersbyrole']);
   }
@@ -910,7 +910,7 @@ function sitenow_toolbar() {
  * @return bool
  *   Boolean indicating whether or not current user is an admin.
  *
- * @todo: Replace this with uiowa_core access checker service.
+ * @todo Replace this with uiowa_core access checker service.
  */
 function sitenow_is_user_admin(AccountProxy $current_user) {
   if ($current_user->id() == 1 || in_array('administrator', $current_user->getRoles())) {
@@ -924,7 +924,7 @@ function sitenow_is_user_admin(AccountProxy $current_user) {
 /**
  * Determine the version of SiteNow based on what config is active.
  *
- * @todo: Return additional information like if any other splits are active that might impact functionality.
+ * @todo Return additional information like if any other splits are active that might impact functionality.
  */
 function sitenow_get_version() {
   $version = 'v3';


### PR DESCRIPTION
Resolves warnings like:

`914 | WARNING | [x] '@todo: Replace this with uiowa_core access checker service.' should match the format '@todo Fix problem X here.'`