### PR TITLE
Feature: Hotfix for page left sidebar layout main content overflow issue

### DIFF
--- a/docroot/themes/custom/uids_base/scss/admin.scss
+++ b/docroot/themes/custom/uids_base/scss/admin.scss
@@ -1594,3 +1594,13 @@ only screen and (min-resolution: 1.5dppx) {
 [class*="bg--"] [class*="bg--"] .layout-builder__direct-add__list:after {
   border-color: transparent;
 }
+
+// Layouts not covered by lb_direct_add module
+.layout--page--left-sidebar .layout__region--main .layout-builder__add-block.open .layout-builder__direct-add__list > .links {
+  @include breakpoint(sm) {
+    display: grid;
+    gap: 10px 10px;
+    grid-template-columns: repeat(auto-fit, minmax(29.74%, 1fr));
+  }
+}
+

--- a/docroot/themes/custom/uids_base/scss/admin.scss
+++ b/docroot/themes/custom/uids_base/scss/admin.scss
@@ -1594,8 +1594,3 @@ only screen and (min-resolution: 1.5dppx) {
 [class*="bg--"] [class*="bg--"] .layout-builder__direct-add__list:after {
   border-color: transparent;
 }
-
-// Fix for overflow property set for v2 main regions
-.layout-builder__section .layout--has-sidebar .layout__region--main {
-  overflow: visible;
-}

--- a/docroot/themes/custom/uids_base/scss/admin.scss
+++ b/docroot/themes/custom/uids_base/scss/admin.scss
@@ -1594,3 +1594,8 @@ only screen and (min-resolution: 1.5dppx) {
 [class*="bg--"] [class*="bg--"] .layout-builder__direct-add__list:after {
   border-color: transparent;
 }
+
+// Fix for overflow property set for v2 main regions
+.layout-builder__section .layout--has-sidebar .layout__region--main {
+  overflow: visible;
+}

--- a/docroot/themes/custom/uids_base/scss/layouts/page--left-sidebar.scss
+++ b/docroot/themes/custom/uids_base/scss/layouts/page--left-sidebar.scss
@@ -77,7 +77,6 @@
 }
 
 .layout--has-sidebar .layout__region--main {
-  overflow: auto;
   @include breakpoint(menu) {
     flex: 0 1 72.75%;
     @include inner-grid(75);

--- a/docroot/themes/custom/uids_base/scss/sitenow.scss
+++ b/docroot/themes/custom/uids_base/scss/sitenow.scss
@@ -463,3 +463,8 @@ figure.caption .embedded-entity+figcaption {
     color: $secondary;
   }
 }
+
+// Page left sidebar 
+.layout--has-sidebar .layout__region--main {
+  overflow: auto;
+}


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/3340. 

This overrides the `overflow` property set for v2 layouts.    The fix here targets the layout builder edit screen only and should not effect v2 sites. 

# How to test

- `yarn workspace uids_base gulp --development`
- Create a Page in v3 and try to add a block to the main content region. 

