### PR TITLE
Update Webform module to 6.0.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9694,17 +9694,17 @@
         },
         {
             "name": "drupal/webform",
-            "version": "6.0.1",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/webform.git",
-                "reference": "6.0.1"
+                "reference": "6.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/webform-6.0.1.zip",
-                "reference": "6.0.1",
-                "shasum": "3ddc95895dcd446325432eae286910cd8e056da7"
+                "url": "https://ftp.drupal.org/files/projects/webform-6.0.2.zip",
+                "reference": "6.0.2",
+                "shasum": "a264554699736034b44fd960e2858d006029e025"
             },
             "require": {
                 "drupal/core": "^8.8 || ^9"
@@ -9752,8 +9752,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "6.0.1",
-                    "datestamp": "1612453373",
+                    "version": "6.0.2",
+                    "datestamp": "1614791851",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/config/default/webform.webform.contact.yml
+++ b/config/default/webform.webform.contact.yml
@@ -182,7 +182,7 @@ handlers:
     settings:
       states:
         - completed
-      to_mail: '[webform_submission:values:email:raw]'
+      to_mail: '[current-user:mail]'
       to_options: {  }
       cc_mail: ''
       cc_options: {  }


### PR DESCRIPTION
# Updates
* Updates webform module to 6.0.2
* Updates default `webform.webform.contact.yml` to include change from https://git.drupalcode.org/project/webform/-/compare/6.0.1...6.0.2

# How to test

* `blt ds`
* Observe update hook runs without issue.
* `drush @default.local admin/structure/webform/manage/contact/handlers`
* Click "Email Confirmation" to view those settings.
* Confirm that "To email" under the "Send to" section has been updated to "Current user email address [Authenticated only]."
* If you want to further confirm the change you can look at it in https://default.local.drupal.uiowa.edu/admin/config/development/configuration/single/export, select "Webform" and then "Contact (contact)" and search for `to_mail` and verify that the first value has been changed to `[current-user:mail]`.