### PR TITLE
Fix menu depth defaults for horizontal, mega

### DIFF
--- a/config/default/block.block.main_navigation__superfish__horizontal.yml
+++ b/config/default/block.block.main_navigation__superfish__horizontal.yml
@@ -22,7 +22,7 @@ settings:
   provider: superfish
   label_display: '0'
   level: '1'
-  depth: '0'
+  depth: '3'
   expand_all_items: false
   menu_type: horizontal
   style: none

--- a/config/default/block.block.main_navigation__superfish__mega.yml
+++ b/config/default/block.block.main_navigation__superfish__mega.yml
@@ -22,7 +22,7 @@ settings:
   provider: superfish
   label_display: '0'
   level: '1'
-  depth: '0'
+  depth: '2'
   expand_all_items: false
   menu_type: horizontal
   style: none

--- a/docroot/themes/custom/uids_base/config/optional/block.block.main_navigation__superfish__horizontal.yml
+++ b/docroot/themes/custom/uids_base/config/optional/block.block.main_navigation__superfish__horizontal.yml
@@ -19,7 +19,7 @@ settings:
   provider: superfish
   label_display: '0'
   level: '1'
-  depth: '0'
+  depth: '3'
   expand_all_items: false
   menu_type: horizontal
   style: none

--- a/docroot/themes/custom/uids_base/config/optional/block.block.main_navigation__superfish__mega.yml
+++ b/docroot/themes/custom/uids_base/config/optional/block.block.main_navigation__superfish__mega.yml
@@ -19,7 +19,7 @@ settings:
   provider: superfish
   label_display: '0'
   level: '1'
-  depth: '0'
+  depth: '2'
   expand_all_items: false
   menu_type: horizontal
   style: none


### PR DESCRIPTION
Coming from https://github.com/uiowa/uiowa/pull/3186, changes the defaults for horizontal and mega from unlimited to 3 and 2 respectively.

## To test
Sync a site with a lot of menu depth (e.g. engineering). Change between the menu options and see the change in depth.