### PR TITLE
Remove twig_tweak module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -162,7 +162,6 @@
         "drupal/superfish": "^1.2",
         "drupal/swiftmailer": "^1.0@beta",
         "drupal/theme_permission": "^2.0",
-        "drupal/twig_tweak": "^2.4",
         "drupal/upgrade_status": "^2.0",
         "drupal/views_ical": "^1.0@alpha",
         "drupal/views_tree": "^2.0@alpha",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8bb537a188d56a7dfd875c66f17aa4a",
+    "content-hash": "1cca7a8be801e8a1954a7415b4b49bb7",
     "packages": [
         {
             "name": "acquia/blt",
@@ -8433,59 +8433,6 @@
             "homepage": "https://www.drupal.org/project/token",
             "support": {
                 "source": "https://git.drupalcode.org/project/token"
-            }
-        },
-        {
-            "name": "drupal/twig_tweak",
-            "version": "2.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/twig_tweak.git",
-                "reference": "8.x-2.8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/twig_tweak-8.x-2.8.zip",
-                "reference": "8.x-2.8",
-                "shasum": "11ae232159fc1139e00980736dff39bf2bfcfa6d"
-            },
-            "require": {
-                "drupal/core": "^8.7 || ^9.0",
-                "twig/twig": "^1.41 || ^2.12"
-            },
-            "suggest": {
-                "symfony/var-dumper": "Better dump() function for debugging Twig variables"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-2.8",
-                    "datestamp": "1602156806",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "Chi",
-                    "homepage": "https://www.drupal.org/user/556138"
-                }
-            ],
-            "description": "A Twig extension with some useful functions and filters for Drupal development.",
-            "homepage": "https://www.drupal.org/project/twig_tweak",
-            "keywords": [
-                "Drupal",
-                "Twig"
-            ],
-            "support": {
-                "source": "https://git.drupalcode.org/project/twig_tweak",
-                "issues": "https://www.drupal.org/project/issues/twig_tweak"
             }
         },
         {


### PR DESCRIPTION
Removes the `twig_tweak` module, which is no longer in use.

# How to test

I think it is enough that this passes tests. A search of the config directory results in 0 matches for `twig_tweak`, so it is not reference by the default config or any split.
