### PR TITLE
Admissions - Custom AoS block for Apply/Request buttons

### DIFF
--- a/config/admissions.uiowa.edu/core.entity_view_display.node.area_of_study.default.yml
+++ b/config/admissions.uiowa.edu/core.entity_view_display.node.area_of_study.default.yml
@@ -35,6 +35,7 @@ dependencies:
     - node.type.area_of_study
     - views.view.areas_of_study_block
   module:
+    - admissions_core
     - entity_reference_revisions
     - layout_builder
     - layout_builder_restrictions
@@ -207,7 +208,7 @@ third_party_settings:
                 block_padding_all: block_padding_all
                 block_margin_top: block_margin_top
                 block_margin_bottom: block_margin_bottom
-            weight: 7
+            weight: 8
           -
             uuid: 0eeb1ce7-7903-4640-89a5-cd8d147d3244
             region: first
@@ -236,6 +237,17 @@ third_party_settings:
               label_display: null
               views_label: ''
               items_per_page: none
+              context_mapping: {  }
+            additional: {  }
+            weight: 7
+          -
+            uuid: 088e48b0-97ec-479c-ae31-bac797a7e224
+            region: second
+            configuration:
+              id: aosbuttons_block
+              label: null
+              provider: admissions_core
+              label_display: null
               context_mapping: {  }
             additional: {  }
             weight: 6

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/area-of-study.scss
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/area-of-study.scss
@@ -25,6 +25,10 @@
   .bttn.bttn--link {
     padding-left: 0;
   }
+  // @todo remove after https://github.com/uiowa/uiowa/issues/2706 is fixed.
+  .views-element-container {
+    margin-top: 0;
+  }
 }
 
 .view-id-areas_of_study_block {

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/src/Plugin/Block/AOSButtons.php
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/src/Plugin/Block/AOSButtons.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\admissions_core\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * An Area of Study Buttons block.
+ *
+ * @Block(
+ *   id = "aosbuttons_block",
+ *   admin_label = @Translation("Area of Study Buttons Block"),
+ *   category = @Translation("Area of Study")
+ * )
+ */
+class AOSButtons extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return ['label_display' => FALSE];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $markup = '<div class="layout-builder-block block-margin__bottom">
+      <p>
+          <a class="bttn bttn--full bttn--primary bttn--caps" href="https://www.example.com">
+              Apply Now <span class="fa-arrow-right fas"></span>
+          </a>
+      </p>
+    </div>
+    <div class="layout-builder-block block-margin__bottom block-margin__top">
+      <p>
+        <a class="bttn bttn--full bttn--secondary bttn--caps" href="https://www.maui.uiowa.edu/maui/pub/admissions/webinquiry/undergraduate.page">
+            Request Info <span class="fa-arrow-right fas"></span>
+        </a>
+      </p>
+    </div>';
+
+    return ['#markup' => $markup];
+  }
+}

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/src/Plugin/Block/AOSButtons.php
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/src/Plugin/Block/AOSButtons.php
@@ -27,18 +27,14 @@ class AOSButtons extends BlockBase {
    */
   public function build() {
     $markup = '<div class="layout-builder-block block-margin__bottom">
-      <p>
-          <a class="bttn bttn--full bttn--primary bttn--caps" href="https://apply.admissions.uiowa.edu/admissions/login.page">
-              Apply Now <span class="fa-arrow-right fas"></span>
-          </a>
-      </p>
-    </div>
-    <div class="layout-builder-block block-margin__bottom block-margin__top">
-      <p>
-        <a class="bttn bttn--full bttn--secondary bttn--caps" href="https://www.maui.uiowa.edu/maui/pub/admissions/webinquiry/undergraduate.page">
-            Request Info <span class="fa-arrow-right fas"></span>
+        <a class="bttn bttn--full bttn--primary bttn--caps" href="https://apply.admissions.uiowa.edu/admissions/login.page">
+            Apply Now <span class="fa-arrow-right fas"></span>
         </a>
-      </p>
+    </div>
+    <div class="layout-builder-block block-margin__bottom block-margin__top--extra">
+      <a class="bttn bttn--full bttn--secondary bttn--caps" href="https://www.maui.uiowa.edu/maui/pub/admissions/webinquiry/undergraduate.page">
+          Request Info <span class="fa-arrow-right fas"></span>
+      </a>
     </div>';
 
     return ['#markup' => $markup];

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/src/Plugin/Block/AOSButtons.php
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/src/Plugin/Block/AOSButtons.php
@@ -28,7 +28,7 @@ class AOSButtons extends BlockBase {
   public function build() {
     $markup = '<div class="layout-builder-block block-margin__bottom">
       <p>
-          <a class="bttn bttn--full bttn--primary bttn--caps" href="https://www.example.com">
+          <a class="bttn bttn--full bttn--primary bttn--caps" href="https://apply.admissions.uiowa.edu/admissions/login.page">
               Apply Now <span class="fa-arrow-right fas"></span>
           </a>
       </p>


### PR DESCRIPTION
Resolves #2968

## To test

- Pull and go to http://admissions.local.drupal.uiowa.edu/areas-of-study/accounting
- See buttons in right side bar which match the mockup here: https://admissions.prod.drupal.uiowa.edu/academics/accounting
- Check the links to make sure they match #2968
- Structured as a custom block, dynamic labels are possible beyond MVP.
- As a webmaster, I can't place the block myself on the page content type.
- ???
- Profit