### PR TITLE
HR Video - fix default and full size, fix ckeditor versions

### DIFF
--- a/docroot/themes/custom/uiowa_bootstrap/scss/partials/03_components/media/_embedded-entity.scss
+++ b/docroot/themes/custom/uiowa_bootstrap/scss/partials/03_components/media/_embedded-entity.scss
@@ -1,258 +1,267 @@
-.embed-responsive {
-  position: relative;
-  display: block;
-  width: 100%;
-  padding: 0;
-  overflow: hidden;
-}
-
-.embed-responsive embed,
-.embed-responsive iframe,
-.embed-responsive object,
-.embed-responsive video {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border: 0;
-}
-
-@media (min-width: 576px) {
-
-  .align-right.media {
-    margin-left: 1rem;
+body:not(.cke_editable) {
+  .embed-responsive {
+    position: relative;
+    display: block;
+    width: 100%;
+    padding: 0;
+    overflow: hidden;
   }
 
-  .align-left.media {
-    margin-right: 1rem;
+  .embed-responsive embed,
+  .embed-responsive iframe,
+  .embed-responsive object,
+  .embed-responsive video {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
   }
 
-  .align-right.media--type-remote-video {
-    width: auto;
-    margin-left: 1rem;
-    .field--name-field-media-oembed-video iframe {
-      float: right;
+  @media (min-width: 576px) {
+
+    .align-right.media {
+      margin-left: 1rem;
+    }
+
+    .align-left.media {
+      margin-right: 1rem;
+    }
+
+    .align-right.media--type-remote-video {
+      width: auto;
+      margin-left: 1rem;
+
+      .field--name-field-media-oembed-video iframe {
+        float: right;
+      }
+    }
+    .align-left.media--type-remote-video {
+      width: auto;
+      margin-right: 1rem;
+
+      .field--name-field-media-oembed-video iframe {
+        float: left;
+      }
+    }
+
+  }
+
+  .align-center.media--type-remote-video {
+    & .field--name-field-media-oembed-video iframe {
+      margin: 0 auto;
     }
   }
-  .align-left.media--type-remote-video {
-    width: auto;
-    margin-right: 1rem;
-    .field--name-field-media-oembed-video iframe {
+
+  .media--type-remote-video {
+    @extend .embed-responsive;
+    padding-bottom: 56.25%;
+
+    &.media--view-mode-full,
+    &.media--view-mode-default,
+    &.media--view-mode-image-large,
+    &.media--view-mode-image-medium,
+    &.media--view-mode-image-small,
+    &.media--view-mode-large,
+    &.media--view-mode-medium,
+    &.media--view-mode-small,
+    figure.caption & {
+      @include media-breakpoint-up(sm) {
+        padding-bottom: 0;
+      }
+    }
+  }
+
+  figure.caption .media--type-remote-video iframe,
+  .media--type-remote-video.media--view-mode-image-medium iframe,
+  .media--type-remote-video.media--view-mode-image-large iframe,
+  .media--type-remote-video.media--view-mode-image-small iframe,
+  .media--type-remote-video.media--view-mode-medium iframe,
+  .media--type-remote-video.media--view-mode-large iframe,
+  .media--type-remote-video.media--view-mode-small iframe {
+    @include media-breakpoint-up(sm) {
+      position: unset;
+      display: inherit;
+      width: auto;
+      height: auto;
+      padding: 0;
+      overflow: auto;
+    }
+  }
+
+  figure.caption .media--type-remote-video.media--view-mode-image-large iframe,
+  figure.caption .media--type-remote-video.media--view-mode-large iframe,
+  figure.caption .media--type-remote-video.media--view-mode-full iframe,
+  .media--type-remote-video.media--view-mode-large iframe,
+  .media--type-remote-video.media--view-mode-image-large iframe {
+    @include media-breakpoint-up(sm) {
+      width: 854px;
+      height: 480px;
+    }
+  }
+
+  figure.caption .media--type-remote-video.media--view-mode-image-medium iframe,
+  figure.caption .media--type-remote-video.media--view-mode-medium iframe,
+  .media--type-remote-video.media--view-mode-image-medium iframe,
+  .media--type-remote-video.media--view-mode-medium iframe {
+    @include media-breakpoint-up(sm) {
+      width: 640px;
+      height: 360px;
+    }
+  }
+
+  figure.caption .media--type-remote-video.media--view-mode-image-small iframe,
+  figure.caption .media--type-remote-video.media--view-mode-small iframe,
+  .media--type-remote-video.media--view-mode-small iframe,
+  .media--type-remote-video.media--view-mode-image-small iframe {
+    @include media-breakpoint-up(sm) {
+      width: 426px;
+      height: 240px;
+    }
+  }
+
+  .embedded-entity {
+    max-width: 100%;
+    margin-bottom: 0;
+
+    figure & {
+      margin-bottom: 0;
+    }
+
+    figcaption {
+      margin-top: 0.5rem;
+    }
+  }
+
+
+  .embedded-entity + p {
+    margin-top: 1rem !important;
+  }
+
+  .embedded-entity.align-center,
+  .media.align-center {
+    .field--name-field-media-oembed-video iframe,
+    .field--name-field-media-instagram iframe {
+      margin: 0 auto !important;
+    }
+  }
+
+  figure.caption {
+    display: block;
+
+    @include media-breakpoint-up(sm) {
+      display: table;
+    }
+
+    margin: 0;
+    margin-bottom: .5rem;
+
+    &.align-center {
+      margin-right: auto;
+      margin-left: auto;
+    }
+
+    figcaption {
+      display: block;
+
+      @include media-breakpoint-up(sm) {
+        display: table-caption;
+      }
+
+      max-width: none;
+      caption-side: bottom;
+    }
+  }
+
+  .align-left,
+  figure.align-left,
+  .align-left.embedded-entity,
+  .align-left .embedded-entity {
+    float: none;
+    margin: 0;
+
+    @include media-breakpoint-up(sm) {
+      margin-right: 1rem;
+      margin-bottom: .5rem;
       float: left;
     }
   }
 
-}
-
-.align-center.media--type-remote-video {
-  & .field--name-field-media-oembed-video iframe {
-    margin: 0 auto;
-  }
-}
-
-.media--type-remote-video {
-  @extend .embed-responsive;
-  &.media--view-mode-full,
-  &.media--view-mode-default,
-  &.media--view-mode-image-large,
-  &.media--view-mode-image-medium,
-  &.media--view-mode-image-small,
-  &.media--view-mode-large,
-  &.media--view-mode-medium,
-  &.media--view-mode-small,
-  figure.caption & {
-    @include media-breakpoint-up(sm) {
-      padding-bottom: 0;
-    }
-  }
-}
-
-figure.caption .media--type-remote-video iframe,
-.media--type-remote-video.media--view-mode-full iframe,
-.media--type-remote-video.media--view-mode-default iframe,
-.media--type-remote-video.media--view-mode-image-medium iframe,
-.media--type-remote-video.media--view-mode-image-large iframe,
-.media--type-remote-video.media--view-mode-image-small iframe,
-.media--type-remote-video.media--view-mode-medium iframe,
-.media--type-remote-video.media--view-mode-large iframe,
-.media--type-remote-video.media--view-mode-small iframe {
-  @include media-breakpoint-up(sm) {
-    position: unset;
-    display: inherit;
-    width: auto;
-    height: auto;
-    padding: 0;
-    overflow: auto;
-  }
-}
-
-figure.caption .media--type-remote-video.media--view-mode-image-large iframe,
-figure.caption .media--type-remote-video.media--view-mode-large iframe,
-figure.caption .media--type-remote-video.media--view-mode-full iframe,
-.media--type-remote-video.media--view-mode-large iframe,
-.media--type-remote-video.media--view-mode-image-large iframe {
-  @include media-breakpoint-up(sm) {
-    width: 854px;
-    height: 480px;
-  }
-}
-
-figure.caption .media--type-remote-video.media--view-mode-image-medium iframe,
-figure.caption .media--type-remote-video.media--view-mode-medium iframe,
-.media--type-remote-video.media--view-mode-image-medium iframe,
-.media--type-remote-video.media--view-mode-medium iframe {
-  @include media-breakpoint-up(sm) {
-    width: 640px;
-    height: 360px;
-  }
-}
-
-figure.caption .media--type-remote-video.media--view-mode-image-small iframe,
-figure.caption .media--type-remote-video.media--view-mode-small iframe,
-.media--type-remote-video.media--view-mode-small iframe,
-.media--type-remote-video.media--view-mode-image-small iframe {
-  @include media-breakpoint-up(sm) {
-    width: 426px;
-    height: 240px;
-  }
-}
-
-.embedded-entity {
-  max-width: 100%;
-  margin-bottom: 0;
-
-  figure & {
-    margin-bottom: 0;
-  }
-
-  figcaption {
-    margin-top: 0.5rem;
-  }
-}
-
-
-.embedded-entity+p {
-  margin-top: 1rem !important;
-}
-
-.embedded-entity.align-center,
-.media.align-center {
-  .field--name-field-media-oembed-video iframe,
-  .field--name-field-media-instagram iframe {
-    margin: 0 auto !important;
-  }
-}
-
-figure.caption {
-  display: block;
-
-  @include media-breakpoint-up(sm) {
-    display: table;
-  }
-
-  margin: 0;
-  margin-bottom: .5rem;
-
-  &.align-center {
-    margin-right: auto;
-    margin-left: auto;
-  }
-
-  figcaption {
-    display: block;
-
-    @include media-breakpoint-up(sm) {
-      display: table-caption;
-    }
-
-    max-width: none;
-    caption-side: bottom;
-  }
-}
-
-.align-left,
-figure.align-left,
-.align-left.embedded-entity,
-.align-left .embedded-entity {
-  float: none;
-  margin: 0;
-
-  @include media-breakpoint-up(sm) {
-    margin-right: 1rem;
-    margin-bottom: .5rem;
-    float: left;
-  }
-}
-
-.align-right,
-figure.align-right,
-.align-right.embedded-entity,
-.align-right .embedded-entity {
-  float: none;
-  margin: 0;
-
-  @include media-breakpoint-up(sm) {
-    margin-left: 1rem;
-    margin-bottom: .5rem;
-    float: right;
-  }
-}
-
-figure.caption .embedded-entity+figcaption {
-  font-size: 90%;
-  color: $gray-900;
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
-}
-
-figure.caption.align-right .embedded-entity+figcaption {
-  @include media-breakpoint-up(sm) {
-    text-align: right;
-  }
-}
-
-.alert {
-  figure.caption .embedded-entity+figcaption {
-    color: $gray-900;
-  }
-}
-
-// Media alignment
-
-@media (min-width: 576px) {
-
+  .align-right,
+  figure.align-right,
   .align-right.embedded-entity,
   .align-right .embedded-entity {
-    margin-left: 1rem;
+    float: none;
+    margin: 0;
+
+    @include media-breakpoint-up(sm) {
+      margin-left: 1rem;
+      margin-bottom: .5rem;
+      float: right;
+    }
   }
 
-  .align-left.embedded-entity,
-  .align-left .embedded-entity {
-    margin-right: 1rem;
+  figure.caption .embedded-entity + figcaption {
+    font-size: 90%;
+    color: $gray-900;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
   }
 
-}
+  figure.caption.align-right .embedded-entity + figcaption {
+    @include media-breakpoint-up(sm) {
+      text-align: right;
+    }
+  }
+
+  .alert {
+    figure.caption .embedded-entity + figcaption {
+      color: $gray-900;
+    }
+  }
+
+  // Media alignment
+
+  @media (min-width: 576px) {
+
+    .align-right.embedded-entity,
+    .align-right .embedded-entity {
+      margin-left: 1rem;
+    }
+
+    .align-left.embedded-entity,
+    .align-left .embedded-entity {
+      margin-right: 1rem;
+    }
+
+  }
 
 
-.align-center {
-  text-align: center;
-}
+  .align-center {
+    text-align: center;
+  }
 
-.embedded-entity.align-center {
+  .embedded-entity.align-center {
 
-  .media--type-image,
+    .media--type-image,
+    .field--name-field-media-image {
+      margin: 0 auto;
+    }
+  }
+
   .field--name-field-media-image {
-    margin: 0 auto;
+    min-width: 1px;
+
+    img {
+      max-width: 100%;
+      height: auto;
+    }
   }
-}
 
-.field--name-field-media-image {
-  min-width: 1px;
-
-  img {
-    max-width: 100%;
-    height: auto;
+  .media--type-remote-video.media--view-mode-default,
+  .media--type-remote-video.media--view-mode-full {
+    padding-bottom: 56.25%;
   }
 }


### PR DESCRIPTION
Follow up hotfix to https://github.com/uiowa/uiowa/pull/3109 where i got the video to render again but it was the wrong size

The default/full should be full-width on render and actually clickable/configurable in the WYSIWYG.

Looks like a lot but it is just wrapping an exclusion for ckeditor (everything is loaded in hr, so this problem doesn't happen in v2/v3) and making the default/full view mode full width responsive.

`body:not(.cke_editable) {}` is causing the large diff