### PR TITLE
Feature: Adjust field order on area of study

### DIFF
--- a/config/admissions.uiowa.edu/core.entity_form_display.node.area_of_study.default.yml
+++ b/config/admissions.uiowa.edu/core.entity_form_display.node.area_of_study.default.yml
@@ -65,7 +65,7 @@ third_party_settings:
         - field_area_of_study_competitive
         - field_area_of_study_comp_txt
       parent_name: ''
-      weight: 15
+      weight: 2
       format_type: fieldset
       region: content
       format_settings:
@@ -81,7 +81,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 3
+    weight: 5
     settings:
       rows: 9
       summary_rows: 3
@@ -96,7 +96,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_area_of_study_career:
-    weight: 9
+    weight: 12
     settings:
       rows: 5
       placeholder: ''
@@ -126,7 +126,7 @@ content:
     type: options_buttons
     region: content
   field_area_of_study_course_work:
-    weight: 12
+    weight: 16
     settings:
       rows: 5
       placeholder: ''
@@ -135,7 +135,7 @@ content:
     region: content
   field_area_of_study_first_year:
     type: paragraphs
-    weight: 6
+    weight: 9
     settings:
       title: Requirement
       title_plural: Requirement
@@ -174,7 +174,7 @@ content:
     region: content
   field_area_of_study_intl:
     type: paragraphs
-    weight: 8
+    weight: 11
     settings:
       title: Requirement
       title_plural: Requirement
@@ -192,7 +192,7 @@ content:
     third_party_settings: {  }
     region: content
   field_area_of_study_link:
-    weight: 16
+    weight: 3
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -200,7 +200,7 @@ content:
     type: link_default
     region: content
   field_area_of_study_mail_code:
-    weight: 1
+    weight: 4
     settings:
       size: 60
       placeholder: ''
@@ -243,7 +243,7 @@ content:
     type: string_textfield
     region: content
   field_area_of_study_opportunity:
-    weight: 10
+    weight: 13
     settings:
       rows: 5
       placeholder: ''
@@ -259,7 +259,7 @@ content:
     type: string_textfield
     region: content
   field_area_of_study_requirement:
-    weight: 5
+    weight: 8
     settings:
       rows: 5
       placeholder: ''
@@ -267,7 +267,7 @@ content:
     type: text_textarea
     region: content
   field_area_of_study_scholarship:
-    weight: 11
+    weight: 14
     settings:
       rows: 5
       placeholder: ''
@@ -290,7 +290,7 @@ content:
     region: content
   field_area_of_study_stat:
     type: entity_reference_autocomplete
-    weight: 13
+    weight: 7
     region: content
     settings:
       match_operator: CONTAINS
@@ -300,7 +300,7 @@ content:
     third_party_settings: {  }
   field_area_of_study_stories:
     type: paragraphs
-    weight: 14
+    weight: 15
     settings:
       title: Story
       title_plural: Stories
@@ -332,7 +332,7 @@ content:
     type: string_textfield
     region: content
   field_area_of_study_subtitle:
-    weight: 2
+    weight: 1
     settings:
       rows: 5
       placeholder: ''
@@ -355,7 +355,7 @@ content:
     region: content
   field_area_of_study_transfer:
     type: paragraphs
-    weight: 7
+    weight: 10
     settings:
       title: Requirement
       title_plural: Requirement
@@ -373,7 +373,7 @@ content:
     third_party_settings: {  }
     region: content
   field_area_of_study_why:
-    weight: 4
+    weight: 6
     settings:
       rows: 5
       placeholder: ''

--- a/config/admissions.uiowa.edu/core.entity_form_display.node.area_of_study.default.yml
+++ b/config/admissions.uiowa.edu/core.entity_form_display.node.area_of_study.default.yml
@@ -51,8 +51,6 @@ third_party_settings:
         - field_area_of_study_majors
         - field_area_of_study_minors
         - field_area_of_study_certificates
-        - field_area_of_study_sub_type
-        - field_area_of_study_subprogram
         - field_area_of_study_preprof
         - field_area_of_study_online
         - field_area_of_study_teaching
@@ -64,6 +62,8 @@ third_party_settings:
         - field_area_of_study_select_txt
         - field_area_of_study_competitive
         - field_area_of_study_comp_txt
+        - field_area_of_study_sub_type
+        - field_area_of_study_subprogram
       parent_name: ''
       weight: 2
       format_type: fieldset
@@ -112,7 +112,7 @@ content:
     type: string_textfield
     region: content
   field_area_of_study_comp_txt:
-    weight: 17
+    weight: 15
     settings:
       size: 60
       placeholder: ''
@@ -120,7 +120,7 @@ content:
     type: string_textfield
     region: content
   field_area_of_study_competitive:
-    weight: 16
+    weight: 14
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
@@ -153,7 +153,7 @@ content:
     third_party_settings: {  }
     region: content
   field_area_of_study_four_txt:
-    weight: 13
+    weight: 11
     settings:
       size: 60
       placeholder: ''
@@ -161,13 +161,13 @@ content:
     type: string_textfield
     region: content
   field_area_of_study_four_year:
-    weight: 12
+    weight: 10
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_area_of_study_honors:
-    weight: 11
+    weight: 9
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
@@ -235,7 +235,7 @@ content:
     type: string_textfield
     region: content
   field_area_of_study_online:
-    weight: 8
+    weight: 6
     settings:
       size: 60
       placeholder: ''
@@ -251,7 +251,7 @@ content:
     type: text_textarea
     region: content
   field_area_of_study_preprof:
-    weight: 7
+    weight: 5
     settings:
       size: 60
       placeholder: ''
@@ -275,7 +275,7 @@ content:
     type: text_textarea
     region: content
   field_area_of_study_select_txt:
-    weight: 15
+    weight: 13
     settings:
       size: 60
       placeholder: ''
@@ -283,7 +283,7 @@ content:
     type: string_textfield
     region: content
   field_area_of_study_selective:
-    weight: 14
+    weight: 12
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
@@ -318,13 +318,13 @@ content:
     third_party_settings: {  }
     region: content
   field_area_of_study_sub_type:
-    weight: 5
+    weight: 16
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   field_area_of_study_subprogram:
-    weight: 6
+    weight: 17
     settings:
       size: 60
       placeholder: ''
@@ -340,13 +340,13 @@ content:
     type: text_textarea
     region: content
   field_area_of_study_teaching:
-    weight: 9
+    weight: 7
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_area_of_study_teaching_txt:
-    weight: 10
+    weight: 8
     settings:
       size: 60
       placeholder: ''


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/3108.

# How to test
1. `blt ds --site=admissions.uiowa.edu`
2. Go to http://admissions.local.drupal.uiowa.edu/node/add/area_of_study and verify the the new order reflects the order listed below in the details. 
<details>

1. -     Title 
2. -     Subtitle 
3. -     *Academic Group Selection 
4. -     Program Types (majors/minors/certs/etc) 
5. -     Tracks/Subprograms/etc. 
6. -     *College Selection 
7. -     Related Links 
8. -     *Mail Item 
9. -     Intro 
10. -     Why Iowa 
11. -     Statistic 
12. -     Admission Requirements field block 
13. -     First-year 
14. -     Transfer 
15. -     International 
16. -     Careers and Outcomes 
17. -     Student Opportunities 
18. -     Scholarships 
19. -     Stories 
20. -     Coursework 
* Not yet in this pull request. 
</details>