### PR TITLE
Fix: container fix for v2 sites

### DIFF
--- a/docroot/themes/custom/uids_base/scss/sitenow.scss
+++ b/docroot/themes/custom/uids_base/scss/sitenow.scss
@@ -83,7 +83,7 @@ html {
   .container-lg,
   .container-xl {
     margin: 0 auto;
-    max-width: 83.875em;
+    max-width: 1342px;
   }
 }
 


### PR DESCRIPTION
The `field__item` size set to `rem` in https://github.com/uiowa/uiowa/pull/2677 has created some container issues with `v2` sites.   This pr adjusts the container size to use `px` instead of `em` to fix this issue. 

<img width="2073" alt="Screen Shot 2020-12-16 at 3 26 49 PM" src="https://user-images.githubusercontent.com/1036433/102409259-594fd780-3fb4-11eb-938e-84d6417fa226.png">

# How to test

- Test on hawkeyemarchingband.uiowa.edu or brand.uiowa.edu
- `yarn workspace uids_base gulp --development`
- Verify that page containers align with the page title and do not overflow like the screenshot above
