### PR TITLE
Specify specific version of memcache to install in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - mv deploy_key $HOME/.ssh/id_rsa
   - chmod 600 $HOME/.ssh/id_rsa
   - phpenv config-rm xdebug.ini
-  - yes | pecl install memcache
+  - yes | pecl install memcache-3.0.8
 
 install:
   - nvm install 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - mv deploy_key $HOME/.ssh/id_rsa
   - chmod 600 $HOME/.ssh/id_rsa
   - phpenv config-rm xdebug.ini
-  - yes | pecl install memcache-3.0.8
+  - yes | pecl install memcache-4.0.5.2
 
 install:
   - nvm install 10


### PR DESCRIPTION
PECL memcache v8 is out which requires PHP 8. Requiring a specific version should get CI running which is using PHP 7.3.