### PR TITLE
Feature: added UI Indigenous Land Acknowledgement link to footer

### DIFF
--- a/docroot/themes/custom/uids_base/templates/uids/footer--socket-menu.twig
+++ b/docroot/themes/custom/uids_base/templates/uids/footer--socket-menu.twig
@@ -10,5 +10,8 @@
     <li>
       <a href="https://uiowa.edu/accessibility">Accessibility</a>
     </li>
+    <li>
+      <a href="https://nativeamericancouncil.org.uiowa.edu">UI Indigenous Land Acknowledgement</a>
+    </li>
   </ul>
 </div>


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/3503. 

# How to test

The footer of every site should have the updated link text "UI Indigenous Land Acknowledgement" and link directly to the home page of https://nativeamericancouncil.org.uiowa.edu/. 

<img width="1549" alt="Screen Shot 2021-05-07 at 3 44 57 PM" src="https://user-images.githubusercontent.com/1036433/117506521-55b0f300-af4b-11eb-94ca-7b7c770ae070.png">
