### PR TITLE
Feature: Hotfix to remove display setting from article featured image display

### DIFF
--- a/config/default/core.entity_view_display.node.article.default.yml
+++ b/config/default/core.entity_view_display.node.article.default.yml
@@ -85,21 +85,6 @@ third_party_settings:
                 view_mode: view_mode
             additional: {  }
             weight: -9
-          -
-            uuid: 8dda86f2-3116-4141-8f0f-60dbaa3b2fd6
-            region: content
-            configuration:
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              id: 'field_block:node:article:field_featured_image_display'
-              formatter:
-                label: above
-                settings: {  }
-                third_party_settings: {  }
-                type: list_default
-            additional: {  }
-            weight: -8
         third_party_settings: {  }
       -
         layout_id: layout_onecol


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/2780. 

# How to test

Add a featured image to an article and change the size to something other than the default site setting.    Once the article is saved the "Display size" text should not appear in the banner. 