### PR TITLE
Alphabetically sort person type options

### DIFF
--- a/docroot/modules/custom/sitenow_people/sitenow_people.module
+++ b/docroot/modules/custom/sitenow_people/sitenow_people.module
@@ -532,6 +532,7 @@ function sitenow_people_form_views_exposed_form_alter(&$form, FormStateInterface
       foreach ($person_types as $type) {
         $options[$type->id()] = $type->label();
       }
+      asort($options);
 
       // Rebuild the person type text filter as select list.
       $form[$person_type_filter]['#type'] = 'select';


### PR DESCRIPTION
fixes #3306

# How to test

- pull and sync sandbox.uiowa.edu
- go to https://sandbox.local.drupal.uiowa.edu/sandbox-people
- see that person types dropdown is alphabetical
