### PR TITLE
Add basic validation to article view arguments and hide feed icons for filtered displays.

### DIFF
--- a/config/default/views.view.articles.yml
+++ b/config/default/views.view.articles.yml
@@ -883,4 +883,3 @@ display:
         - user.permissions
       max-age: -1
       tags: {  }
-

--- a/config/default/views.view.articles.yml
+++ b/config/default/views.view.articles.yml
@@ -19,7 +19,6 @@ description: 'All articles, feed'
 tag: default
 base_table: node_field_data
 base_field: nid
-core: '8'
 display:
   default:
     id: default
@@ -134,7 +133,7 @@ display:
             format: default_summary
           specify_validation: true
           validate:
-            type: none
+            type: numeric
             fail: 'not found'
           validate_options: {  }
           entity_type: node
@@ -168,7 +167,7 @@ display:
             format: default_summary
           specify_validation: true
           validate:
-            type: none
+            type: numeric
             fail: 'not found'
           validate_options: {  }
           entity_type: node
@@ -182,6 +181,8 @@ display:
           group: 0
           expose:
             operator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
           plugin_id: boolean
           entity_type: node
           entity_field: status
@@ -210,6 +211,8 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -880,3 +883,4 @@ display:
         - user.permissions
       max-age: -1
       tags: {  }
+

--- a/docroot/modules/custom/sitenow_articles/sitenow_articles.install
+++ b/docroot/modules/custom/sitenow_articles/sitenow_articles.install
@@ -16,3 +16,21 @@ function sitenow_articles_update_8001() {
     ->set('display.page_articles.display_options.display_extenders.metatag_display_extender.metatags.description', 'The latest articles from [site:name].')
     ->save();
 }
+
+/**
+ * Add numeric validation to articles view arguments.
+ */
+function sitenow_articles_update_9001() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('views.view.articles');
+
+  $config
+    ->clear('core')
+    ->set('display.default.display_options.arguments.created_year.validate.type', 'numeric')
+    ->set('display.default.display_options.arguments.created_month.validate.type', 'numeric')
+    ->set('display.default.display_options.filters.status.expose.operator_limit_selection', false)
+    ->set('display.default.display_options.filters.status.expose.operator_list', NULL)
+    ->set('display.default.display_options.filters.type.expose.operator_limit_selection', false)
+    ->set('display.default.display_options.filters.type.expose.operator_list', NULL)
+    ->save();
+}

--- a/docroot/modules/custom/sitenow_articles/sitenow_articles.install
+++ b/docroot/modules/custom/sitenow_articles/sitenow_articles.install
@@ -29,8 +29,8 @@ function sitenow_articles_update_9001() {
     ->set('display.default.display_options.arguments.created_year.validate.type', 'numeric')
     ->set('display.default.display_options.arguments.created_month.validate.type', 'numeric')
     ->set('display.default.display_options.filters.status.expose.operator_limit_selection', false)
-    ->set('display.default.display_options.filters.status.expose.operator_list', NULL)
+    ->set('display.default.display_options.filters.status.expose.operator_list', [])
     ->set('display.default.display_options.filters.type.expose.operator_limit_selection', false)
-    ->set('display.default.display_options.filters.type.expose.operator_list', NULL)
+    ->set('display.default.display_options.filters.type.expose.operator_list', [])
     ->save();
 }

--- a/docroot/modules/custom/sitenow_articles/sitenow_articles.install
+++ b/docroot/modules/custom/sitenow_articles/sitenow_articles.install
@@ -20,7 +20,7 @@ function sitenow_articles_update_8001() {
 /**
  * Add numeric validation to articles view arguments.
  */
-function sitenow_articles_update_9001() {
+function sitenow_articles_update_9101() {
   $config_factory = \Drupal::configFactory();
   $config = $config_factory->getEditable('views.view.articles');
 

--- a/docroot/modules/custom/sitenow_articles/sitenow_articles.install
+++ b/docroot/modules/custom/sitenow_articles/sitenow_articles.install
@@ -28,9 +28,9 @@ function sitenow_articles_update_9001() {
     ->clear('core')
     ->set('display.default.display_options.arguments.created_year.validate.type', 'numeric')
     ->set('display.default.display_options.arguments.created_month.validate.type', 'numeric')
-    ->set('display.default.display_options.filters.status.expose.operator_limit_selection', false)
+    ->set('display.default.display_options.filters.status.expose.operator_limit_selection', FALSE)
     ->set('display.default.display_options.filters.status.expose.operator_list', [])
-    ->set('display.default.display_options.filters.type.expose.operator_limit_selection', false)
+    ->set('display.default.display_options.filters.type.expose.operator_limit_selection', FALSE)
     ->set('display.default.display_options.filters.type.expose.operator_list', [])
     ->save();
 }

--- a/docroot/modules/custom/sitenow_articles/sitenow_articles.module
+++ b/docroot/modules/custom/sitenow_articles/sitenow_articles.module
@@ -236,9 +236,9 @@ function sitenow_articles_preprocess_views_view(&$variables) {
         unset($variables['header']['area']);
       }
 
-      // If this the page display and two arguments were provided, this is
-      // filtered by month so we'll hide the not-so-useful feed link.
-      if ($view->current_display == 'page_articles' && count($view->args) == 2) {
+      // If this is the page display and arguments were provided, hide the
+      // feed icons since we don't want to promote those filtered RSS feeds.
+      if ($view->current_display == 'page_articles' && !empty($view->args)) {
         $variables['feed_icons'] = [];
       }
 

--- a/docroot/modules/custom/sitenow_articles/sitenow_articles.module
+++ b/docroot/modules/custom/sitenow_articles/sitenow_articles.module
@@ -227,11 +227,22 @@ function sitenow_articles_node_view(array &$build, EntityInterface $entity, Enti
  * Implements hook_preprocess_HOOK().
  */
 function sitenow_articles_preprocess_views_view(&$variables) {
-  switch ($variables["id"]) {
+  switch ($variables['id']) {
     case 'articles':
-      if (empty($variables["header"]["area"]["#text"])) {
-        unset($variables["header"]["area"]);
+      /** @var  \Drupal\views\ViewExecutable $view */
+      $view = $variables['view'];
+
+      if (empty($variables['header']['area']['#text'])) {
+        unset($variables['header']['area']);
       }
+
+      // If this the page display and two arguments were provided, this is
+      // filtered by month so we'll hide the not-so-useful feed link.
+      if ($view->current_display == 'page_articles' && count($view->args) == 2) {
+        $variables['feed_icons'] = [];
+      }
+
+
       break;
 
   }

--- a/docroot/modules/custom/sitenow_articles/sitenow_articles.module
+++ b/docroot/modules/custom/sitenow_articles/sitenow_articles.module
@@ -242,7 +242,6 @@ function sitenow_articles_preprocess_views_view(&$variables) {
         $variables['feed_icons'] = [];
       }
 
-
       break;
 
   }

--- a/docroot/modules/custom/sitenow_articles/src/Form/SettingsForm.php
+++ b/docroot/modules/custom/sitenow_articles/src/Form/SettingsForm.php
@@ -221,7 +221,7 @@ class SettingsForm extends ConfigFormBase {
       '#type' => 'checkbox',
       '#title' => $this->t('Show RSS Feed icon'),
       '#default_value' => $show_feed,
-      '#description' => $this->t('If checked, a linked RSS icon will be displayed.'),
+      '#description' => $this->t('If checked, a linked RSS icon will be displayed on the main news page and year views.'),
       '#size' => 60,
     ];
 

--- a/docroot/modules/custom/sitenow_articles/src/Form/SettingsForm.php
+++ b/docroot/modules/custom/sitenow_articles/src/Form/SettingsForm.php
@@ -221,7 +221,7 @@ class SettingsForm extends ConfigFormBase {
       '#type' => 'checkbox',
       '#title' => $this->t('Show RSS Feed icon'),
       '#default_value' => $show_feed,
-      '#description' => $this->t('If checked, a linked RSS icon will be displayed on the main news page and year views.'),
+      '#description' => $this->t('If checked, a linked RSS icon will be displayed on the main news page.'),
       '#size' => 60,
     ];
 


### PR DESCRIPTION
Resolves #2031 
Resolves #1310 

### Testing
- Sync a number of sites to ensure database update sitenow_articles_9001 runs ok.
- Log in to a site locally and test that the show/hide feed icon config for articles works as expected.
  - Note the change that it only appears on the main news page.
- Put in an article views argument as text and see that a 404 is returned as it does not validate.
  - https://default.local.drupal.uiowa.edu/news/asdf/asdf
  - https://default.local.drupal.uiowa.edu/news/feed/asdf/asdf