### PR TITLE
Feature: headline size adjustment and bug fixes

### DIFF
--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/area-of-study.scss
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/area-of-study.scss
@@ -8,7 +8,9 @@
     @include flex(0, 1, 100%);
     @include flex-wrap(wrap);
     .field__item {
-      flex: 1;
+      @include breakpoint(sm) {
+        flex: 1;
+      }
     }
     .field__item:not(:last-child) {
       margin-right: $md;

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/area-of-study.scss
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/area-of-study.scss
@@ -27,7 +27,9 @@
   .field--name-field-area-of-study-first-year,
   .field--name-field-area-of-study-transfer,
   .field--name-field-area-of-study-intl {
-    display: flex;
+    @include breakpoint(sm) {
+      display: flex;
+    }
   }
   .bttn.bttn--link {
     padding-left: 0;

--- a/docroot/themes/custom/uids_base/scss/components/typography/headings.scss
+++ b/docroot/themes/custom/uids_base/scss/components/typography/headings.scss
@@ -21,12 +21,7 @@ body:not(.page-node-type-article, .page-node-type-page) #block-uids-base-page-ti
 }
 
 .headline.headline--parent {
-  font-size: 2.2rem;
   margin-bottom: 2rem;
-
-  .layout--onecol & {
-    font-size: 2.3rem;
-  }
 }
 
 .bg-pattern--brain-black [class*="bg--white"] .bold-headline--underline,

--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -249,23 +249,29 @@ body:not(.page-node-type-article, .page-node-type-page).layout-builder-disabled 
 }
 
 .block-margin {
-  @include breakpoint(sm) {
-    &__top {
+  &__top {
+    margin-top: $md;
+
+    &--extra {
       margin-top: $md;
-      &--extra {
+      @include breakpoint(sm) {
         margin-top: $mobile-height-gutter;
       }
     }
+  }
 
-    &__right {
+  &__right {
+    @include breakpoint(sm) {
       margin-right: $md;
     }
+  }
 
-    &__bottom {
-      margin-bottom: $md;
-    }
+  &__bottom {
+    margin-bottom: $md;
+  }
 
-    &__left {
+  &__left {
+    @include breakpoint(sm) {
       margin-left: $md;
     }
   }


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/3298
Resolves #3299 
Resolves #3296 
Resolves #3297

# How to test

`yarn workspace admissions_core build`
`yarn workspace uids_base gulp --development`

For #3298, Go to http://admissions.local.drupal.uiowa.edu/academics/college-level-examination-program-clep and view on mobile emulator and verify that "College-Level Examination Program Credit Policies" now smaller than `<h1>` tag and that it is using the Clamp sizing. 

For, #3299 go to http://admissions.local.drupal.uiowa.edu/academics/accounting-0  in Safari and emulate mobile view and verify that overflow issue noted in issue screenshot is no longer there. 

For https://github.com/uiowa/uiowa/issues/3296, go to http://admissions.local.drupal.uiowa.edu/academics/accounting-0 and view in mobile emulator and verify that stats stack at the smallest screen size. 

For #3297, go to go to http://admissions.local.drupal.uiowa.edu/academics/accounting-0  and verify that apply and info buttons have white space between them. 
