### PR TITLE
Make the section links show up on focus.

### DIFF
--- a/docroot/themes/custom/uids_base/scss/admin.scss
+++ b/docroot/themes/custom/uids_base/scss/admin.scss
@@ -148,6 +148,10 @@ form#node-page-layout-builder-form {
     }
   }
 
+  .layout-builder__link:focus {
+    opacity: 1;
+  }
+
   &__add-block {
     background-color: transparent;
     margin-top: 0;


### PR DESCRIPTION
Small change to make the Layout builder section links show up on focus, which was not happening before.

# How to test
* `blt frontend`
* `blt ds`
* `drush @default.local uli /`
* Click the "Layout" tab.
* To avoid having to tab endlessly, set the focus closer to the test by clicking in the empty space below the "Save Layout" button.
* Tab until you see the "X" and "Configure" links display.