### PR TITLE
Store APR publications departments as text and convert to JSON.

### DIFF
--- a/docroot/modules/custom/uiowa_apr/src/Controller/PublicationsController.php
+++ b/docroot/modules/custom/uiowa_apr/src/Controller/PublicationsController.php
@@ -3,7 +3,6 @@
 namespace Drupal\uiowa_apr\Controller;
 
 use Drupal\Component\Utility\Html;
-use Drupal\Component\Utility\Xss;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\uiowa_apr\Apr;

--- a/docroot/modules/custom/uiowa_apr/src/Controller/PublicationsController.php
+++ b/docroot/modules/custom/uiowa_apr/src/Controller/PublicationsController.php
@@ -87,10 +87,20 @@ class PublicationsController extends ControllerBase {
       ],
     ];
 
-    $departments = $this->config->get('publications.departments');
+    $departments = Html::escape($this->config->get('publications.departments'));
 
     if (!empty($departments)) {
-      $build['publications']['#attributes'][':departments'] = Xss::filter($departments);
+      $json = [];
+
+      foreach (explode(PHP_EOL, $departments) as $department) {
+        $json[] = (object) [
+          'text' => rtrim($department),
+          'value' => rtrim($department),
+        ];
+      }
+
+      $json = json_encode($json);
+      $build['publications']['#attributes'][':departments'] = $json;
     }
 
     return $build;

--- a/docroot/modules/custom/uiowa_apr/src/Form/SettingsForm.php
+++ b/docroot/modules/custom/uiowa_apr/src/Form/SettingsForm.php
@@ -186,8 +186,8 @@ class SettingsForm extends ConfigFormBase {
       '#cols' => '100',
       '#title' => $this->t('Publications Departments'),
       '#default_value' => $this->config('uiowa_apr.settings')->get('publications.departments') ?? '',
-      '#description' => $this->t('Customize the list of departments exposed by the publications tool. Expects a JSON array. Value attributes in the array must match a department name in APR. Use the text attribute to customize the text the user will see.'),
-      '#attributes' => ['placeholder' => "[{text: 'Economics', value: 'Economics'}]"],
+      '#description' => $this->t('Customize the list of departments exposed by the publications tool. Enter one department per line. The department must match a name in APR.'),
+      '#attributes' => ['placeholder' => "Economics\rAccounting\rFinance"],
       '#required' => FALSE,
     ];
 

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -427,7 +427,7 @@ function _sitenow_node_form_defaults(&$form, $form_state) {
 
     if ($form_object && $node = $form_object->getEntity()) {
       $type = $node->getType() . 's';
-      $form['field_featured_image_display']['widget']['#description'] .= t(' If "Site-wide default" is selected, this setting can be changed on the <a href="@settings_url">SiteNow @types settings</a>.', [
+      $form['field_featured_image_display']['widget']['#description'] .= t('&nbsp;If "Site-wide default" is selected, this setting can be changed on the <a href="@settings_url">SiteNow @types settings</a>.', [
         '@settings_url' => Url::fromRoute("sitenow_$type.settings_form")->toString(),
         '@types' => ucfirst($type),
       ]);


### PR DESCRIPTION
Running through a quick APR demo myself, I had trouble getting this config to work. Asking folks to enter valid JSON is probably a bad idea. Tippie is not customizing the text of any of its department overrides. We can add that later through an alter hook if needed but seems like overkill.

### Testing
- See #2725 for setup.
- Enter department names, one per line. The placeholder values should work for tippie.
- Go to publications route and test out the department filter.