### PR TITLE
Feature: Add pretty title to Admissions Area of Study content type

### DIFF
--- a/config/admissions.uiowa.edu/config_split.config_split.admissions.yml
+++ b/config/admissions.uiowa.edu/config_split.config_split.admissions.yml
@@ -31,33 +31,6 @@ graylist:
   - core.entity_view_display.paragraph.admissions_card.default
   - core.entity_view_display.paragraph.admissions_requirement.default
   - core.entity_view_mode.media.grid_gallery
-  - field.field.node.area_of_study.body
-  - field.field.node.area_of_study.field_area_of_study_academic_gp
-  - field.field.node.area_of_study.field_area_of_study_career
-  - field.field.node.area_of_study.field_area_of_study_college
-  - field.field.node.area_of_study.field_area_of_study_competitive
-  - field.field.node.area_of_study.field_area_of_study_comp_txt
-  - field.field.node.area_of_study.field_area_of_study_course_work
-  - field.field.node.area_of_study.field_area_of_study_first_year
-  - field.field.node.area_of_study.field_area_of_study_four_txt
-  - field.field.node.area_of_study.field_area_of_study_four_year
-  - field.field.node.area_of_study.field_area_of_study_intl
-  - field.field.node.area_of_study.field_area_of_study_link
-  - field.field.node.area_of_study.field_area_of_study_mail_code
-  - field.field.node.area_of_study.field_area_of_study_opportunity
-  - field.field.node.area_of_study.field_area_of_study_requirement
-  - field.field.node.area_of_study.field_area_of_study_scholarship
-  - field.field.node.area_of_study.field_area_of_study_selective
-  - field.field.node.area_of_study.field_area_of_study_select_txt
-  - field.field.node.area_of_study.field_area_of_study_stories
-  - field.field.node.area_of_study.field_area_of_study_subprogram
-  - field.field.node.area_of_study.field_area_of_study_subtitle
-  - field.field.node.area_of_study.field_area_of_study_sub_type
-  - field.field.node.area_of_study.field_area_of_study_teaching
-  - field.field.node.area_of_study.field_area_of_study_teaching_txt
-  - field.field.node.area_of_study.field_area_of_study_transfer
-  - field.field.node.area_of_study.field_area_of_study_why
-  - field.field.node.area_of_study.field_image
   - field.field.node.person.field_person_hometown
   - field.field.node.person.field_person_territory
   - field.field.node.scholarship.field_scholarship_resident
@@ -91,32 +64,6 @@ graylist:
   - field.field.taxonomy_term.academic_groups.field_academic_groups_media
   - field.field.taxonomy_term.academic_groups.field_image
   - field.storage.node.body
-  - field.storage.node.field_area_of_study_academic_gp
-  - field.storage.node.field_area_of_study_career
-  - field.storage.node.field_area_of_study_college
-  - field.storage.node.field_area_of_study_competitive
-  - field.storage.node.field_area_of_study_comp_txt
-  - field.storage.node.field_area_of_study_course_work
-  - field.storage.node.field_area_of_study_first_year
-  - field.storage.node.field_area_of_study_four_txt
-  - field.storage.node.field_area_of_study_four_year
-  - field.storage.node.field_area_of_study_honors
-  - field.storage.node.field_area_of_study_intl
-  - field.storage.node.field_area_of_study_link
-  - field.storage.node.field_area_of_study_mail_code
-  - field.storage.node.field_area_of_study_opportunity
-  - field.storage.node.field_area_of_study_requirement
-  - field.storage.node.field_area_of_study_scholarship
-  - field.storage.node.field_area_of_study_selective
-  - field.storage.node.field_area_of_study_select_txt
-  - field.storage.node.field_area_of_study_stories
-  - field.storage.node.field_area_of_study_subprogram
-  - field.storage.node.field_area_of_study_subtitle
-  - field.storage.node.field_area_of_study_sub_type
-  - field.storage.node.field_area_of_study_teaching
-  - field.storage.node.field_area_of_study_teaching_txt
-  - field.storage.node.field_area_of_study_transfer
-  - field.storage.node.field_area_of_study_why
   - field.storage.node.field_image
   - field.storage.node.field_meta_tags
   - field.storage.node.field_person_first_name
@@ -172,21 +119,19 @@ graylist:
   - views.view.student_card
   - views.view.student_profiles
   - views.view.transfer_tips_list
-  - field.field.node.area_of_study.field_area_of_study_ref_ar
-  - field.storage.node.field_area_of_study_ref_ar
-  - field.field.node.student_profile.field_person_territory
-  - 'core.entity_form_display.node.scholarship.*'
-  - 'core.entity_view_display.node.scholarship.*'
-  - 'core.entity_view_display.node.page.*'
   - 'core.entity_form_display.node.person.*'
+  - 'core.entity_form_display.node.scholarship.*'
+  - 'core.entity_view_display.block_content.uiowa_collection.*'
+  - 'core.entity_view_display.media.image.*'
+  - 'core.entity_view_display.node.page.*'
   - 'core.entity_view_display.node.person.*'
-  - 'user.role.*'
-  - fragment.fragment_type.stat
+  - 'core.entity_view_display.node.scholarship.*'
+  - 'core.entity_view_display.paragraph.uiowa_collection_item.*'
+  - field.field.node.student_profile.field_person_territory
   - 'field.storage.fragment.field_stat_*'
   - 'field.storage.node.field_area_of_study_*'
-  - 'core.entity_view_display.media.image.*'
-  - 'core.entity_view_display.block_content.uiowa_collection.*'
-  - 'core.entity_view_display.paragraph.uiowa_collection_item.*'
+  - fragment.fragment_type.stat
+  - 'user.role.*'
 graylist_dependents: true
 graylist_skip_equal: true
 weight: 90

--- a/config/admissions.uiowa.edu/config_split.config_split.admissions.yml
+++ b/config/admissions.uiowa.edu/config_split.config_split.admissions.yml
@@ -88,9 +88,9 @@ graylist:
   - field.field.paragraph.admissions_requirement.field_ar_intro
   - field.field.paragraph.admissions_requirement.field_ar_process
   - field.field.paragraph.admissions_requirement.field_ar_requirement
-  - field.storage.node.body
   - field.field.taxonomy_term.academic_groups.field_academic_groups_media
   - field.field.taxonomy_term.academic_groups.field_image
+  - field.storage.node.body
   - field.storage.node.field_area_of_study_academic_gp
   - field.storage.node.field_area_of_study_career
   - field.storage.node.field_area_of_study_college
@@ -149,6 +149,7 @@ graylist:
   - field.storage.taxonomy_term.field_image
   - image.style.grid_gallery
   - metatag.metatag_defaults.node__transfer_tips
+  - node.type.area_of_study
   - node.type.student_profile
   - node.type.transfer_tips
   - paragraphs.paragraphs_type.admissions_card
@@ -182,6 +183,7 @@ graylist:
   - 'user.role.*'
   - fragment.fragment_type.stat
   - 'field.storage.fragment.field_stat_*'
+  - 'field.storage.node.field_area_of_study_*'
   - 'core.entity_view_display.media.image.*'
   - 'core.entity_view_display.block_content.uiowa_collection.*'
   - 'core.entity_view_display.paragraph.uiowa_collection_item.*'

--- a/config/admissions.uiowa.edu/config_split.config_split.admissions.yml
+++ b/config/admissions.uiowa.edu/config_split.config_split.admissions.yml
@@ -13,17 +13,13 @@ module:
   weight: 0
 theme: {  }
 blacklist:
-  - core.entity_view_display.node.area_of_study.pdf
   - core.entity_view_mode.node.pdf
 graylist:
   - config_split.config_split.admissions
-  - core.entity_form_display.node.area_of_study.default
   - core.entity_form_display.node.student_profile.default
   - core.entity_form_display.node.transfer_tips.default
   - core.entity_form_display.paragraph.admissions_card.default
   - core.entity_form_display.paragraph.admissions_requirement.default
-  - core.entity_view_display.node.area_of_study.default
-  - core.entity_view_display.node.area_of_study.teaser
   - core.entity_view_display.node.student_profile.default
   - core.entity_view_display.node.student_profile.teaser
   - core.entity_view_display.node.transfer_tips.default

--- a/config/admissions.uiowa.edu/core.entity_form_display.node.area_of_study.default.yml
+++ b/config/admissions.uiowa.edu/core.entity_form_display.node.area_of_study.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.area_of_study.body
+    - field.field.node.area_of_study.field_area_of_study_pretty_title
     - field.field.node.area_of_study.field_area_of_study_academic_gp
     - field.field.node.area_of_study.field_area_of_study_career
     - field.field.node.area_of_study.field_area_of_study_certificates
@@ -67,7 +68,7 @@ third_party_settings:
         - field_area_of_study_sub_type
         - field_area_of_study_subprogram
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: fieldset
       region: content
       format_settings:
@@ -83,7 +84,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 7
+    weight: 8
     settings:
       rows: 9
       summary_rows: 3
@@ -93,12 +94,12 @@ content:
     region: content
   created:
     type: datetime_timestamp
-    weight: 20
+    weight: 21
     region: content
     settings: {  }
     third_party_settings: {  }
   field_area_of_study_academic_gp:
-    weight: 2
+    weight: 3
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -108,7 +109,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_area_of_study_career:
-    weight: 14
+    weight: 15
     settings:
       rows: 5
       placeholder: ''
@@ -124,7 +125,7 @@ content:
     type: string_textfield
     region: content
   field_area_of_study_college:
-    weight: 4
+    weight: 5
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -148,7 +149,7 @@ content:
     type: options_buttons
     region: content
   field_area_of_study_course_work:
-    weight: 18
+    weight: 19
     settings:
       rows: 5
       placeholder: ''
@@ -157,7 +158,7 @@ content:
     region: content
   field_area_of_study_first_year:
     type: paragraphs
-    weight: 11
+    weight: 12
     settings:
       title: Requirement
       title_plural: Requirement
@@ -196,7 +197,7 @@ content:
     region: content
   field_area_of_study_intl:
     type: paragraphs
-    weight: 13
+    weight: 14
     settings:
       title: Requirement
       title_plural: Requirement
@@ -214,7 +215,7 @@ content:
     third_party_settings: {  }
     region: content
   field_area_of_study_link:
-    weight: 5
+    weight: 6
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -222,7 +223,7 @@ content:
     type: link_default
     region: content
   field_area_of_study_mail_code:
-    weight: 6
+    weight: 7
     settings:
       size: 60
       placeholder: ''
@@ -265,7 +266,7 @@ content:
     type: string_textfield
     region: content
   field_area_of_study_opportunity:
-    weight: 15
+    weight: 16
     settings:
       rows: 5
       placeholder: ''
@@ -280,8 +281,16 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  field_area_of_study_pretty_title:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_area_of_study_requirement:
-    weight: 10
+    weight: 11
     settings:
       rows: 5
       placeholder: ''
@@ -289,7 +298,7 @@ content:
     type: text_textarea
     region: content
   field_area_of_study_scholarship:
-    weight: 16
+    weight: 17
     settings:
       rows: 5
       placeholder: ''
@@ -312,7 +321,7 @@ content:
     region: content
   field_area_of_study_stat:
     type: entity_reference_autocomplete
-    weight: 9
+    weight: 10
     region: content
     settings:
       match_operator: CONTAINS
@@ -322,7 +331,7 @@ content:
     third_party_settings: {  }
   field_area_of_study_stories:
     type: paragraphs
-    weight: 17
+    weight: 18
     settings:
       title: Story
       title_plural: Stories
@@ -354,7 +363,7 @@ content:
     type: string_textfield
     region: content
   field_area_of_study_subtitle:
-    weight: 1
+    weight: 2
     settings:
       rows: 5
       placeholder: ''
@@ -377,7 +386,7 @@ content:
     region: content
   field_area_of_study_transfer:
     type: paragraphs
-    weight: 12
+    weight: 13
     settings:
       title: Requirement
       title_plural: Requirement
@@ -395,7 +404,7 @@ content:
     third_party_settings: {  }
     region: content
   field_area_of_study_why:
-    weight: 8
+    weight: 9
     settings:
       rows: 5
       placeholder: ''
@@ -403,7 +412,7 @@ content:
     type: text_textarea
     region: content
   field_image:
-    weight: 27
+    weight: 28
     settings:
       media_types: {  }
     third_party_settings: {  }
@@ -411,13 +420,13 @@ content:
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 25
+    weight: 26
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 23
+    weight: 24
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -425,21 +434,21 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 21
+    weight: 22
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 26
+    weight: 27
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 22
+    weight: 23
     region: content
     third_party_settings: {  }
   title:
@@ -452,7 +461,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 19
+    weight: 20
     settings:
       match_operator: CONTAINS
       size: 60
@@ -461,7 +470,7 @@ content:
     region: content
     third_party_settings: {  }
   url_redirects:
-    weight: 24
+    weight: 25
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/admissions.uiowa.edu/core.entity_view_display.node.area_of_study.default.yml
+++ b/config/admissions.uiowa.edu/core.entity_view_display.node.area_of_study.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.area_of_study.body
+    - field.field.node.area_of_study.field_area_of_study_pretty_title
     - field.field.node.area_of_study.field_area_of_study_academic_gp
     - field.field.node.area_of_study.field_area_of_study_career
     - field.field.node.area_of_study.field_area_of_study_certificates
@@ -697,6 +698,14 @@ content:
     region: content
   field_area_of_study_preprof:
     weight: 11
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_area_of_study_pretty_title:
+    weight: 41
     label: above
     settings:
       link_to_entity: false

--- a/config/admissions.uiowa.edu/core.entity_view_display.node.area_of_study.pdf.yml
+++ b/config/admissions.uiowa.edu/core.entity_view_display.node.area_of_study.pdf.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.pdf
     - field.field.node.area_of_study.body
+    - field.field.node.area_of_study.field_area_of_study_pretty_title
     - field.field.node.area_of_study.field_area_of_study_academic_gp
     - field.field.node.area_of_study.field_area_of_study_career
     - field.field.node.area_of_study.field_area_of_study_certificates
@@ -317,6 +318,7 @@ hidden:
   field_area_of_study_intl: true
   field_area_of_study_link: true
   field_area_of_study_mail_code: true
+  field_area_of_study_pretty_title: true
   field_area_of_study_stat: true
   field_area_of_study_stories: true
   field_area_of_study_transfer: true

--- a/config/admissions.uiowa.edu/core.entity_view_display.node.area_of_study.teaser.yml
+++ b/config/admissions.uiowa.edu/core.entity_view_display.node.area_of_study.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.area_of_study.body
+    - field.field.node.area_of_study.field_area_of_study_pretty_title
     - field.field.node.area_of_study.field_area_of_study_academic_gp
     - field.field.node.area_of_study.field_area_of_study_career
     - field.field.node.area_of_study.field_area_of_study_certificates
@@ -87,6 +88,7 @@ hidden:
   field_area_of_study_online: true
   field_area_of_study_opportunity: true
   field_area_of_study_preprof: true
+  field_area_of_study_pretty_title: true
   field_area_of_study_requirement: true
   field_area_of_study_scholarship: true
   field_area_of_study_select_txt: true

--- a/config/admissions.uiowa.edu/field.field.node.area_of_study.field_area_of_study_pretty_title.yml
+++ b/config/admissions.uiowa.edu/field.field.node.area_of_study.field_area_of_study_pretty_title.yml
@@ -1,0 +1,19 @@
+uuid: 94543177-9632-4899-b01a-bb049c5e6438
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_area_of_study_pretty_title
+    - node.type.area_of_study
+id: node.area_of_study.field_area_of_study_pretty_title
+field_name: field_area_of_study_pretty_title
+entity_type: node
+bundle: area_of_study
+label: 'Pretty title'
+description: 'Use the <em>pretty title</em> only in cases where you need to present a shorter or more easy to read version of the title for listing pages. This is not shown on the details page.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/admissions.uiowa.edu/field.storage.node.field_area_of_study_pretty_title.yml
+++ b/config/admissions.uiowa.edu/field.storage.node.field_area_of_study_pretty_title.yml
@@ -1,0 +1,21 @@
+uuid: 75ea80d7-c703-4fab-a436-a2e0878b97ea
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_area_of_study_pretty_title
+field_name: field_area_of_study_pretty_title
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
# Updates
* Resolves #3213 
* Cleans up the `admissions` split with regard to the Area of Study content type.

# How to test

* `blt ds --site=admissions.uiowa.edu`
* Observe creation of two config items related to `field_area_of_study_pretty_title` and updating of 4 config files like `core.entity_*_display.node.area_of_study.*` and the `admissions` config split.
* `drush @admissions.local uli node/1141/edit`, add a Pretty title to Anthropology, and Save.
* Observe that the pretty title does not show up on the page.
* Observe that the pretty title does not show up on the PDF: http://admissions.local.drupal.uiowa.edu/print/pdf/node/1141
* `drush @admissions.local csex admissions` and `git status` to observe there are no changes to config based on changes to `admissions` split.