### PR TITLE
Socialwork site split and initial configuration settings for two custom menus

### DIFF
--- a/config/socialwork.uiowa.edu/block.block.fieldeducation.yml
+++ b/config/socialwork.uiowa.edu/block.block.fieldeducation.yml
@@ -1,0 +1,31 @@
+uuid: 5210127b-030e-4592-86b6-c513d0fbb224
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.field-education
+  module:
+    - menu_block
+  theme:
+    - uids_base
+id: fieldeducation
+theme: uids_base
+region: secondary_menu
+weight: 0
+provider: null
+plugin: 'menu_block:field-education'
+settings:
+  id: 'menu_block:field-education'
+  label: 'Field Education'
+  provider: menu_block
+  label_display: visible
+  follow: false
+  follow_parent: child
+  level: 1
+  depth: 0
+  expand_all_items: false
+  parent: 'field-education:'
+  suggestion: field_education
+  label_type: block
+  label_link: false
+visibility: {  }

--- a/config/socialwork.uiowa.edu/block.block.nationalnursinghomesocialworknetwork.yml
+++ b/config/socialwork.uiowa.edu/block.block.nationalnursinghomesocialworknetwork.yml
@@ -1,0 +1,31 @@
+uuid: 0acf1a59-59ca-4f2a-a9d8-e173069e3fdb
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.national-nursing-home-network
+  module:
+    - menu_block
+  theme:
+    - uids_base
+id: nationalnursinghomesocialworknetwork
+theme: uids_base
+region: secondary_menu
+weight: 0
+provider: null
+plugin: 'menu_block:national-nursing-home-network'
+settings:
+  id: 'menu_block:national-nursing-home-network'
+  label: 'National Nursing Home Social Work Network'
+  provider: menu_block
+  label_display: visible
+  follow: false
+  follow_parent: child
+  level: 1
+  depth: 0
+  expand_all_items: false
+  parent: 'national-nursing-home-network:'
+  suggestion: national_nursing_home_network
+  label_type: block
+  label_link: false
+visibility: {  }

--- a/config/socialwork.uiowa.edu/config_split.config_split.socialwork_uiowa_edu.yml
+++ b/config/socialwork.uiowa.edu/config_split.config_split.socialwork_uiowa_edu.yml
@@ -1,4 +1,4 @@
-uuid: ce237da7-c9c1-4b6c-a132-1bffb4a5e26a
+uuid: e91c0545-77f7-4d80-9dca-56fbaee7fbfb
 langcode: en
 status: true
 dependencies: {  }
@@ -10,7 +10,13 @@ module: {  }
 theme: {  }
 blacklist: {  }
 graylist:
+  - block.block.fieldeducation
+  - block.block.nationalnursinghomesocialworknetwork
   - config_split.config_split.socialwork_uiowa_edu
+  - core.entity_view_display.node.page.default
+  - node.type.page
+  - system.menu.field-education
+  - system.menu.national-nursing-home-network
 graylist_dependents: true
 graylist_skip_equal: true
 weight: 90

--- a/config/socialwork.uiowa.edu/core.entity_view_display.node.page.default.yml
+++ b/config/socialwork.uiowa.edu/core.entity_view_display.node.page.default.yml
@@ -1,0 +1,300 @@
+uuid: 78b5d686-d3c3-45b0-a69c-5014e0a96760
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.page.body
+    - field.field.node.page.field_featured_image_display
+    - field.field.node.page.field_image
+    - field.field.node.page.field_meta_tags
+    - field.field.node.page.field_publish_options
+    - field.field.node.page.field_tags
+    - field.field.node.page.field_teaser
+    - field.field.node.page.layout_builder__layout
+    - node.type.page
+    - system.menu.main
+  module:
+    - layout_builder
+    - layout_builder_restrictions
+    - menu_block
+    - system
+    - text
+    - user
+  theme:
+    - uids_base
+third_party_settings:
+  layout_builder:
+    allow_custom: true
+    enabled: true
+    sections:
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: 'Moderation control'
+          layout_builder_styles_style:
+            section_margin_remove_default_margins: section_margin_remove_default_margins
+            0: ''
+        components:
+          -
+            uuid: 051b1326-800c-40ca-b518-98ce13ca4e6f
+            region: content
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'extra_field_block:node:page:content_moderation_control'
+            additional: {  }
+            weight: 0
+        third_party_settings:
+          layout_builder_lock:
+            lock:
+              1: 1
+              2: 2
+              3: 3
+              4: 4
+              5: 5
+              6: 6
+              8: 8
+      -
+        layout_id: layout_header
+        layout_settings:
+          label: Header
+          layout_builder_styles_style:
+            - ''
+            - section_margin_edge_to_edge
+        components:
+          -
+            uuid: 40b768ff-6e34-4257-9398-d83430b061e8
+            region: content
+            configuration:
+              id: system_breadcrumb_block
+              label: Breadcrumbs
+              provider: system
+              label_display: '0'
+              context_mapping: {  }
+            additional: {  }
+            weight: 0
+          -
+            uuid: 56a58312-d93e-4d32-84a0-39b2a2fc89fb
+            region: content
+            configuration:
+              id: 'field_block:node:page:title'
+              label: Title
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: visually_hidden
+                type: string
+                settings:
+                  link_to_entity: false
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 1
+          -
+            uuid: b444f835-62e1-4e31-b433-22fe88ef3372
+            region: background
+            configuration:
+              id: 'field_block:node:page:field_image'
+              label: 'Featured Image'
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: visually_hidden
+                type: entity_reference_entity_view
+                settings:
+                  view_mode: full__ultrawide
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 0
+        third_party_settings:
+          layout_builder_lock:
+            lock:
+              1: 1
+              2: 2
+              3: 3
+              4: 4
+              5: 5
+              6: 6
+              8: 8
+      -
+        layout_id: layout_page
+        layout_settings:
+          label: Content
+        components:
+          -
+            uuid: c8d974cb-667f-4e0d-8716-d2a77004e0e1
+            region: sidebar
+            configuration:
+              id: 'menu_block:main'
+              label: 'Main navigation'
+              provider: menu_block
+              label_display: '0'
+              follow: true
+              follow_parent: '0'
+              level: 2
+              depth: 0
+              expand: false
+              parent: 'main:'
+              suggestion: main
+              context_mapping: {  }
+            additional:
+              layout_builder_styles_style:
+                block_menu_vertical: block_menu_vertical
+            weight: 0
+          -
+            uuid: e6fa78b4-cacc-4d27-baa3-f29dde0b845b
+            region: content
+            configuration:
+              id: 'field_block:node:page:body'
+              label: Body
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: text_default
+                settings: {  }
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: -9
+        third_party_settings: {  }
+  layout_builder_restrictions:
+    entity_view_mode_restriction:
+      allowed_blocks: {  }
+      allowed_layouts:
+        - layout_onecol
+        - layout_twocol
+        - layout_threecol
+        - layout_fourcol
+        - layout_page
+      whitelisted_blocks:
+        'Chaos Tools': {  }
+        'Content fields':
+          - 'field_block:node:page:body'
+        'Custom blocks': {  }
+        Devel: {  }
+        Forms: {  }
+        'Lists (Views)': {  }
+        Menus:
+          - 'system_menu_block:field-education'
+          - 'menu_block:field-education'
+          - 'menu_block:main'
+          - 'system_menu_block:main'
+          - 'menu_block:national-nursing-home-network'
+          - 'system_menu_block:national-nursing-home-network'
+        Superfish: {  }
+        System: {  }
+        'University of Iowa Alerts': {  }
+        User: {  }
+        Webform:
+          - webform_block
+        core: {  }
+      blacklisted_blocks:
+        'Custom block types':
+          - uiowa_hero
+          - uiowa_page_title_hero
+          - uiowa_spacer_separator
+        'Inline blocks':
+          - 'inline_block:uiowa_hero'
+          - 'inline_block:uiowa_page_title_hero'
+          - 'inline_block:uiowa_spacer_separator'
+    allowed_block_categories:
+      - 'Chaos Tools'
+      - 'Content fields'
+      - 'Custom block types'
+      - 'Custom blocks'
+      - Devel
+      - Forms
+      - 'Inline blocks'
+      - 'Lists (Views)'
+      - Menus
+      - 'Site custom'
+      - Superfish
+      - System
+      - 'University of Iowa Alerts'
+      - User
+      - Webform
+      - core
+    entity_view_mode_restriction_by_region:
+      allowed_layouts:
+        - layout_onecol
+        - layout_twocol
+        - layout_threecol
+        - layout_fourcol
+        - layout_page
+      blacklisted_blocks:
+        layout_fourcol:
+          all_regions:
+            'Custom block types':
+              - uiowa_slider
+            'Inline blocks':
+              - 'inline_block:uiowa_slider'
+        layout_onecol: {  }
+        layout_page:
+          all_regions:
+            'Custom block types':
+              - uiowa_slider
+            'Inline blocks':
+              - 'inline_block:uiowa_slider'
+        layout_threecol:
+          all_regions:
+            'Custom block types':
+              - uiowa_slider
+            'Inline blocks':
+              - 'inline_block:uiowa_slider'
+        layout_twocol:
+          all_regions:
+            'Custom block types':
+              - uiowa_slider
+            'Inline blocks':
+              - 'inline_block:uiowa_slider'
+      whitelisted_blocks: {  }
+_core:
+  default_config_hash: 0AcX0F0voV5TKB6_GPZxJpAfbKCnDU7er_5TWcqIgSw
+id: node.page.default
+targetEntityType: node
+bundle: page
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  content_moderation_control:
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_image:
+    type: entity_reference_entity_view
+    weight: 0
+    region: content
+    label: visually_hidden
+    settings:
+      view_mode: full__ultrawide
+      link: false
+    third_party_settings: {  }
+  links:
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_featured_image_display: true
+  field_meta_tags: true
+  field_publish_options: true
+  field_tags: true
+  field_teaser: true
+  layout_builder__layout: true
+  search_api_excerpt: true

--- a/config/socialwork.uiowa.edu/node.type.page.yml
+++ b/config/socialwork.uiowa.edu/node.type.page.yml
@@ -1,0 +1,30 @@
+uuid: 29dc4ac0-fa4b-45da-b405-95cba2cbe9d1
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+    - node_revision_delete
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - field-education
+      - footer-primary
+      - footer-secondary
+      - footer-tertiary
+      - main
+      - national-nursing-home-network
+    parent: 'main:'
+  node_revision_delete:
+    minimum_revisions_to_keep: 10
+    minimum_age_to_delete: 0
+    when_to_delete: 0
+_core:
+  default_config_hash: hs9nW8rf2ckLhmXkCgS7Yj5jIsdVZzTa2fLm7wfaL1M
+name: Page
+type: page
+description: 'Use <em>pages</em> for your static content, such as an ''About us'' page.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/config/socialwork.uiowa.edu/system.menu.field-education.yml
+++ b/config/socialwork.uiowa.edu/system.menu.field-education.yml
@@ -1,0 +1,8 @@
+uuid: a6287d83-2a47-42c4-9009-5b7be3d8113d
+langcode: en
+status: true
+dependencies: {  }
+id: field-education
+label: 'Field Education'
+description: 'Custom menu for Field Education section.'
+locked: false

--- a/config/socialwork.uiowa.edu/system.menu.national-nursing-home-network.yml
+++ b/config/socialwork.uiowa.edu/system.menu.national-nursing-home-network.yml
@@ -1,0 +1,8 @@
+uuid: faf2e224-76b9-4301-bf22-ee098b6a0cd7
+langcode: en
+status: true
+dependencies: {  }
+id: national-nursing-home-network
+label: 'National Nursing Home Social Work Network'
+description: 'Custom menu for National Nursing Home Social Work Network section.'
+locked: false


### PR DESCRIPTION
Creates initial site_split for socialwork.uiowa.edu, then:

- adds two custom menus,
- allows menus on pages,
- allows menus in layout builder More options, and
- sets blocks in secondary menu.

Only concern that hasnt been addressed yet is the styling:
<img width="425" alt="Screen Shot 2021-03-05 at 3 33 40 AM" src="https://user-images.githubusercontent.com/3067017/110096532-99c52300-7d63-11eb-8f7b-7dc11eacf1be.png">

I didnt want to add the "main" class to this menu, is it possible to add these styles another way without adding to uids?

