### PR TITLE
Disable security-checker for now since it was abandoned

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -24,6 +24,9 @@ drush:
     ci: self
   default_alias: self
 disable-targets:
+  security:
+    check:
+      composer: true
   drupal:
     toggle:
       modules: true

--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -24,9 +24,6 @@ drush:
     ci: self
   default_alias: self
 disable-targets:
-  security:
-    check:
-      composer: true
   drupal:
     toggle:
       modules: true
@@ -35,6 +32,9 @@ disable-targets:
       run: true
     frontend:
       run: true
+    security:
+      check:
+        composer: true
 tests:
   phpunit:
     - config: '${repo.root}'


### PR DESCRIPTION
sensiolabs/security-checker was abandoned and no longer works. This was replaced in BLT 12.x but not 11. We can't upgrade to BLT 12.x as it requires Drupal 9. There is a pending backport to BLT 11 buts lets just disable this for now.

# How to test

If tests pass.
