### PR TITLE
Feature: Fixing sass mixin import for admissions_core

### DIFF
--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/global.scss
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/global.scss
@@ -1,6 +1,6 @@
 @import "../../../../../themes/custom/uids_base/uids/assets/scss/_variables.scss";
 @import "../../../../../themes/custom/uids_base/uids/assets/scss/_utilities.scss";
-@import "../../../../../themes/custom/uids_base/uids/components/headline/headline.scss";
+@import "../../../../../themes/custom/uids_base/uids/components/headline/_headline-mixins.scss";
 
 .view-colleges-taxonomy-term {
   h3, ul {

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/student-profile.scss
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/student-profile.scss
@@ -1,5 +1,3 @@
-@import "../../../../../themes/custom/uids_base/uids/components/headline/headline.scss";
-
 .block-views-blockstudent-card-block-student-grid {
   .views-col {
     display: flex;


### PR DESCRIPTION
We were importing the wrong file for headings.  This pr fixes that with the mixin file instead. 