### PR TITLE
Do not generate/update the yarn lock file via blt frontend.

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -46,7 +46,7 @@ validate:
 command-hooks:
   frontend-reqs:
     dir: ${docroot}
-    command: 'yarn install --production --ignore-optional --non-interactive'
+    command: 'yarn install --production --ignore-optional --frozen-lockfile --non-interactive'
   frontend-assets:
     dir: ${docroot}
     command: 'yarn workspaces run build'


### PR DESCRIPTION
PR #2521 introduced devDependencies to two Yarn workspaces. That was required for running `watch` commands locally. Because `blt frontend` will not install devDependencies, the yarn.lock file will be modified after running it. That is the default behavior of `yarn install`.

This PR adds the `--frozen-lockfile` option to the `blt frontend` command alias which will prevent `yarn install` from syncing the yarn.lock file and fail if it is required. https://classic.yarnpkg.com/en/docs/cli/install#toc-yarn-install-frozen-lockfile

The `blt frontend` command alias is essentially production mode, i.e. replicate exactly what is installed for prod. To get devDependencies installed locally, use `yarn install`.

### Testing
- On main, run `blt frontend`.
  - See yarn.lock modification. Discard.
- On this branch, run `blt frontend`.
  - See no yarn.lock modification.