### PR TITLE
Fix some search regressions.

### DIFF
--- a/docroot/modules/custom/uiowa_search/src/Controller/UiowaSearchResultsController.php
+++ b/docroot/modules/custom/uiowa_search/src/Controller/UiowaSearchResultsController.php
@@ -38,17 +38,14 @@ class UiowaSearchResultsController extends ControllerBase {
       'site' => 'default_collection',
     ];
 
-    // Only show the search-all link if search-this-site is configured.
-    if ($config['cse_scope'] === 1) {
-      $build['search'] = [
-        '#type' => 'link',
-        '#title' => $this->t('Search all University of Iowa for @terms', ['@terms' => $search_terms]),
-        '#url' => Url::fromUri('https://search.uiowa.edu', ['query' => $search_params]),
-        '#attributes' => [
-          'target' => '_blank',
-        ],
-      ];
-    }
+    $build['search'] = [
+      '#type' => 'link',
+      '#title' => $this->t('Search all University of Iowa for @terms', ['@terms' => $search_terms]),
+      '#url' => Url::fromUri('https://search.uiowa.edu', ['query' => $search_params]),
+      '#attributes' => [
+        'target' => '_blank',
+      ],
+    ];
 
     $build['results_container'] = [
       '#type' => 'container',

--- a/docroot/modules/custom/uiowa_search/src/Form/SearchForm.php
+++ b/docroot/modules/custom/uiowa_search/src/Form/SearchForm.php
@@ -52,7 +52,8 @@ class SearchForm extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form = [];
 
-    $form['search_terms'] = [
+    // Styles are targeting hyphenated element keys which control the name.
+    $form['search-terms'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Search'),
       '#label_attributes' => [
@@ -67,7 +68,7 @@ class SearchForm extends FormBase {
       '#size' => '15',
     ];
 
-    $form['submit_search'] = [
+    $form['submit-search'] = [
       '#type' => 'submit',
       '#value' => $this->t('Search'),
       '#name' => 'btnG',

--- a/docroot/modules/custom/uiowa_search/src/Form/SearchForm.php
+++ b/docroot/modules/custom/uiowa_search/src/Form/SearchForm.php
@@ -89,7 +89,7 @@ class SearchForm extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $form_state->setRedirectUrl(Url::fromRoute('uiowa_search.search_results', [], [
       'query' => [
-        'terms' => $form_state->getValue('search_terms'),
+        'terms' => $form_state->getValue('search-terms'),
       ],
     ]));
   }

--- a/docroot/modules/custom/uiowa_search/src/Form/SearchForm.php
+++ b/docroot/modules/custom/uiowa_search/src/Form/SearchForm.php
@@ -60,21 +60,11 @@ class SearchForm extends FormBase {
           'sr-only',
         ],
       ],
+      '#attributes' => [
+        'placeholder' => $this->t('Search this site'),
+      ],
       '#maxlength' => '256',
       '#size' => '15',
-    ];
-
-    $placeholder = $this->t('Search');
-
-    if ($this->config->get('uiowa_search.cse_scope') === 1) {
-      $placeholder = $this->t('Search this site');
-    }
-    elseif ($this->config->get('uiowa_search.cse_scope') === 0) {
-      $placeholder = $this->t('Search all University of Iowa');
-    }
-
-    $form['search_terms']['#attributes'] = [
-      'placeholder' => $placeholder,
     ];
 
     $form['submit_search'] = [


### PR DESCRIPTION
Follow up to #2743 

Always show search-all link since CSE can be configured to search multiple domains. Set placeholder text back to "Search this site" since there is no way to detect otherwise. Change form element keys and document they control styling.

Testing
- Click search
- See placeholder
- Enter search terms and submit
- See search all link