### PR TITLE
Feature: taxonomy term page default styles

### DIFF
--- a/docroot/themes/custom/uids_base/scss/views/view-taxonomy-term.scss
+++ b/docroot/themes/custom/uids_base/scss/views/view-taxonomy-term.scss
@@ -19,6 +19,18 @@
 
     .views-row {
       @include list-group-item;
+      padding: 0;
+      .card--media-left,
+      .card--media-right {
+        margin-top: 1.6rem;
+      }
+      &:first-child {
+        border-top: none;
+        .card--media-left,
+        .card--media-right {
+          margin-top: 0;
+        }
+      }
     }
   }
 }

--- a/docroot/themes/custom/uids_base/templates/content/node--view--taxonomy-term.html.twig
+++ b/docroot/themes/custom/uids_base/templates/content/node--view--taxonomy-term.html.twig
@@ -1,0 +1,100 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+
+{%
+  set classes = [
+  'card--list',
+  'card--media-right',
+  'card--person-teaser',
+]
+%}
+
+{% set headline_level = heading_size ?: 'h3' %}
+{% if view %}
+  {% set headline_level = view.display_handler.getOption('heading_size') %}
+{% endif %}
+
+{{ attach_library('classy/node') }}
+{{ attach_library('uids_base/paragraphs-lists') }}
+{{ attach_library('uids_base/person') }}
+
+{% set taxonomy_card = {
+  'attributes': attributes.addClass(classes),
+  'card_text': content.field_teaser | render,
+  'card_title': label,
+  'card_link_url': url,
+  'headline_level': headline_level,
+} %}
+
+{% embed '@uids_base/uids/card.html.twig' with taxonomy_card only %}
+{% endembed %}

--- a/docroot/themes/custom/uids_base/templates/content/node--view--taxonomy-term.html.twig
+++ b/docroot/themes/custom/uids_base/templates/content/node--view--taxonomy-term.html.twig
@@ -73,28 +73,15 @@
 
 {%
   set classes = [
-  'card--list',
   'card--media-right',
-  'card--person-teaser',
 ]
 %}
-
-{% set headline_level = heading_size ?: 'h3' %}
-{% if view %}
-  {% set headline_level = view.display_handler.getOption('heading_size') %}
-{% endif %}
-
-{{ attach_library('classy/node') }}
-{{ attach_library('uids_base/paragraphs-lists') }}
-{{ attach_library('uids_base/person') }}
 
 {% set taxonomy_card = {
   'attributes': attributes.addClass(classes),
   'card_text': content.field_teaser | render,
   'card_title': label,
-  'card_link_url': url,
-  'headline_level': headline_level,
+  'card_link_url': url ?: node_link,
 } %}
 
-{% embed '@uids_base/uids/card.html.twig' with taxonomy_card only %}
-{% endembed %}
+{% include '@uids_base/uids/card.html.twig' with taxonomy_card only %}


### PR DESCRIPTION
Resolves  https://github.com/uiowa/uiowa/issues/3358

# How to test

- `blt ds --site=sandbox.uiowa.edu`
- `yarn workspace uids_base gulp --development`
- `drush @sandbox.local cr`
- Go to https://sandbox.local.drupal.uiowa.edu/tags/mascot and verify that the basic pages, people, and articles should all look the same and only display the title and summary like the screenshot below.

<img width="1583" alt="Screen Shot 2021-05-10 at 12 44 51 PM" src="https://user-images.githubusercontent.com/1036433/117702493-2fc76080-b18e-11eb-93e8-41564c118afd.png">
