### PR TITLE
i2248 - Removed unnecessary padding with narrow container

### DIFF
--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -192,8 +192,6 @@ body:not(.page-node-type-article, .page-node-type-page).layout-builder-disabled 
       @include breakpoint(md) {
         max-width: 63.75em;
         margin: 0 auto;
-        padding-right: $lg;
-        padding-left: $lg;
       }
     }
   }

--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -196,7 +196,8 @@ body:not(.page-node-type-article, .page-node-type-page).layout-builder-disabled 
         padding-left: 1.25rem;
       }
       @include breakpoint(container) {
-        padding: 0;
+        padding-right: 0;
+        padding-left: 0;
       }
     }
   }

--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -192,6 +192,11 @@ body:not(.page-node-type-article, .page-node-type-page).layout-builder-disabled 
       @include breakpoint(md) {
         max-width: 63.75em;
         margin: 0 auto;
+        padding-right: 1.25rem;
+        padding-left: 1.25rem;
+      }
+      @include breakpoint(container) {
+        padding: 0;
       }
     }
   }


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->
Closes #2248 
<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test
1. Install default site
2. blt frontend
3. Add page w/ section using narrow layout styling
4. Add block
5. Save page and inspect
6. Find .layout__spacing-container and make sure side padding is removed
<!-- Include detailed steps for how to test this PR. -->
