### PR TITLE
Re-enable composer security check and disable drupal security check.

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -32,9 +32,7 @@ disable-targets:
       run: true
     frontend:
       run: true
-    security:
-      check:
-        composer: true
+    security-drupal: true
 tests:
   phpunit:
     - config: '${repo.root}'


### PR DESCRIPTION
I actually forgot to rollback #2985 after upgrading to BLT 12 and Drupal 9. This re-enables Composer security checks and disables Drupal security checks (temporarily).