### PR TITLE
Admissions' Area of Study Stories Styles

### DIFF
--- a/config/admissions.uiowa.edu/core.entity_view_display.node.area_of_study.default.yml
+++ b/config/admissions.uiowa.edu/core.entity_view_display.node.area_of_study.default.yml
@@ -323,7 +323,7 @@ third_party_settings:
         layout_settings:
           label: ''
           layout_builder_styles_style:
-            - ''
+            - section_background_style_gray
             - ''
         components:
           -
@@ -335,7 +335,7 @@ third_party_settings:
               provider: layout_builder
               label_display: null
               formatter:
-                label: above
+                label: hidden
                 type: entity_reference_revisions_entity_view
                 settings:
                   view_mode: default
@@ -345,7 +345,9 @@ third_party_settings:
                 view_mode: view_mode
             additional: {  }
             weight: 0
-        third_party_settings: {  }
+        third_party_settings:
+          layout_builder_lock:
+            lock: {  }
       -
         layout_id: layout_onecol
         layout_settings:

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
@@ -136,9 +136,33 @@ function admissions_core_preprocess_entity_print(&$variables) {
  * Implements hook_preprocess_HOOK().
  */
 function admissions_core_preprocess_field(&$variables) {
-  // Add question mark to label.
-  if ($variables["element"]["#field_name"] == 'field_area_of_study_why') {
-    $variables["label"] = t('Why Iowa?');
+  switch ($variables["element"]["#field_name"]) {
+    case 'field_area_of_study_why':
+      $variables["label"] = t('Why Iowa?');
+      break;
+
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function admissions_core_preprocess_paragraph__admissions_card(&$variables) {
+  $admin_context = \Drupal::service('router.admin_context');
+  if (!$admin_context->isAdminRoute()) {
+    $paragraph = $variables['paragraph'];
+    $variables['delta'] = 0;
+    $parent = $paragraph->getParentEntity();
+    if ($parent instanceof ContentEntityInterface) {
+      if ($parent->hasField('field_area_of_study_stories')) {
+        $id = $paragraph->id();
+        foreach ($parent->get('field_area_of_study_stories')->getValue() as $delta => $item) {
+          if ($item['target_id'] === $id) {
+            $variables['zebra'] = ($delta % 2 == 0 ? 'odd':'even');
+          }
+        }
+      }
+    }
   }
 }
 

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/paragraph--admissions-card--default.html.twig
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/paragraph--admissions-card--default.html.twig
@@ -38,59 +38,37 @@
  * @ingroup themeable
  */
 #}
-{% set classes = [
-  'paragraph',
-  'paragraph--type--' ~ paragraph.bundle|clean_class,
-  view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
-  not paragraph.isPublished() ? 'paragraph--unpublished'
-] %}
 
-{% set card_attributes = create_attribute() %}
+{%
+  set classes = [
+  'card--list',
+  'card--enclosed',
+  'bg--white',
+  'media--widescreen',
+  'card--centered-left',
+  'card--alignment-left',
+  'card',
+]
+%}
 
-{% set no_body = (paragraph.field_card_title.isEmpty()) and (paragraph.field_card_subtitle.isEmpty()) and (paragraph.field_card_body.isEmpty()) %}
-<div{{ attributes.addclass(classes) }}>
+{% if zebra == 'odd' %}
+  {% set classes = classes|merge(['card--media-left']) %}
+{% else %}
+  {% set classes = classes|merge(['card--media-right']) %}
+{% endif %}
 
-  {% if no_body %}
-    {#
-          sitenow_card includes the ability to have just an image and a link.
-          This isn't considered a card in UIDS, so in that case we just output
-          an image wrapped in a link.
-    #}
-    {% set paragraph_card_link = {
-      'link_url': content.field_admissions_card_link[0]['#url'],
-      'link_class': 'media',
-      'card_image': content.field_admissions_card_media,
-    } %}
-    {% embed '@uids_base/uids/link.html.twig' with paragraph_card_link only %}
-      {% block link_content %}
-        {% if card_image is not empty %}
-          {{ card_image }}
-        {% endif %}
-      {% endblock %}
-    {% endembed %}
+{{ attach_library('classy/node') }}
 
-  {% else %}
-    {# This is a card and can be handled as such. #}
-    {% set paragraph_card = {
-      'attributes': card_attributes.addClass(['card--enclosed']),
-      'card_image': content.field_admissions_card_media|render,
-      'card_text': content.field_admissions_card_body,
-      'card_subtitle': content.field_admissions_card_subtitle,
-      'card_title': content.field_admissions_card_title|render,
-      'card_link_url': content.field_admissions_card_link[0]['#url'],
-      'headline_level': 'h2',
-      'paragraph': paragraph,
-    } %}
+{% set admissions_card = {
+  'attributes': attributes.addClass(classes),
+  'card_text': content.field_admissions_card_body,
+  'card_subtitle': content.field_admissions_card_subtitle,
+  'card_title': content.field_admissions_card_title|render,
+  'card_link_url': content.field_admissions_card_link[0]['#url'],
+  'card_image': content.field_admissions_card_media|render,
+  'media_sizes': 'card__media--large',
+  'card_link_url': url,
+  'headline_level': 'h2',
+} %}
 
-    {% embed '@uids_base/uids/card.html.twig' with paragraph_card only %}
-
-      {# We override this because the text is formatted already. #}
-      {% block card_content %}
-        {% if card_text is not empty %}
-          {{ card_text }}
-        {% endif %}
-      {% endblock %}
-
-    {% endembed %}
-  {% endif %}
-</div>
+{% embed '@uids_base/uids/card.html.twig' with admissions_card only %}{% endembed %}

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/paragraph--admissions-card--default.html.twig
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/paragraph--admissions-card--default.html.twig
@@ -61,10 +61,11 @@
 
 {% set admissions_card = {
   'attributes': attributes.addClass(classes),
-  'card_text': content.field_admissions_card_body,
+  'card_text': content.field_admissions_card_content,
   'card_subtitle': content.field_admissions_card_subtitle,
   'card_title': content.field_admissions_card_title|render,
   'card_link_url': content.field_admissions_card_link[0]['#url'],
+  'card_link_title': content.field_admissions_card_link[0]['#title']|render,
   'card_image': content.field_admissions_card_media|render,
   'media_sizes': 'card__media--large',
   'card_link_url': url,

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/paragraph--admissions-card--default.html.twig
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/paragraph--admissions-card--default.html.twig
@@ -68,7 +68,6 @@
   'card_link_title': content.field_admissions_card_link[0]['#title']|render,
   'card_image': content.field_admissions_card_media|render,
   'media_sizes': 'card__media--large',
-  'card_link_url': url,
   'headline_level': 'h2',
 } %}
 


### PR DESCRIPTION
Resolves #2965

## To Test

Pull and bring up http://admissions.local.drupal.uiowa.edu/areas-of-study/accounting
Compare to https://admissions.prod.drupal.uiowa.edu/academics/accounting for general card styling, _not_ content.