### PR TITLE
Do not tag source repository during deployment and outline manual testing steps.

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -18,7 +18,7 @@ git:
     commit-msg: false
     pre-commit: false
 deploy:
-  tag_source: true
+  tag_source: false
 drush:
   aliases:
     ci: self


### PR DESCRIPTION
As per the BLT docs (https://docs.acquia.com/blt/tech-architect/deploy/#create-and-deploy-the-build-artifact), the deploy script will tag the source repository automatically. We don't need this since we tag the source repo ourselves. It also muddies the manual deployment process with another tag.

CI ex. https://travis-ci.com/github/uiowa/uiowa/builds/202525159#L5279

This is also an attempt to outline manual testing steps.

### Testing
#### Replicate Travis
**Note** this will drop your default database.
- `git checkout no-tag-source`
- `vagrant ssh`
- `blt validate:all --no-interaction`
- `blt setup --no-interaction`
- `blt tests:all --no-interaction`
  - See tests/behat/README.md if this fails.

If you have changes to yarn.lock, discard them.

#### Specific to this PR
- Close PHPStorm
- `blt deploy --tag 9.9.9 --commit-msg 'This is a test.' --dry-run`
- `git tag --list 9.9.9`
  - See no tag exists in source repo.
- Delete deploy directory.
