### PR TITLE
Patch moderated_content_bulk_publish to remove edit node JS confirmation.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -271,6 +271,9 @@
                 "Hide block title if menu tree contains no links": "https://www.drupal.org/files/issues/2020-02-12/menu_block-hide_block_if_no_links-2757215-13.patch",
                 "Suppress display of regular system menu blocks in Layout Builder": "https://www.drupal.org/files/issues/2019-12-11/menu_block-remove_duplicates-3062278-11.patch"
             },
+            "drupal/moderated_content_bulk_publish": {
+                "Remove or make optional the node edit form confirmation dialog": "https://www.drupal.org/files/issues/2020-12-01/no_confirmation_dialog-3185848-3.patch"
+            },
             "drupal/paragraphs": {
                 "Langcode error when switching away from IEF for paragraphs in LB": "https://www.drupal.org/files/issues/2020-06-25/paragraphs-2901390-51.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8195e2785383ecef3334130bd9dc9f70",
+    "content-hash": "c709326e97246457c47dc6f5798bf285",
     "packages": [
         {
             "name": "acquia/blt",


### PR DESCRIPTION
### Problem

Edit a node in production (going from published to published) and see an annoying JS confirmation popup.

https://www.drupal.org/project/moderated_content_bulk_publish/issues/3185848

# How to test

- blt sync a site.
- Edit a node.
- See no JS confirmation.
- Publish multiple nodes on content overview page to ensure it still asks for confirmation.


