### PR TITLE
Move database size query to separate command and limit scope of status alter.

### DIFF
--- a/drush/Commands/UiowaCommands.php
+++ b/drush/Commands/UiowaCommands.php
@@ -50,6 +50,7 @@ class UiowaCommands extends DrushCommands implements SiteAliasManagerAwareInterf
     $defaults = $annotationData->getList('default-fields');
 
     // If no specific fields were requested, add ours to the defaults.
+    // @todo Is there a more-defined context for when to do this?
     if ($fields == $defaults) {
       $annotationData->append('field-labels', "\n application: Application");
       array_unshift($defaults, 'application');

--- a/drush/Commands/UiowaCommands.php
+++ b/drush/Commands/UiowaCommands.php
@@ -19,39 +19,39 @@ class UiowaCommands extends DrushCommands implements SiteAliasManagerAwareInterf
   use SiteAliasManagerAwareTrait;
   use ProcessManagerAwareTrait;
 
-  /**
-   * Add database size to status command output.
-   *
-   * @param mixed $result
-   *   The command result.
-   * @param \Consolidation\AnnotatedCommand\CommandData $commandData
-   *   The command data.
-   *
-   * @hook alter core:status
-   *
-   * @return array
-   *   The altered command result.
-   */
-  public function alterStatus($result, CommandData $commandData) {
-    if ($app = getenv('AH_SITE_GROUP')) {
-      $result['application'] = $app;
-    }
-
-    return $result;
-  }
-
-  /**
-   * Add the DB size field label to the status command annotation data.
-   *
-   * @hook init core:status
-   */
-  public function initStatus(InputInterface $input, AnnotationData $annotationData) {
-    $annotationData->append('field-labels', "\n application: Application");
-    $defaults = $annotationData->getList('default-fields');
-    array_unshift($defaults, 'application');
-    $annotationData->set('default-fields', $defaults);
-    $input->setOption('fields', $defaults);
-  }
+//  /**
+//   * Add database size to status command output.
+//   *
+//   * @param mixed $result
+//   *   The command result.
+//   * @param \Consolidation\AnnotatedCommand\CommandData $commandData
+//   *   The command data.
+//   *
+//   * @hook alter core:status
+//   *
+//   * @return array
+//   *   The altered command result.
+//   */
+//  public function alterStatus($result, CommandData $commandData) {
+//    if ($app = getenv('AH_SITE_GROUP')) {
+//      $result['application'] = $app;
+//    }
+//
+//    return $result;
+//  }
+//
+//  /**
+//   * Add the DB size field label to the status command annotation data.
+//   *
+//   * @hook init core:status
+//   */
+//  public function initStatus(InputInterface $input, AnnotationData $annotationData) {
+//    $annotationData->append('field-labels', "\n application: Application");
+//    $defaults = $annotationData->getList('default-fields');
+//    array_unshift($defaults, 'application');
+//    $annotationData->set('default-fields', $defaults);
+//    $input->setOption('fields', $defaults);
+//  }
 
   /**
    * Invoke BLT update command after sql:sync for remote targets only.

--- a/drush/Commands/UiowaCommands.php
+++ b/drush/Commands/UiowaCommands.php
@@ -46,11 +46,16 @@ class UiowaCommands extends DrushCommands implements SiteAliasManagerAwareInterf
    * @hook init core:status
    */
   public function initStatus(InputInterface $input, AnnotationData $annotationData) {
-    $annotationData->append('field-labels', "\n application: Application");
+    $fields = explode(',', $input->getOption('fields'));
     $defaults = $annotationData->getList('default-fields');
-    array_unshift($defaults, 'application');
-    $annotationData->set('default-fields', $defaults);
-    $input->setOption('fields', $defaults);
+
+    // If no specific fields were requested, add ours to the defaults.
+    if ($fields == $defaults) {
+      $annotationData->append('field-labels', "\n application: Application");
+      array_unshift($defaults, 'application');
+      $annotationData->set('default-fields', $defaults);
+      $input->setOption('fields', $defaults);
+    }
   }
 
   /**

--- a/drush/Commands/UiowaCommands.php
+++ b/drush/Commands/UiowaCommands.php
@@ -20,7 +20,7 @@ class UiowaCommands extends DrushCommands implements SiteAliasManagerAwareInterf
   use ProcessManagerAwareTrait;
 
   /**
-   * Add database size to status command output.
+   * Add additional fields to status command output.
    *
    * @param mixed $result
    *   The command result.

--- a/drush/Commands/UiowaCommands.php
+++ b/drush/Commands/UiowaCommands.php
@@ -41,7 +41,7 @@ class UiowaCommands extends DrushCommands implements SiteAliasManagerAwareInterf
   }
 
   /**
-   * Add the DB size field label to the status command annotation data.
+   * Add custom field labels to the status command annotation data.
    *
    * @hook init core:status
    */

--- a/drush/Commands/UiowaCommands.php
+++ b/drush/Commands/UiowaCommands.php
@@ -19,39 +19,39 @@ class UiowaCommands extends DrushCommands implements SiteAliasManagerAwareInterf
   use SiteAliasManagerAwareTrait;
   use ProcessManagerAwareTrait;
 
-//  /**
-//   * Add database size to status command output.
-//   *
-//   * @param mixed $result
-//   *   The command result.
-//   * @param \Consolidation\AnnotatedCommand\CommandData $commandData
-//   *   The command data.
-//   *
-//   * @hook alter core:status
-//   *
-//   * @return array
-//   *   The altered command result.
-//   */
-//  public function alterStatus($result, CommandData $commandData) {
-//    if ($app = getenv('AH_SITE_GROUP')) {
-//      $result['application'] = $app;
-//    }
-//
-//    return $result;
-//  }
-//
-//  /**
-//   * Add the DB size field label to the status command annotation data.
-//   *
-//   * @hook init core:status
-//   */
-//  public function initStatus(InputInterface $input, AnnotationData $annotationData) {
-//    $annotationData->append('field-labels', "\n application: Application");
-//    $defaults = $annotationData->getList('default-fields');
-//    array_unshift($defaults, 'application');
-//    $annotationData->set('default-fields', $defaults);
-//    $input->setOption('fields', $defaults);
-//  }
+  /**
+   * Add database size to status command output.
+   *
+   * @param mixed $result
+   *   The command result.
+   * @param \Consolidation\AnnotatedCommand\CommandData $commandData
+   *   The command data.
+   *
+   * @hook alter core:status
+   *
+   * @return array
+   *   The altered command result.
+   */
+  public function alterStatus($result, CommandData $commandData) {
+    if ($app = getenv('AH_SITE_GROUP')) {
+      $result['application'] = $app;
+    }
+
+    return $result;
+  }
+
+  /**
+   * Add the DB size field label to the status command annotation data.
+   *
+   * @hook init core:status
+   */
+  public function initStatus(InputInterface $input, AnnotationData $annotationData) {
+    $annotationData->append('field-labels', "\n application: Application");
+    $defaults = $annotationData->getList('default-fields');
+    array_unshift($defaults, 'application');
+    $annotationData->set('default-fields', $defaults);
+    $input->setOption('fields', $defaults);
+  }
 
   /**
    * Invoke BLT update command after sql:sync for remote targets only.


### PR DESCRIPTION
The Drush status command is used by other commands (Drush, BLT, etc.) to check various things. Running our database size query every time was coming up in the slow query logs on AC. This moves it to a separate command to avoid that. This also only alters status output if no specific fields were provided via input option which I think was breaking a couple things.

I think this actually resolves #1338 - I've deployed this feature branch to dev.

### Testing
- On main, run `blt doctor` and notice that it reports errors.
- Check out this branch, and run `blt doctor` again. Should have no errors.
- Run `drush @home.dev uiowa:database:size`.
- Run `drush @home.dev uiowa:table:size`.
- Run `drush @home.dev status` and notice application is in output.
- Run `drush @home.dev status --fields db-name` and notice application is not in output.
- Run `drush @home.test rsync @self:%files @uiowa.test:%files` and see that the command errors.
- Run `drush @home.dev rsync @self:%files @uiowa.dev:%files` and see that the command will run but please cancel!

Todo:
- [ ] Update slackbot response if this works.