### PR TITLE
hotfix - events card styling in layout columns

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/event.scss
+++ b/docroot/themes/custom/uids_base/scss/components/event.scss
@@ -56,28 +56,6 @@
     }
   }
 
-  .layout--twocol .layout__spacing_container & {
-    @media screen and (min-width: 40em) {
-      .card__media img {
-        border-radius: 50%;
-        margin-top: 0;
-        height: auto;
-        padding: 8px;
-      }
-    }
-  }
-
-  .layout--fourcol .layout__spacing_container & {
-    @media screen and (min-width: 40em) {
-      .card__media img {
-        border-radius: 50%;
-        margin-top: 0;
-        height: auto;
-        padding: 8px;
-      }
-    }
-  }
-
   &.hide-descriptions,
   .paragraph--type--events.hide-descriptions & {
     .card__description {


### PR DESCRIPTION
For layout builder columns other than one-column, circle image styling was applied. This is either hardcoded (event) or is now controlled by layout builder styles.

# Test

- event and events blocks in v3 layout builder.
- event should stay circle regardless of column
- change the image to square or widescreen in an events block and move between 1-4 column layouts. the images should stay as you configured.

of course at smaller widths, it switches styles entirely which is expected.