### PR TITLE
Feature: slider padding fix

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/banner.scss
+++ b/docroot/themes/custom/uids_base/scss/components/banner.scss
@@ -97,6 +97,15 @@
 // Adjust padding for left aligned bottom content
 .layout--onecol {
   &[class*=page__container--edge] {
+    .slider__slide {
+      .banner.banner--vertical-bottom.banner--horizontal-left {
+        .banner__content {
+          @include breakpoint(container) {
+            padding: 3rem 1.5rem 4rem;
+          }
+        }
+      }
+    }
     .banner.banner--vertical-bottom.banner--horizontal-left {
       .banner__content {
         @include breakpoint(container) {


### PR DESCRIPTION
Resolves #3129. 

# How to test

`blt ds --site=sandbox.uiowa.edu`
`yarn workspace uids_base gulp --development`
`drush @sandbox.local uli`
`drush @sandbox.local cr`
Change slider on home page to "Edge to Edge" and verify that the slider slides have padding on them. 