### PR TITLE
update uiowa_footer

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -18789,15 +18789,15 @@
         },
         {
             "name": "uiowa/uiowa_footer",
-            "version": "1.0.0-alpha7",
+            "version": "1.0.0-alpha8",
             "source": {
                 "type": "git",
                 "url": "git@github.com:uiowa/uiowa_footer",
-                "reference": "139566103898d26792873c7f3d7c31c88b689d7b"
+                "reference": "e6bca0ecbed2ba43434fe30b962fa7fdf9b73cb0"
             },
             "type": "drupal-custom-module",
             "description": "Configuration and block implementation for common footer.",
-            "time": "2021-02-08T22:15:46+00:00"
+            "time": "2021-03-31T20:09:16+00:00"
         },
         {
             "name": "webflo/drupal-finder",


### PR DESCRIPTION
I think I mixed up uiowa_bar and uiowa_footer earlier when tackling D9. This should fix that.

## To Test

- `composer install && blt ds --site=hr.uiowa.edu`
- no error about uiowa_footer d9 compatibility