### PR TITLE
Added command to fix xdebug log error to post provision script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Follow the [BLT docs](https://docs.acquia.com/blt/install/local-development/) to
 
 All BLT commands should be run on the VM. You can SSH into the VM using `vagrant ssh`. See the [Vagrant docs](https://www.vagrantup.com/docs/cli/) for basic CLI usage.
 
-If you have troubles with [an error](https://github.com/geerlingguy/drupal-vm/issues/1813) on DrupalVM related to /tmp/xdebug.log, un `sudo chmod 766 /tmp/xdebug.log` in the VM.
-
 ## Workspaces
 Yarn [workspaces](https://classic.yarnpkg.com/en/docs/workspaces) can be defined in the top-level package.json file. Each workspace can depend on other workspaces as well as define their own build script. You can run workspace build scripts on the VM with `yarn workspace WORKSPACE_NAME run SCRIPT_NAME`. Every workspace build script gets run during continuous integration to build assets. The build assets are committed to the build artifact and deployed.
 

--- a/box/post-provision.sh
+++ b/box/post-provision.sh
@@ -5,3 +5,4 @@
 
 # Update Composer to version 2 since setting composer_version didn't work.
 composer self-update --2
+sudo chmod 766 /tmp/xdebug.log


### PR DESCRIPTION
I'm not totally sure this works because I didn't want to run `vagrant destroy` ATM because of other work in progress. But it didn't cause a failure when I ran `vagrant provision`, so at a minimum it doesn't seem to cause any issues.

# How to test

If you have a local environment that you don't mind blowing up:
* `vagrant destroy`
* `vagrant up`
* `vagrant ssh`
* Run a PHP-related command... I think `drush` or `blt` commands normally cause the error.
