### PR TITLE
Made degree abbreviation not a required field

### DIFF
--- a/config/features/areas_of_study/field.field.paragraph.degree.field_degree_abbreviation.yml
+++ b/config/features/areas_of_study/field.field.paragraph.degree.field_degree_abbreviation.yml
@@ -13,7 +13,7 @@ entity_type: paragraph
 bundle: degree
 label: Abbreviation
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/features/areas_of_study/field.storage.paragraph.field_degree_abbreviation.yml
+++ b/config/features/areas_of_study/field.storage.paragraph.field_degree_abbreviation.yml
@@ -14,7 +14,7 @@ settings:
   allowed_values_function: uiowa_area_of_study_allowed_values_function
 module: options
 locked: false
-cardinality: 1
+cardinality: 0
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/features/areas_of_study/field.storage.paragraph.field_degree_abbreviation.yml
+++ b/config/features/areas_of_study/field.storage.paragraph.field_degree_abbreviation.yml
@@ -14,7 +14,7 @@ settings:
   allowed_values_function: uiowa_area_of_study_allowed_values_function
 module: options
 locked: false
-cardinality: 0
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->
Closes #3575 
<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test
1. checkout branch
2. blt ds --site=admissions.uiowa.edu
3. Go to field and make sure the "required field' isn't selected https://admissions.local.drupal.uiowa.edu/admin/structure/paragraphs_type/degree/fields/paragraph.degree.field_degree_abbreviation
<!-- Include detailed steps for how to test this PR. -->
