### PR TITLE
bumping uids release number

### DIFF
--- a/docroot/themes/custom/uids_base/package.json
+++ b/docroot/themes/custom/uids_base/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "ISC",
   "dependencies": {
-    "@uiowa/uids": "uiowa/uids#3.4.2",
+    "@uiowa/uids": "uiowa/uids#3.4.3",
     "autoprefixer": "^9.8.6",
     "breakpoint-sass": "^2.7.1",
     "cssnano": "^4.1.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1084,9 +1084,9 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
-"@uiowa/uids@uiowa/uids#3.4.1":
-  version "3.4.1"
-  resolved "https://codeload.github.com/uiowa/uids/tar.gz/6cd9aba4a93c06241b9a77506e011f7be0974237"
+"@uiowa/uids@uiowa/uids#3.4.3":
+  version "3.4.3"
+  resolved "https://codeload.github.com/uiowa/uids/tar.gz/41a881546c88a94bc2460caf191fab095d732e86"
   dependencies:
     autoprefixer "^9.8.0"
     cssnano "^4.1.10"


### PR DESCRIPTION
Is resolving https://github.com/uiowa/uids/issues/445. This is intended to give headings and intros a scaling size based upon screen wdth.

# How to test

1. Pull down any site with headings or intros
2. Test that the sizing of any headers or intros scales between 600px and 1310 px viewport width, and that there are clamp rules to change their size and backup rules for unsupported browsers (Which should only be ie7 and before)

