### PR TITLE
Fixed Grad Programs view and LB header layout issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -230,7 +230,8 @@
                 "Off-canvas style resets are overriding styles (especially SVGs) in Safari resulting in display issues": "https://www.drupal.org/files/issues/2019-05-07/off-canvas-style-resets-2958588-13.patch",
                 "Media viewmode control": "https://www.drupal.org/files/issues/2020-01-31/3097416-ckeditor-view-modes-8.9-combined.patch",
                 "Expose Layout Builder data to REST and JSON:API": "https://www.drupal.org/files/issues/2020-07-07/2942975-116.patch",
-                "Temporary Hotfix for YouTube oEmbeds": "https://www.drupal.org/files/issues/2020-12-04/3186415-8.9.x-youtube-headers-html.patch"
+                "Temporary Hotfix for YouTube oEmbeds": "https://www.drupal.org/files/issues/2020-12-04/3186415-8.9.x-youtube-headers-html.patch",
+                "Themes have no context of the entity being rendered in preprocessing a layout when using Layout builder": "https://www.drupal.org/files/issues/2020-02-11/3111192-entity-14.patch"
             },
             "drupal/layout_builder_styles": {
                 "Section dependency on layout plugin configuration form": "https://www.drupal.org/files/issues/2019-08-23/layout_builder_styles-3062261-%2310.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dddf1b744ada5dd66e27adb423fc3367",
+    "content-hash": "ad4bd46e428ac633a7a005c752ba3a46",
     "packages": [
         {
             "name": "acquia/blt",

--- a/config/grad.uiowa.edu/config_split.config_split.site_grad_uiowa_edu.yml
+++ b/config/grad.uiowa.edu/config_split.config_split.site_grad_uiowa_edu.yml
@@ -12,18 +12,19 @@ module:
   smart_date: 0
 theme: {  }
 blacklist:
-  - fragment.fragment_type.program
   - config_split.config_split.site_grad_uiowa_edu
   - node.type.thesis_defense
   - pathauto.pattern.thesis_defense
   - simple_sitemap.bundle_settings.default.node.thesis_defense
   - sitenow_people.person_type.mentor
+  - fragment.fragment_type.program
   - 'field.storage.fragment.field_program_*'
   - 'field.storage.node.field_thesis_defense_*'
 graylist:
   - core.entity_view_display.block_content.uiowa_people.default
   - field.storage.node.field_uiowa_college
   - node.type.person
+  - node.type.scholarship
   - simple_sitemap.bundle_settings.default.node.person
   - sitenow_people.field_settings
   - sitenow_people.person_type.mentor

--- a/config/grad.uiowa.edu/node.type.scholarship.yml
+++ b/config/grad.uiowa.edu/node.type.scholarship.yml
@@ -1,0 +1,23 @@
+uuid: 0ab0aa18-3e51-4a84-9fc6-91ec68d7b0d4
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+    - node_revision_delete
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:menu_link_content:5da2fd04-9fe9-4f52-b915-ccc2612e9b44'
+  node_revision_delete:
+    minimum_revisions_to_keep: 10
+    minimum_age_to_delete: 0
+    when_to_delete: 0
+name: Fellowship
+type: scholarship
+description: 'Use <em>fellowship</em> to provide information about an individual fellowship funding opportunities.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/config/grad.uiowa.edu/views.view.graduate_programs.yml
+++ b/config/grad.uiowa.edu/views.view.graduate_programs.yml
@@ -1,12 +1,12 @@
-uuid: 22c3a29d-4676-4703-8e9b-3e7ab5c10e7f
+uuid: bb397ef7-786c-4df8-b71c-4a54e9e638f1
 langcode: en
 status: true
 dependencies:
   config:
-    - fragments.fragment_type.program
     - field.storage.fragment.field_grad_degrees_offered
     - field.storage.fragment.field_grad_discipline
     - field.storage.fragment.field_program_homepage
+    - fragments.fragment_type.program
   module:
     - fragments
     - link
@@ -16,7 +16,7 @@ label: 'Graduate Programs'
 module: views
 description: ''
 tag: ''
-base_table: fragment
+base_table: fragment_field_data
 base_field: id
 display:
   default:
@@ -56,39 +56,6 @@ display:
           offset: 0
       style:
         type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            field_program_homepage: field_program_homepage
-            title: title
-            field_grad_degrees_offered: field_grad_degrees_offered
-          info:
-            field_program_homepage:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            title:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            field_grad_degrees_offered:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: '-1'
-          empty_table: false
       row:
         type: fields
       fields:
@@ -161,7 +128,7 @@ display:
           plugin_id: field
         title:
           id: title
-          table: fragment
+          table: fragment_field_data
           field: title
           relationship: none
           group_type: group
@@ -349,64 +316,18 @@ display:
           field_api_classes: false
           plugin_id: field
       filters:
-        bundle:
-          id: bundle
-          table: fragment
-          field: bundle
+        type:
+          id: type
+          table: fragment_field_data
+          field: type
           value:
             program: program
           entity_type: fragment
-          entity_field: bundle
+          entity_field: type
           plugin_id: bundle
           expose:
             operator_limit_selection: false
             operator_list: {  }
-        field_grad_discipline_value:
-          id: field_grad_discipline_value
-          table: fragment__field_grad_discipline
-          field: field_grad_discipline_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: or
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: field_grad_discipline_value_op
-            label: Discipline
-            description: ''
-            use_operator: false
-            operator: field_grad_discipline_value_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: discipline
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              viewer: '0'
-              editor: '0'
-              publisher: '0'
-              webmaster: '0'
-              administrator: '0'
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          plugin_id: list_field
         field_grad_degrees_offered_value:
           id: field_grad_degrees_offered_value
           table: fragment__field_grad_degrees_offered
@@ -448,48 +369,6 @@ display:
             group_items: {  }
           reduce_duplicates: false
           plugin_id: list_field
-      sorts: {  }
-      title: 'Graduate Programs'
-      header: {  }
-      footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
-      display_extenders: {  }
-      use_ajax: true
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - url.query_args
-      tags:
-        - 'config:field.storage.fragment.field_grad_degrees_offered'
-        - 'config:field.storage.fragment.field_grad_discipline'
-        - 'config:field.storage.fragment.field_program_homepage'
-  block_1:
-    display_plugin: block
-    id: block_1
-    display_title: 'Certificates Block'
-    position: 2
-    display_options:
-      display_extenders:
-        metatag_display_extender: {  }
-      display_description: ''
-      filters:
-        bundle:
-          id: bundle
-          table: fragment
-          field: bundle
-          value:
-            program: program
-          entity_type: fragment
-          entity_field: bundle
-          plugin_id: bundle
-          expose:
-            operator_limit_selection: false
-            operator_list: {  }
         field_grad_discipline_value:
           id: field_grad_discipline_value
           table: fragment__field_grad_discipline
@@ -536,6 +415,52 @@ display:
             group_items: {  }
           reduce_duplicates: false
           plugin_id: list_field
+      sorts: {  }
+      title: 'Graduate Programs'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      use_ajax: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+      tags:
+        - 'config:field.storage.fragment.field_grad_degrees_offered'
+        - 'config:field.storage.fragment.field_grad_discipline'
+        - 'config:field.storage.fragment.field_program_homepage'
+  certificates:
+    display_plugin: block
+    id: certificates
+    display_title: Certificates
+    position: 2
+    display_options:
+      display_extenders:
+        metatag_display_extender: {  }
+      display_description: ''
+      title: 'Graduate Certificates'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      filters:
+        type:
+          id: type
+          table: fragment_field_data
+          field: type
+          value:
+            program: program
+          entity_type: fragment
+          entity_field: type
+          plugin_id: bundle
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
         field_grad_degrees_offered_value:
           id: field_grad_degrees_offered_value
           table: fragment__field_grad_degrees_offered
@@ -543,7 +468,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          operator: or
+          operator: and
           value:
             Certificate: Certificate
           group: 1
@@ -577,48 +502,89 @@ display:
             group_items: {  }
           reduce_duplicates: false
           plugin_id: list_field
-      defaults:
-        filters: false
-        filter_groups: false
+        field_grad_discipline_value:
+          id: field_grad_discipline_value
+          table: fragment__field_grad_discipline
+          field: field_grad_discipline_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_grad_discipline_value_op
+            label: Discipline
+            description: ''
+            use_operator: false
+            operator: field_grad_discipline_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: discipline
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              viewer: '0'
+              editor: '0'
+              publisher: '0'
+              webmaster: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
       filter_groups:
         operator: AND
         groups:
           1: AND
       block_category: Custom
-      block_description: 'Certificates list'
       allow:
         items_per_page: false
+      block_description: 'Grad certificates list'
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
-        - url.query_args
       tags:
         - 'config:field.storage.fragment.field_grad_degrees_offered'
         - 'config:field.storage.fragment.field_grad_discipline'
         - 'config:field.storage.fragment.field_program_homepage'
-  program_block:
+  programs:
     display_plugin: block
-    id: program_block
-    display_title: 'Programs Block'
+    id: programs
+    display_title: Programs
     position: 1
     display_options:
       display_extenders:
         metatag_display_extender: {  }
+      display_description: ''
       block_category: Custom
-      block_description: 'Program list'
       allow:
         items_per_page: false
-      display_description: ''
+      block_description: 'Grad programs list'
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
-        - url.query_args
       tags:
         - 'config:field.storage.fragment.field_grad_degrees_offered'
         - 'config:field.storage.fragment.field_grad_discipline'

--- a/docroot/themes/custom/uids_base/templates/layouts/onecol--background/layout--onecol--background.html.twig
+++ b/docroot/themes/custom/uids_base/templates/layouts/onecol--background/layout--onecol--background.html.twig
@@ -14,7 +14,7 @@
 #}
 
 {% set background = content.background | render %}
-{% if background is not empty %}
+{% if background is not empty and (featured_image_display is not empty) %}
   {% set classes = [
     'banner--gradient-bottom',
     'banner--gradient-dark',

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -290,7 +290,7 @@ function uids_base_preprocess_field(&$variables) {
  * Implements hook_preprocess_layout().
  */
 function uids_base_preprocess_layout(&$variables) {
-  $node = $variables['content']['#entity'] ?: null;
+  $node = $variables['content']['#entity'] ?: NULL;
   // If we don't have the node yet, attempt
   // to grab it from the route.
   // @todo Is this necessary? Possibly we can

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -290,12 +290,22 @@ function uids_base_preprocess_field(&$variables) {
  * Implements hook_preprocess_layout().
  */
 function uids_base_preprocess_layout(&$variables) {
-  /** @var \Drupal\Core\Layout\LayoutDefinition $layout */
-  $layout = $variables['layout'];
-  $node = \Drupal::routeMatch()->getParameter('node');
-  $node = (isset($node) ? $node : \Drupal::routeMatch()->getParameter('node_preview'));
-  $title_hidden = FALSE;
+  $node = $variables['content']['#entity'] ?: null;
+  // If we don't have the node yet, attempt
+  // to grab it from the route.
+  // @todo Is this necessary? Possibly we can
+  //   remove it.
+  if (!$node) {
+    $route_matcher = \Drupal::routeMatch();
+    $node = $route_matcher->getParameter('node');
+    $node = (isset($node) ? $node : $route_matcher->getParameter('node_preview'));
+  }
+  // If we have found a node instance, continue.
   if ($node instanceof NodeInterface) {
+    $title_hidden = FALSE;
+    /** @var \Drupal\Core\Layout\LayoutDefinition $layout */
+    $layout = $variables['layout'];
+
     // @todo Scope this to target layout so it doesn't run
     //   every time a layout is preprocessed.
     if ($node->hasField('field_publish_options') && !$node->get('field_publish_options')->isEmpty()) {


### PR DESCRIPTION
# Updates
* Resolves #2228 including https://github.com/uiowa/uiowa/issues/2228#issuecomment-754759841
* Replaces non-functional Grad Programs view blocks with functional ones.
* Added `node.type.scholarship.yml` to Grad split to call them Fellowships instead and allow adding them to the main menu.

# How to test

## Grad split updates
* `composer install`
* `blt ds --site=grad.uiowa.edu`
* `drush @grad.local uli node/add/page`
* Add a page, setting a featured image (and leaving the default display settings).
* Visit the "Layout" tab.
* Add Grad programs list and Grad certificates list blocks, found under "More..."
* Save page
* Observe no issues with adding blocks, saving page, or viewing it.
* Visit https://grad.local.drupal.uiowa.edu/admin/structure/types to observe that "Scholarship" has been replaced by "Fellowship."
* Visit https://grad.local.drupal.uiowa.edu/node/706/edit and open "Menu settings" accordion to see that adding a scholarship to the menu is an option.

## #2228 fixes
* When using LB UI the page should always show the image added above in the same format
* Remove the featured image from the page and test adding/updating block again and ensure that the header section does not change the way it is presented in LB.
