### PR TITLE
i3348 APR style adjustments

### DIFF
--- a/docroot/modules/custom/uiowa_apr/sass/styles.scss
+++ b/docroot/modules/custom/uiowa_apr/sass/styles.scss
@@ -90,7 +90,8 @@
     }
   }
 
-  .apr-profile #apr-sites li {
+  .apr-profile #apr-sites li,
+  .profiles ul>li {
     display: block;
   }
 

--- a/docroot/modules/custom/uiowa_apr/sass/styles.scss
+++ b/docroot/modules/custom/uiowa_apr/sass/styles.scss
@@ -90,6 +90,10 @@
     }
   }
 
+  .apr-profile #apr-sites li {
+    display: block;
+  }
+
   .list-view {
     margin: $gutter 0;
   }

--- a/docroot/modules/custom/uiowa_apr/sass/styles.scss
+++ b/docroot/modules/custom/uiowa_apr/sass/styles.scss
@@ -107,12 +107,16 @@
     margin-bottom: .5em;
   }
 
-  .apr-profile .apr-phone:before {
-    content:'Phone';
-    position: relative;
-    font-size: 1.3rem;
-    font-weight: 500;
+  .apr-profile .apr-contact .apr-phone.apr-detail {
     display: block;
+
+    &:before {
+      content:'Phone';
+      position: relative;
+      font-size: 1.3rem;
+      font-weight: 500;
+      display: block;
+    }
   }
 
   .list-view {

--- a/docroot/modules/custom/uiowa_apr/sass/styles.scss
+++ b/docroot/modules/custom/uiowa_apr/sass/styles.scss
@@ -50,6 +50,10 @@
 
 
 #apr-directory-service {
+  .apr.directory>div:first-child>a {
+    display: none;
+  }
+
   .apr-profile .apr-section.summary {
     ul {
       @extend %no-ul-list;

--- a/docroot/modules/custom/uiowa_apr/sass/styles.scss
+++ b/docroot/modules/custom/uiowa_apr/sass/styles.scss
@@ -95,6 +95,22 @@
     display: block;
   }
 
+  .apr-profile .profile-image figcaption {
+    text-align: left;
+    font-size: 1.5rem;
+    font-weight: 600;
+    padding-top: .5em;
+    margin-bottom: .5em;
+  }
+
+  .apr-profile .apr-phone:before {
+    content:'Phone';
+    position: relative;
+    font-size: 1.3rem;
+    font-weight: 500;
+    display: block;
+  }
+
   .list-view {
     margin: $gutter 0;
   }


### PR DESCRIPTION
Resolves #3348 

- [x] Increase the font size of the Rank/Title displayed under the photo
- [x] List each website on a separate line. They currently run together in some cases. (https://pharmacy.prod.drupal.uiowa.edu/people/guohua-an)
- [x] List the office phone number below the Primary Office and with a heading of “Phone”. In some cases the phone number is listed with the address. (https://pharmacy.prod.drupal.uiowa.edu/people/vern-k-duba)
- [x] Also, I noticed on the main directory page https://pharmacy.prod.drupal.uiowa.edu/people, the rank/title isn’t always listed below the name. Is there a way to ensure it gets listed below the name?
- [x] Remove back button, as it does not function as intended

# How to test
____
1. Sync `pharmacy.uiowa.edu`.
1. Check that the title under the profile picture matches the size of the other headings underneath it.
2. All websites for a user should be on a separate line. (https://pharmacy.local.drupal.uiowa.edu/people/guohua-an)
3. Phone numbers should now have the title "Phone". (https://pharmacy.local.drupal.uiowa.edu/people/vern-k-duba)
4. The title of a person should now always be underneath their name in the listing view. (https://pharmacy.local.drupal.uiowa.edu/people)
5. The back button should no longer show on individual person pages.
