### PR TITLE
Config ignore fix

### DIFF
--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -28,6 +28,6 @@ ignored_config_entities:
   - views.view.articles
   - views.view.people
   - 'webform.webform.*'
-enable_export_filtering: '1'
+enable_export_filtering: true
 _core:
   default_config_hash: v7E8C8wJWeAW2BGohMNY1tZSBc4bexM6O62tGxecTfE

--- a/config/hr.uiowa.edu/config_ignore.settings.yml
+++ b/config/hr.uiowa.edu/config_ignore.settings.yml
@@ -3,6 +3,7 @@ ignored_config_entities:
   - 'block.block.main_navigation__superfish__horizontal:status'
   - 'block.block.main_navigation__superfish__toggle:status'
   - 'block.block.main_navigation__superfish__mega:status'
+  - 'config_split.config_split.apr:status'
   - 'config_split.config_split.areas_of_study:status'
   - 'config_split.config_split.collegiate:status'
   - 'config_split.config_split.person_extended:status'
@@ -20,6 +21,7 @@ ignored_config_entities:
   - 'tour.tour.search-api-*'
   - uids_base.settings
   - uiowa_alerts.settings
+  - uiowa_apr.settings
   - uiowa_bar.settings
   - uiowa_search.settings
   - uiowa_core.settings

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -1913,3 +1913,13 @@ function sitenow_update_8048() {
     }
   }
 }
+
+/**
+ * Sometimes config ignore needs a little push.
+ */
+function sitenow_update_8049() {
+  $config_path = Settings::get('config_sync_directory');
+  $source = new FileStorage($config_path);
+  $config_storage = \Drupal::service('config.storage');
+  $config_storage->write('config_ignore.settings', $source->read('config_ignore.settings'));
+}

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -1922,7 +1922,8 @@ function sitenow_update_8049() {
 
   if ($site_path != 'sites/hr.uiowa.edu') {
     $config_path = Settings::get('config_sync_directory');
-  } else {
+  }
+  else {
     $config_path = DRUPAL_ROOT . '/../config/hr.uiowa.edu/';
   }
   $source = new FileStorage($config_path);

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -1918,7 +1918,13 @@ function sitenow_update_8048() {
  * Sometimes config ignore needs a little push.
  */
 function sitenow_update_8049() {
-  $config_path = Settings::get('config_sync_directory');
+  $site_path = \Drupal::service('site.path');
+
+  if ($site_path != 'sites/hr.uiowa.edu') {
+    $config_path = Settings::get('config_sync_directory');
+  } else {
+    $config_path = DRUPAL_ROOT . '/../config/hr.uiowa.edu/';
+  }
   $source = new FileStorage($config_path);
   $config_storage = \Drupal::service('config.storage');
   $config_storage->write('config_ignore.settings', $source->read('config_ignore.settings'));


### PR DESCRIPTION
Let's try it again. Builds error on a config_ignore diff. This force imports the config first so that there is no diff later.

Related convo: https://iowaweb.slack.com/archives/C8SM82ZFZ/p1610130577315200

# To Test

Following https://github.com/uiowa/uiowa#updating-dependencies

For any website plus HR try some of the following in an attempt to get a config export change for config_ignore.settings:

`blt ds --site=sitename`, login and save the config ignore settings without changing anything (/admin/config/development/configuration/ignore), `drush @sitename.local cex`

next try and do a direct sql-sync:

`drush @sitename.local sql-drop && drush @sitename.local cr && drush sql-sync @sitename.prod @sitename.local && drush @sitename.local updb` login and save the config ignore settings without changing anything (/admin/config/development/configuration/ignore), `drush @sitename.local cex`

Check HR to make sure uiowa_bar settings are still intact.

You may get diffs because there is new config that is not yet in PROD, but config_ignore.settings should not be one of them and `enable_export_filtering: true` should be what you get regardless of what you throw at it.
