### PR TITLE
fix subject line on presidential search contact form

### DIFF
--- a/config/presidentialsearch.uiowa.edu/webform.webform.contact.yml
+++ b/config/presidentialsearch.uiowa.edu/webform.webform.contact.yml
@@ -23,9 +23,13 @@ javascript: ''
 settings:
   ajax: false
   ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
   page: true
   page_submit_path: ''
   page_confirm_path: ''
+  page_theme_name: ''
   form_title: source_entity_webform
   form_submit_once: false
   form_exception_message: ''
@@ -34,7 +38,7 @@ settings:
   form_previous_submissions: true
   form_confidential: false
   form_confidential_message: ''
-  form_remote_addr: true
+  form_disable_remote_addr: false
   form_convert_anonymous: false
   form_prepopulate: false
   form_prepopulate_source_entity: false
@@ -55,6 +59,11 @@ settings:
   form_access_denied_message: ''
   form_access_denied_attributes: {  }
   form_file_limit: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
   submission_label: ''
   submission_log: false
   submission_views: {  }
@@ -79,11 +88,20 @@ settings:
   wizard_progress_pages: false
   wizard_progress_percentage: false
   wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
   wizard_start_label: ''
   wizard_preview_link: false
   wizard_confirmation: true
   wizard_confirmation_label: ''
   wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
   preview: 0
   preview_label: ''
   preview_title: ''
@@ -97,6 +115,8 @@ settings:
   draft_auto_save: false
   draft_saved_message: ''
   draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
   confirmation_type: url_message
   confirmation_title: ''
   confirmation_message: 'Thank you for your feedback! Your message has been sent to the search committee.'
@@ -107,6 +127,7 @@ settings:
   confirmation_back_attributes: {  }
   confirmation_exclude_query: false
   confirmation_exclude_token: false
+  confirmation_update: false
   limit_total: null
   limit_total_interval: null
   limit_total_message: ''
@@ -123,30 +144,10 @@ settings:
   purge_days: null
   results_disabled: false
   results_disabled_ignore: false
-  token_update: false
-  ajax_progress_type: ''
-  ajax_effect: ''
-  ajax_speed: null
-  page_theme_name: ''
-  share: false
-  share_node: false
-  share_theme_name: ''
-  share_title: true
-  share_page_body_attributes: {  }
-  wizard_progress_states: false
-  wizard_auto_forward: true
-  wizard_auto_forward_hide_next_button: false
-  wizard_keyboard: true
-  wizard_prev_button_label: ''
-  wizard_next_button_label: ''
-  wizard_toggle: false
-  wizard_toggle_show_label: ''
-  wizard_toggle_hide_label: ''
-  draft_pending_single_message: ''
-  draft_pending_multiple_message: ''
-  confirmation_update: false
   results_customize: false
   token_view: false
+  token_update: false
+  token_delete: false
   serial_disabled: false
 access:
   create:
@@ -222,16 +223,16 @@ handlers:
       ignore_access: false
       exclude_empty: true
       exclude_empty_checkbox: false
+      exclude_attachments: false
       html: true
       attachments: false
       twig: false
-      theme_name: ''
       debug: false
       reply_to: ''
       return_path: ''
       sender_mail: ''
       sender_name: ''
-      exclude_attachments: false
+      theme_name: ''
       parameters: {  }
   email_notification:
     id: email
@@ -253,21 +254,21 @@ handlers:
       from_mail: _default
       from_options: {  }
       from_name: _default
-      subject: '[webform_submission:values:subject:raw]'
+      subject: 'Presidential Search - Share your feedback'
       body: "Submitted on [webform_submission:created]<br />\r\n<br />\r\nCommittee Contact (Optional): [webform_submission:values:committee_contact]<br />\r\n<br />\r\n[webform_submission:values:name]<br />\r\n[webform_submission:values:email]<br />\r\n<br />\r\nMessage:<br />\r\n[webform_submission:values:message]"
       excluded_elements: {  }
       ignore_access: false
       exclude_empty: true
       exclude_empty_checkbox: false
+      exclude_attachments: false
       html: true
       attachments: false
       twig: false
-      theme_name: ''
       debug: false
       reply_to: ''
       return_path: ''
       sender_mail: ''
       sender_name: ''
-      exclude_attachments: false
+      theme_name: ''
       parameters: {  }
 variants: {  }


### PR DESCRIPTION
It is currently sending out a raw token for a subject line. everything else is a post update config update.

https://github.com/uiowa/uiowa/pull/3073/files#diff-4658bdec1948a0273bd4d7bc972d1ef9a71f55fecedd9c718acbdea524b51874R257