### PR TITLE
Feature: added fix for lb_direct_add `top:100%` issue

### DIFF
--- a/docroot/themes/custom/uids_base/scss/admin.scss
+++ b/docroot/themes/custom/uids_base/scss/admin.scss
@@ -1604,3 +1604,6 @@ only screen and (min-resolution: 1.5dppx) {
   }
 }
 
+.layout-builder__direct-add__list {
+  top: auto;
+}

--- a/docroot/themes/custom/uids_base/scss/admin.scss
+++ b/docroot/themes/custom/uids_base/scss/admin.scss
@@ -1604,6 +1604,7 @@ only screen and (min-resolution: 1.5dppx) {
   }
 }
 
+// @todo Remove this when a corresponding change is made to lb_direct_add module.
 .layout-builder__direct-add__list {
   top: auto;
 }


### PR DESCRIPTION
Since we are using `display: flex` on our layout columns, we need to adjust the top property to fix this visual bug. 

<img width="1579" alt="Screen Shot 2021-04-07 at 10 42 47 AM" src="https://user-images.githubusercontent.com/1036433/114042918-781bf780-984b-11eb-8460-ec6533285f82.png">

# How to test

- `blt ds --site=presidentialsearch.uiowa.edu`
- `yarn workspace uids_base gulp --development`
- Edit http://presidentialsearch.local.drupal.uiowa.edu/node/156/layout and verify that the "Add component" popover does not appear like the screenshot above. 