### PR TITLE
More Allowed Table Attributes

### DIFF
--- a/config/default/filter.format.filtered_html.yml
+++ b/config/default/filter.format.filtered_html.yml
@@ -64,7 +64,7 @@ filters:
     status: true
     weight: -49
     settings:
-      allowed_html: '<a href hreflang title class id target rel data-*> <em> <strong> <cite> <blockquote class cite> <code> <ul type class> <ol start type class> <li> <dl> <dt> <dd> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <h6 id class> <s> <sup> <sub> <p class> <pre class> <div class> <span class> <hr class> <table class border summary> <caption> <tbody class> <thead class> <tfoot class> <th align valign colspan rowspan scope class> <td align valign colspan rowspan class> <tr align valign class> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-view-mode title alt> <br> <mark> <small class>'
+      allowed_html: '<a href hreflang title class id target rel data-*> <em> <strong> <cite> <blockquote class cite> <code> <ul type class> <ol start type class> <li> <dl> <dt> <dd> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <h6 id class> <s> <sup> <sub> <p class> <pre class> <div class> <span class> <hr class> <table class border summary id role="presentation, grid" aria-label aria-labelledby> <caption id> <tbody class> <thead class> <tfoot class> <th id align valign colspan rowspan scope class> <td align valign colspan rowspan class headers> <tr align valign class> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-view-mode title alt> <br> <mark> <small class>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:


### PR DESCRIPTION
added more table attributes, resolves #2826

`<table>` now allows `id` `role`(presentation and grid only) `aria-label` `aria-labelledby`
`<th>` was allowing `scope` but now allows `id`
`<td>` now allows `headers`

I couldn't find an accessible use-case besides serving as an anchor for allowing more granular `id` capabilities so I left that off for this pass.

## To Test

- Using a table, an editor can manually add these attributes to table markup through the source display and not have the attributes stripped on render.
- I am not aware of any site splitting the filtered_html config.