### PR TITLE
Set default menu depth for horizontal menu (3) and mega menu (2).

### DIFF
--- a/config/default/block.block.main_navigation__superfish__horizontal.yml
+++ b/config/default/block.block.main_navigation__superfish__horizontal.yml
@@ -22,7 +22,7 @@ settings:
   provider: superfish
   label_display: '0'
   level: '1'
-  depth: '0'
+  depth: '3'
   expand_all_items: false
   menu_type: horizontal
   style: none

--- a/config/default/block.block.main_navigation__superfish__mega.yml
+++ b/config/default/block.block.main_navigation__superfish__mega.yml
@@ -22,7 +22,7 @@ settings:
   provider: superfish
   label_display: '0'
   level: '1'
-  depth: '0'
+  depth: '2'
   expand_all_items: false
   menu_type: horizontal
   style: none


### PR DESCRIPTION
Sets the default menu depth of the horizontal menu option to 3, and of the mega menu option to 2. Leaves the toggle navigation menu option to unlimited.

# How to test

drush @default.local cr
blt ds
drush @default.local uli
Create a menu structure that is one or more levels deeper than the defaults and make sure they are not visible.

# Screenshots
![Screen Shot 2021-03-11 at 12 28 42 AM](https://user-images.githubusercontent.com/3067017/110745533-05ded580-8201-11eb-9fb2-d8d6cdc38120.png)

![Screen Shot 2021-03-11 at 12 29 13 AM](https://user-images.githubusercontent.com/3067017/110745540-08d9c600-8201-11eb-953c-f4e97843636f.png)

![Screen Shot 2021-03-11 at 12 30 10 AM](https://user-images.githubusercontent.com/3067017/110745555-0c6d4d00-8201-11eb-8a39-aed473452cd7.png)

