### PR TITLE
Hotfix: Update default setting for featured image display field.

### DIFF
--- a/config/default/field.field.node.article.field_featured_image_display.yml
+++ b/config/default/field.field.node.article.field_featured_image_display.yml
@@ -15,9 +15,7 @@ label: 'Display setting'
 description: 'This setting only has an effect when a "Featured image" is uploaded.'
 required: false
 translatable: false
-default_value:
-  -
-    value: large
+default_value: {  }
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.node.page.field_featured_image_display.yml
+++ b/config/default/field.field.node.page.field_featured_image_display.yml
@@ -15,9 +15,7 @@ label: 'Display setting'
 description: 'This setting only has an effect when a "Featured image" is uploaded.'
 required: false
 translatable: false
-default_value:
-  -
-    value: large
+default_value: {  }
 default_value_callback: ''
 settings: {  }
 field_type: list_string


### PR DESCRIPTION
This updates the field default setting for featured image display fields. Resolves #2866 

# How to test

- `blt ds`
- `drush @default.local uli node/add/article`
- Check article edit screen and make sure default is set correctly.
- Visit https://default.local.drupal.uiowa.edu/node/add/page
- Check page edit screen and make sure default is set correctly.
