### PR TITLE
Feature: Added fix for page title size using banners

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/banner.scss
+++ b/docroot/themes/custom/uids_base/scss/components/banner.scss
@@ -137,7 +137,8 @@
 }
 
 // Set larger heading size for large banner only
-.banner--large {
+.banner--large,
+.layout--title.banner {
   .bold-headline {
     @include breakpoint(md) {
       font-size: calc(100% + 3.5vw);


### PR DESCRIPTION
Fix for https://github.com/uiowa/uiowa/issues/2775. 

# How to test

- Add featured image to a page
- Set size to medium or small and verify that page title is same size as large option
- Add medium or small size banner to a layout and verify that `headline` size is not changed