### PR TITLE
Feature: Layout Builder double click block to edit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -123,6 +123,7 @@
         "drupal/layout_builder_lock": "^1.0@RC",
         "drupal/layout_builder_operation_link": "^1.0",
         "drupal/layout_builder_restrictions": "^2.6",
+        "drupal/layout_builder_shortcuts": "1.0.x-dev",
         "drupal/layout_builder_styles": "^1.0@beta",
         "drupal/lazy": "^3.6",
         "drupal/lb_direct_add": "1.x-dev",

--- a/composer.lock
+++ b/composer.lock
@@ -5877,7 +5877,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/layout_builder_shortcuts.git",
-                "reference": "a03aca0d17a0862ce5e6e3db37a049a05946ee52"
+                "reference": "6be2475881da10881c132376dbaffbe4cec65aea"
             },
             "require": {
                 "drupal/core": "^8.8 || ^9"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37860535588d0173fc5e32eaad69db89",
+    "content-hash": "f469f7f178775fbe49b57e033f6742e2",
     "packages": [
         {
             "name": "acquia/blt",
@@ -5869,6 +5869,47 @@
             "homepage": "https://www.drupal.org/project/layout_builder_restrictions",
             "support": {
                 "source": "https://git.drupalcode.org/project/layout_builder_restrictions"
+            }
+        },
+        {
+            "name": "drupal/layout_builder_shortcuts",
+            "version": "dev-1.0.x",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/layout_builder_shortcuts.git",
+                "reference": "a03aca0d17a0862ce5e6e3db37a049a05946ee52"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.0.x": "1.0.x-dev"
+                },
+                "drupal": {
+                    "version": "1.0.x-dev",
+                    "datestamp": "1608040200",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "pyrello",
+                    "homepage": "https://www.drupal.org/user/62893"
+                }
+            ],
+            "description": "Provides a shortcut for editing blocks in Layout Builder.",
+            "homepage": "https://www.drupal.org/project/layout_builder_shortcuts",
+            "support": {
+                "source": "https://git.drupalcode.org/project/layout_builder_shortcuts"
             }
         },
         {
@@ -19558,6 +19599,7 @@
         "drupal/entity_usage": 15,
         "drupal/fragments": 10,
         "drupal/layout_builder_lock": 5,
+        "drupal/layout_builder_shortcuts": 20,
         "drupal/layout_builder_styles": 10,
         "drupal/lb_direct_add": 20,
         "drupal/masquerade": 10,

--- a/composer.lock
+++ b/composer.lock
@@ -5877,7 +5877,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/layout_builder_shortcuts.git",
-                "reference": "c16b97fe51de65b618cbbd6fffd00f2701e00891"
+                "reference": "5cbeec3e4e2f19874dfeaf36345f67d38ef5fd8d"
             },
             "require": {
                 "drupal/core": "^8.8 || ^9"
@@ -5889,7 +5889,7 @@
                 },
                 "drupal": {
                     "version": "1.0.x-dev",
-                    "datestamp": "1608041575",
+                    "datestamp": "1608129839",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"

--- a/composer.lock
+++ b/composer.lock
@@ -5877,7 +5877,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/layout_builder_shortcuts.git",
-                "reference": "6be2475881da10881c132376dbaffbe4cec65aea"
+                "reference": "c16b97fe51de65b618cbbd6fffd00f2701e00891"
             },
             "require": {
                 "drupal/core": "^8.8 || ^9"
@@ -5889,7 +5889,7 @@
                 },
                 "drupal": {
                     "version": "1.0.x-dev",
-                    "datestamp": "1608040200",
+                    "datestamp": "1608041575",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -64,6 +64,7 @@ module:
   layout_builder_operation_link: 0
   layout_builder_restrictions: 0
   layout_builder_restrictions_by_region: 0
+  layout_builder_shortcuts: 0
   layout_builder_styles: 0
   layout_discovery: 0
   lazy: 0

--- a/docroot/modules/custom/layout_builder_custom/js/layout_builder_custom.overrides.js
+++ b/docroot/modules/custom/layout_builder_custom/js/layout_builder_custom.overrides.js
@@ -33,6 +33,17 @@
         }
     };
 
+  Drupal.behaviors.layoutBuilderDoubleClick = {
+    attach: function(context, settings) {
+      const $blocks = $('#layout-builder [data-layout-block-uuid]', context);
+      $blocks.on('dblclick', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $(this).find('.contextual-links li.layout-builder-block-update > a').click();
+      })
+    }
+  }
+
   // Allows saving filtered and minimal html content while Source is open.
   // Solution from https://www.drupal.org/project/drupal/issues/3095304.
   var origBeforeSubmit = Drupal.Ajax.prototype.beforeSubmit;

--- a/docroot/modules/custom/layout_builder_custom/js/layout_builder_custom.overrides.js
+++ b/docroot/modules/custom/layout_builder_custom/js/layout_builder_custom.overrides.js
@@ -33,17 +33,6 @@
         }
     };
 
-  Drupal.behaviors.layoutBuilderDoubleClick = {
-    attach: function(context, settings) {
-      const $blocks = $('#layout-builder [data-layout-block-uuid]', context);
-      $blocks.on('dblclick', function(e) {
-        e.preventDefault();
-        e.stopPropagation();
-        $(this).find('.contextual-links li.layout-builder-block-update > a').click();
-      })
-    }
-  }
-
   // Allows saving filtered and minimal html content while Source is open.
   // Solution from https://www.drupal.org/project/drupal/issues/3095304.
   var origBeforeSubmit = Drupal.Ajax.prototype.beforeSubmit;


### PR DESCRIPTION
Adds a new module called `drupal/layout_builder_shortcuts` which provides the ability to open a blocks edit screen (while in Layout Builder) by double clicking the block.

# How to test
* `blt ds`
* `drush @default.local uli /`
* Click the "Layout" tab.
* Test double clicking a block to see that it opens the block edit screen.
* Test editing a block through the contextual link.
* Test dragging and dropping a block.
* Test moving a block through the contextual link.
* Test removing a block.
* Masquerade as a webmaster.
* Visit the http://default.local.drupal.uiowa.edu/about and click the "Layout" tab.
* Attempt to double click a block in the Header section. This should not work.