### PR TITLE
Hotfix - Admissions - ListBlock

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/src/Plugin/Display/ListBlock.php
+++ b/docroot/modules/custom/layout_builder_custom/src/Plugin/Display/ListBlock.php
@@ -249,12 +249,4 @@ class ListBlock extends CoreBlock {
     return FALSE;
   }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function displaysExposed() {
-    // We don't want this to be available on this type of block.
-    return FALSE;
-  }
-
 }

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
@@ -129,8 +129,16 @@ function admissions_core_form_alter(&$form, FormStateInterface $form_state, $for
  * Implements hook_form_FORM_ID_alter().
  */
 function admissions_core_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if ($form['#id'] == 'views-exposed-form-counselors-block-counselors') {
-    $form["territory"]["#options"]["All"] = t("- All -");
+  $view = $form_state->get('view');
+  if ($view->id() == 'student_card') {
+    if ($view->current_display == 'block_student_grid') {
+      $form['#attributes']['class'][] = 'hidden';
+    }
+  }
+  if ($view->id() == 'counselors') {
+    if ($view->current_display == 'block_counselors') {
+      $form["territory"]["#options"]["All"] = t("- All -");
+    }
   }
 }
 


### PR DESCRIPTION
To make student profiles block revisited possible, we are hijacking views block with a custom one which was hiding any exposed filters. This cause the /counselors filters to not render. We can't make this assumption so for now, I have removed this recent change and updated the student profiles block to hide the filters similar to articles/people blocks until we can figure out a better way.

## To Test

- pull and sync admissions
- go to http://admissions.local.drupal.uiowa.edu/counselors and see the territory dropdown.
- go to http://admissions.local.drupal.uiowa.edu/student-profiles/bhavya-vats and see that there are no exposed filters.
