### PR TITLE
Remove temporary socialwork htaccess redirect from new domain to old domain

### DIFF
--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -89,10 +89,6 @@ AddEncoding gzip svgz
   RewriteCond %{HTTP_HOST} iconsortium\.subst-abuse\.uiowa\.edu$ [NC]
   RewriteRule ^ https://icsa.uiowa.edu/ [L,R=301]
 
-  # Redirect socialwork.uiowa.edu to clas.uiowa.edu/socialwork (temporary)
-  RewriteCond %{HTTP_HOST} socialwork\.uiowa\.edu$ [NC]
-  RewriteRule ^ https://clas.uiowa.edu/socialwork/ [L,R=301]
-
   # Set "protossl" to "s" if we were accessed via https://.  This is used later
   # if you enable "www." stripping or enforcement, in order to ensure that
   # you don't bounce between http and https.


### PR DESCRIPTION
This is simply to remove the redirect from the new https://socialwork.uiowa.edu domain to the old https://clas.uiowa.edu/socialwork domain that was put into place for a marketing campaign last year.

```
  # Redirect socialwork.uiowa.edu to clas.uiowa.edu/socialwork (temporary)
  RewriteCond %{HTTP_HOST} socialwork\.uiowa\.edu$ [NC]
  RewriteRule ^ https://clas.uiowa.edu/socialwork/ [L,R=301]
```

This has been removed.