### PR TITLE
Academic Units: require at least one entity type

### DIFF
--- a/docroot/modules/custom/uiowa_entities/src/Plugin/Field/FieldWidget/AcademicUnitsWidget.php
+++ b/docroot/modules/custom/uiowa_entities/src/Plugin/Field/FieldWidget/AcademicUnitsWidget.php
@@ -92,13 +92,15 @@ class AcademicUnitsWidget extends WidgetBase implements ContainerFactoryPluginIn
   public function settingsForm(array $form, FormStateInterface $form_state) {
     $element['types'] = [
       '#type' => 'checkboxes',
-      '#title' => $this->t('Which types of academic units should be included?'),
+      '#title' => $this->t('Unit Types'),
+      '#description' => $this->t('Which types of academic units should be included? At least one must be selected.'),
       '#options' => [
         // Options are hardcoded in, but this could be updated
         // to pull available options directly from the config entity.
         'college' => $this->t('Collegiate'),
         'non-collegiate' => $this->t('Non-Collegiate'),
       ],
+      '#required' => TRUE,
       '#default_value' => $this->getSetting('types'),
     ];
     return $element;


### PR DESCRIPTION
Resolves #2627.

Academic Units fieldtype widget allowed selecting zero unit types, which led to an empty selection list. 

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

- Add a new field to a content type, select "Academic Units" under "Reference"
- Under `Manage Form Display` tab, edit the new field's widget settings
- Check the option label and help text for clarity
- Attempt to update to various combinations of 0, 1, or 2 of the available options
  - Check that you cannot update to a selection with 0 checkboxes