### PR TITLE
Hotfix: Display table outline by default in WYSIWYG

### DIFF
--- a/docroot/modules/custom/sitenow_media_wysiwyg/js/ckeditor_config.js
+++ b/docroot/modules/custom/sitenow_media_wysiwyg/js/ckeditor_config.js
@@ -64,4 +64,8 @@ if (document.getElementsByTagName("body")[0].classList.contains('text--serif')) 
   });
 }
 
+// This was not working properly when a user first added a table.
+// Removed and functionality duplicated for all CKE tables in docroot/themes/custom/uids_base/scss/components/tables.scss .
+CKEDITOR.config.removePlugins = 'showborders';
+
 

--- a/docroot/themes/custom/uids_base/scss/components/sitenow/sitenow_wysiwyg.scss
+++ b/docroot/themes/custom/uids_base/scss/components/sitenow/sitenow_wysiwyg.scss
@@ -6,3 +6,19 @@
 @import "uids/components/button/button.scss";
 @import "scss/sitenow.scss";
 @import "scss/components/typography/global-serif.scss";
+
+.cke_contents_ltr {
+  table,
+  table caption,
+  table > tr > td,
+  table > tr > th,
+  table > tbody > tr > td,
+  table > tbody > tr > th,
+  table > thead > tr > td,
+  table > thead > tr > th,
+  table > tfoot > tr > td,
+  table > tfoot > tr > th,
+  {
+    border: #d3d3d3 1px dotted
+  }
+}

--- a/docroot/themes/custom/uids_base/scss/components/sitenow/sitenow_wysiwyg.scss
+++ b/docroot/themes/custom/uids_base/scss/components/sitenow/sitenow_wysiwyg.scss
@@ -17,8 +17,8 @@
   table > thead > tr > td,
   table > thead > tr > th,
   table > tfoot > tr > td,
-  table > tfoot > tr > th,
+  table > tfoot > tr > th
   {
-    border: #d3d3d3 1px dotted
+    border: #d3d3d3 1px dotted;
   }
 }


### PR DESCRIPTION
* Adds table border update from #3227 

# How to test

* `blt ds`
* `drush @default.local uli node/add/page`
* Add a table to the WYSIWYG area and observe that you can see its outline.
