### PR TITLE
Sync up person view display for GC and person_extended

### DIFF
--- a/config/features/person_extended/core.entity_view_display.node.person.default.yml
+++ b/config/features/person_extended/core.entity_view_display.node.person.default.yml
@@ -63,13 +63,13 @@ content:
     region: content
   field_person_contact_information:
     type: entity_reference_revisions_entity_view
-    weight: 13
-    region: content
-    label: above
+    weight: 10
+    label: hidden
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
+    region: content
   field_person_department:
     type: entity_reference_label
     weight: 2
@@ -79,12 +79,12 @@ content:
       link: true
     third_party_settings: {  }
   field_person_education:
-    type: basic_string
-    weight: 12
-    region: content
+    weight: 6
     label: above
     settings: {  }
     third_party_settings: {  }
+    type: basic_string
+    region: content
   field_person_email:
     type: email_mailto
     weight: 3
@@ -157,25 +157,25 @@ content:
     type: string
     region: content
   field_person_research_areas:
-    weight: 17
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
     type: entity_reference_label
+    weight: 7
     region: content
-  field_person_website:
-    weight: 16
     label: above
+    settings:
+      link: false
+    third_party_settings: {  }
+  field_person_website:
+    type: link
+    weight: 4
+    region: content
+    label: inline
     settings:
       trim_length: 80
       url_only: false
       url_plain: false
-      rel: ''
-      target: ''
+      rel: '0'
+      target: '0'
     third_party_settings: {  }
-    type: link_separate
-    region: content
   links:
     weight: 14
     region: content

--- a/config/features/person_extended/core.entity_view_display.node.person.teaser.yml
+++ b/config/features/person_extended/core.entity_view_display.node.person.teaser.yml
@@ -6,7 +6,9 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.person.field_image
     - field.field.node.person.field_person_bio
+    - field.field.node.person.field_person_contact_information
     - field.field.node.person.field_person_credential
+    - field.field.node.person.field_person_education
     - field.field.node.person.field_person_email
     - field.field.node.person.field_person_first_name
     - field.field.node.person.field_person_hide
@@ -20,6 +22,7 @@ dependencies:
     - field.field.node.person.field_person_phone
     - field.field.node.person.field_person_position
     - field.field.node.person.field_person_research_areas
+    - field.field.node.person.field_person_types
     - field.field.node.person.field_person_website
     - field.field.node.person.field_pt_student_current
     - field.field.node.person.field_tags

--- a/config/grad.uiowa.edu/core.entity_view_display.node.person.default.yml
+++ b/config/grad.uiowa.edu/core.entity_view_display.node.person.default.yml
@@ -27,8 +27,10 @@ dependencies:
     - field.field.node.person.field_teaser
     - node.type.person
   module:
+    - entity_reference_revisions
     - link
     - options
+    - telephone
     - text
     - user
 id: node.person.default
@@ -43,7 +45,7 @@ content:
     third_party_settings: {  }
   field_image:
     type: entity_reference_entity_view
-    weight: 1
+    weight: 9
     region: content
     label: hidden
     settings:
@@ -51,24 +53,33 @@ content:
       link: false
     third_party_settings: {  }
   field_person_bio:
-    weight: 9
+    weight: 5
     label: visually_hidden
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
+  field_person_contact_information:
+    type: entity_reference_revisions_entity_view
+    weight: 10
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
   field_person_education:
-    weight: 2
-    label: inline
+    weight: 6
+    label: above
     settings: {  }
     third_party_settings: {  }
     type: basic_string
     region: content
   field_person_email:
     type: email_mailto
-    weight: 6
+    weight: 2
     region: content
-    label: hidden
+    label: inline
     settings: {  }
     third_party_settings: {  }
   field_person_mentor_dept:
@@ -86,15 +97,15 @@ content:
     type: text_default
     region: content
   field_person_phone:
-    weight: 5
-    label: hidden
+    weight: 3
+    label: inline
     settings:
-      link_to_entity: false
+      title: ''
     third_party_settings: {  }
-    type: string
+    type: telephone_link
     region: content
   field_person_position:
-    weight: 3
+    weight: 1
     label: hidden
     settings:
       link_to_entity: false
@@ -132,17 +143,17 @@ content:
     region: content
   field_person_research_areas:
     type: entity_reference_label
-    weight: 8
+    weight: 7
     region: content
-    label: inline
+    label: above
     settings:
       link: false
     third_party_settings: {  }
   field_person_website:
     type: link
-    weight: 7
+    weight: 4
     region: content
-    label: hidden
+    label: inline
     settings:
       trim_length: 80
       url_only: false
@@ -151,12 +162,11 @@ content:
       target: '0'
     third_party_settings: {  }
   links:
-    weight: 15
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
-  field_person_contact_information: true
   field_person_credential: true
   field_person_first_name: true
   field_person_hide: true

--- a/config/grad.uiowa.edu/core.entity_view_display.node.person.teaser.yml
+++ b/config/grad.uiowa.edu/core.entity_view_display.node.person.teaser.yml
@@ -38,7 +38,7 @@ mode: teaser
 content:
   field_image:
     type: entity_reference_entity_view
-    weight: 8
+    weight: 6
     region: content
     label: hidden
     settings:
@@ -55,7 +55,7 @@ content:
     third_party_settings: {  }
   field_person_email:
     type: email_mailto
-    weight: 3
+    weight: 2
     region: content
     label: inline
     settings: {  }
@@ -68,7 +68,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_person_phone:
-    weight: 4
+    weight: 3
     label: inline
     settings:
       title: ''
@@ -79,27 +79,19 @@ content:
     type: string
     weight: 1
     region: content
-    label: hidden
+    label: visually_hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
-  field_person_research_areas:
-    type: entity_reference_label
-    weight: 5
-    region: content
-    label: above
-    settings:
-      link: false
-    third_party_settings: {  }
   field_teaser:
     type: basic_string
-    weight: 6
+    weight: 4
     region: content
     label: hidden
     settings: {  }
     third_party_settings: {  }
   links:
-    weight: 7
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -116,6 +108,7 @@ hidden:
   field_person_project_desc: true
   field_person_project_qualif: true
   field_person_project_undergrad: true
+  field_person_research_areas: true
   field_person_types: true
   field_person_website: true
   field_tags: true

--- a/config/grad.uiowa.edu/field.field.node.person.field_person_mentor_dept.yml
+++ b/config/grad.uiowa.edu/field.field.node.person.field_person_mentor_dept.yml
@@ -11,7 +11,7 @@ id: node.person.field_person_mentor_dept
 field_name: field_person_mentor_dept
 entity_type: node
 bundle: person
-label: 'Department'
+label: Department
 description: ''
 required: true
 translatable: false


### PR DESCRIPTION
Updates `entity_view_display` for person content type in the GC site split and `person_extended` feature split.

# How to test

Since these changes are limited to a site split and a feature split in limited use, I think a file review should suffice.
