### PR TITLE
Admissions Hotfix - unset the filters on the homepage block, leave on the AoS page

### DIFF
--- a/docroot/modules/custom/uiowa_area_of_study/src/Plugin/Block/AreasOfStudySearchBlock.php
+++ b/docroot/modules/custom/uiowa_area_of_study/src/Plugin/Block/AreasOfStudySearchBlock.php
@@ -79,6 +79,9 @@ class AreasOfStudySearchBlock extends BlockBase implements ContainerFactoryPlugi
     if ($view) {
       $view->setDisplay($display_id);
       $view->initHandlers();
+      unset($view->filter["field_area_of_study_program_type_value"]);
+      unset($view->filter["field_area_of_study_academic_gp_target_id"]);
+      unset($view->filter["field_area_of_study_college_target_id"]);
       $form_state = (new FormState())
         ->setStorage([
           'view' => $view,


### PR DESCRIPTION
As mentioned here: https://github.com/uiowa/uiowa/issues/3258#issuecomment-802900718

Returns the block to the single search box but doesn't change the http://admissions.local.drupal.uiowa.edu/areas-of-study page filters.

Still passes the filter value to the view page.

## To Test

- pull and sync admissions
- the homepage should have a single search box, no additional filters
- a search term should pass to http://admissions.local.drupal.uiowa.edu/areas-of-study and filter the results (e.g. Geography)