### PR TITLE
imagecache external 3.0.0 update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
         "drupal/google_tag": "^1.3",
         "drupal/heading": "^1.4",
         "drupal/honeypot": "^2.0",
-        "drupal/imagecache_external": "^1.0",
+        "drupal/imagecache_external": "^3.0",
         "drupal/imagemagick": "^3.0",
         "drupal/inline_entity_form": "^1.0.0-rc2",
         "drupal/layout_builder_lock": "^1.0@RC",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad4bd46e428ac633a7a005c752ba3a46",
+    "content-hash": "af5ec6bc416f2c66d1e6f82cd7760219",
     "packages": [
         {
             "name": "acquia/blt",
@@ -5479,26 +5479,26 @@
         },
         {
             "name": "drupal/imagecache_external",
-            "version": "1.2.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/imagecache_external.git",
-                "reference": "8.x-1.2"
+                "reference": "3.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/imagecache_external-8.x-1.2.zip",
-                "reference": "8.x-1.2",
-                "shasum": "dd4f041441d2096f0b9b6979a1f11a58c7c18958"
+                "url": "https://ftp.drupal.org/files/projects/imagecache_external-3.0.0.zip",
+                "reference": "3.0.0",
+                "shasum": "8975bf8229dcfae47600502b872b01861eee1440"
             },
             "require": {
-                "drupal/core": "^8"
+                "drupal/core": "^8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.2",
-                    "datestamp": "1579607283",
+                    "version": "3.0.0",
+                    "datestamp": "1605799095",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/config/default/imagecache_external.settings.yml
+++ b/config/default/imagecache_external.settings.yml
@@ -18,3 +18,4 @@ imagecache_external_allowed_mimetypes:
 _core:
   default_config_hash: pf41tN-PPhgH1h2NxglpZuVbsh8xKOnO2r5cqM3aeYs
 imagecache_external_batch_flush_limit: 1000
+imagecache_external_cron_flush_frequency: 7


### PR DESCRIPTION
Solves https://github.com/uiowa/uiowa/issues/2595

When I tested it on default and the honors website events and pictures seemed to show up and perform as normal.
