### PR TITLE
Feature: Enabled srop scholar view

### DIFF
--- a/config/grad.uiowa.edu/views.view.srop_scholars.yml
+++ b/config/grad.uiowa.edu/views.view.srop_scholars.yml
@@ -1,6 +1,6 @@
 uuid: 7138678e-9e96-4ebc-b20b-578be83126d5
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/2922. 

# How to test

- `blt ds --site=grad.uiowa.edu`
- Go to https://grad.local.drupal.uiowa.edu/dei/srop/past-scholars and verify that page is enabled. 