### PR TITLE
Set date input placeholder attribute to expected format.

### DIFF
--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -850,6 +850,15 @@ function uids_base_preprocess_input(&$variables) {
   if (isset($variables['element']['#name']) && $variables['element']['#name'] === 'search-terms') {
     $variables['attributes']['class'] = [];
   }
+
+  // Set the placeholder attribute for date inputs if we know the expected
+  // format and no placeholder has already been set. This helps people input
+  // the date as a string for browsers that do not support the HTML input.
+  if (isset($variables['element']['#type']) && $variables['element']['#type'] === 'date') {
+    if (!isset($variables['attributes']['placeholder']) && isset($variables['element']['#date_date_format'])) {
+      $variables['attributes']['placeholder'] = $variables['element']['#date_date_format'];
+    }
+  }
 }
 
 /**

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -851,13 +851,11 @@ function uids_base_preprocess_input(&$variables) {
     $variables['attributes']['class'] = [];
   }
 
-  // Set the placeholder attribute for date inputs if we know the expected
-  // format and no placeholder has already been set. This helps people input
-  // the date as a string for browsers that do not support the HTML input.
+  // Set the placeholder attribute for date inputs. The required format is
+  // always YYYY-MM-DD. This helps people input the date as a string for
+  // browsers that do not support the HTML input.
   if (isset($variables['element']['#type']) && $variables['element']['#type'] === 'date') {
-    if (!isset($variables['attributes']['placeholder']) && isset($variables['element']['#date_date_format'])) {
-      $variables['attributes']['placeholder'] = $variables['element']['#date_date_format'];
-    }
+    $variables['attributes']['placeholder'] = 'YYYY-MM-DD';
   }
 }
 

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -853,7 +853,7 @@ function uids_base_preprocess_input(&$variables) {
 
   // Set the placeholder attribute for date inputs. The required format is
   // always YYYY-MM-DD. This helps people input the date as a string for
-  // browsers that do not support the HTML input.
+  // browsers that do not support the HTML date element.
   if (isset($variables['element']['#type']) && $variables['element']['#type'] === 'date') {
     $variables['attributes']['placeholder'] = 'YYYY-MM-DD';
   }


### PR DESCRIPTION
Resolves #3126

I thought this was a better workaround than adding back a jQuery UI or other JS polyfill. Safari will hopefully support date input elements soon.

### Testing
- `blt sync --site designcenter.uiowa.edu`
- Open https://designcenter.local.drupal.uiowa.edu/form/submit-job-request in Safari or IE.
- Notice that the placeholder value for the Due Date field is set to the expected format.
- Try to submit the form.
- Open the same form in Chrome, FireFox, etc. Notice the placeholder does not display.
- Try to submit the form.

Another workaround for this is to use the Date List webform component instead which offers dropdowns for each element of a date - year, month, etc. We should document this on https://sitenow.uiowa.edu/known-issues.