### PR TITLE
Feature stat no hover

### DIFF
--- a/config/default/field.field.block_content.uiowa_statistic.field_uiowa_statistic_content.yml
+++ b/config/default/field.field.block_content.uiowa_statistic.field_uiowa_statistic_content.yml
@@ -10,7 +10,7 @@ field_name: field_uiowa_statistic_content
 entity_type: block_content
 bundle: uiowa_statistic
 label: Content
-description: 'Optional text to appear below the statistic on mouse hover, providing additional detail for the statistic.'
+description: 'Optional text to appear below the statistic on mouse hover, providing additional detail for the statistic. To always show this text, remove the hover effect in the display option styles.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/default/layout_builder_styles.style.cta_remove_hover_effect.yml
+++ b/config/default/layout_builder_styles.style.cta_remove_hover_effect.yml
@@ -1,0 +1,12 @@
+uuid: 70549ec1-6ee7-43f7-9c40-f00db44c27e2
+langcode: en
+status: true
+dependencies: {  }
+id: cta_remove_hover_effect
+label: 'Remove hover effect'
+classes: stat--static
+type: component
+group: default
+weight: 0
+block_restrictions:
+  - 'inline_block:uiowa_statistic'

--- a/config/default/layout_builder_styles.style.stat_remove_hover_effect.yml
+++ b/config/default/layout_builder_styles.style.stat_remove_hover_effect.yml
@@ -2,7 +2,7 @@ uuid: 70549ec1-6ee7-43f7-9c40-f00db44c27e2
 langcode: en
 status: true
 dependencies: {  }
-id: cta_remove_hover_effect
+id: stat_remove_hover_effect
 label: 'Remove hover effect'
 classes: stat--static
 type: component

--- a/docroot/themes/custom/uids_base/scss/components/stat.scss
+++ b/docroot/themes/custom/uids_base/scss/components/stat.scss
@@ -17,3 +17,11 @@
     padding-top: 0;
   }
 }
+
+.stat--static .stat__content {
+  position: static!important;
+  clip: auto;
+  height: auto;
+  overflow: auto;
+  opacity: 1;
+}

--- a/docroot/themes/custom/uids_base/templates/block/block--inline-block--uiowa-statistic.html.twig
+++ b/docroot/themes/custom/uids_base/templates/block/block--inline-block--uiowa-statistic.html.twig
@@ -26,8 +26,7 @@
  */
 #}
 {% set stat_classes = [] %}
-
-{% if content.field_uiowa_statistic_content[0]['#context']['value'] is not null %}
+{% if has_hover_effect and content.field_uiowa_statistic_content[0]['#context']['value'] is not null %}
 	{% set stat_classes = 'stat stat__grid stat--transform' %}
 {% endif %}
 

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -468,6 +468,11 @@ function uids_base_preprocess_block(&$variables) {
     }
   }
 
+  //
+  if ($variables['derivative_plugin_id'] == 'uiowa_statistic' && isset($variables['elements']['#layout_builder_style'])) {
+    $variables['has_hover_effect'] = !in_array('stat--static', $variables['elements']['#layout_builder_style']);
+  }
+
 }
 
 /**

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -468,7 +468,7 @@ function uids_base_preprocess_block(&$variables) {
     }
   }
 
-  //
+  // Check if the hover effect should be applied on the stat block.
   if ($variables['derivative_plugin_id'] == 'uiowa_statistic' && isset($variables['elements']['#layout_builder_style'])) {
     $variables['has_hover_effect'] = !in_array('stat--static', $variables['elements']['#layout_builder_style']);
   }


### PR DESCRIPTION
Resolves #2583 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
`blt ds --site=default` or your preferred test site
`blt frontend`
Create (or edit an existing) stat block
Add the `Remove hover effect` style
Check that the stat no longer exhibits the hover behavior (the `content` text appears, correctly styled, statically below the statistic)
Check that a stat block without the `Remove hover effect` style still exhibits the proper hover effect (the `content` text appears hidden until hovering over the statistic block).

# Feedback
As part of this, we're trying to determine the naming for the style option. Few initial thoughts are:

- "Remove hover effect"
- "Display content field by default"
- "Persistent content field display"

Preferences from these options, or alternatives, highly welcomed!

Additionally, the help text for the content field references the hover effect, which is the default behavior. Depending on if the style label changes, we may want to update that help text as well.