### PR TITLE
Configuration Split Status

### DIFF
--- a/docroot/profiles/custom/sitenow/composer.json
+++ b/docroot/profiles/custom/sitenow/composer.json
@@ -7,5 +7,12 @@
             "name": "ITS",
             "homepage": "https://its.uiowa.edu"
         }
-    ]
+    ],
+    "extra": {
+        "drush": {
+            "services": {
+                "drush.services.yml": "^10"
+            }
+        }
+    }
 }

--- a/docroot/profiles/custom/sitenow/sitenow.services.yml
+++ b/docroot/profiles/custom/sitenow/sitenow.services.yml
@@ -23,3 +23,7 @@ services:
     arguments: [ '@request_stack' ]
     tags:
       - { name: config.factory.override }
+  sitenow.commands:
+    class: \Drupal\sitenow\Commands\SiteNowCommands
+    tags:
+      - { name: drush.command }

--- a/docroot/profiles/custom/sitenow/src/Commands/SiteNowCommands.php
+++ b/docroot/profiles/custom/sitenow/src/Commands/SiteNowCommands.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\sitenow\Commands;
+
+use Drush\Commands\DrushCommands;
+
+/**
+ * A Drush commandfile.
+ *
+ * In addition to this file, you need a drush.services.yml
+ * in root of your module, and a composer.json file that provides the name
+ * of the services file to use.
+ */
+class SiteNowCommands extends DrushCommands {
+
+  /**
+   * Displays status of a valid configuration split.
+   *
+   * @command sitenow:config-split:status
+   * @aliases scss
+   *
+   * @param string $split
+   *   Argument provided to the drush command.
+   *
+   * @usage sitenow:config-split:status sitenow_v2
+   */
+  public function configSplitStatus(string $split) {
+
+    /** @var \Drupal\Core\Plugin\DefaultPluginManager $filters */
+    $filters = \Drupal::service('plugin.manager.config_filter')->getDefinitions();
+    $split = 'config_split:' . $split;
+
+    // If split isn't registered.
+    if (!isset($filters[$split])) {
+      \Drupal::logger('sitenow')->error('Split does not exist.');
+      return;
+    }
+    $status = $filters[$split]["status"] ? 'true':'false';
+    $this->output()->writeln($split . ':' . $status);
+  }
+}


### PR DESCRIPTION
Drush command that works with blt ume to check the status of a given split.

I am flexible on where this lives, just need something to tell me the usage of a given split.

## To Test

- pull and `drush cc drush`
- with a few multisites synced (v2 and v3) and present in your local.blt.yml file, run the following command:
`blt ume "sitenow:config-split:status sitenow_v2"`
- you should get output "true/false" depending on the site.