### PR TITLE
Began process of applying flex basis styles to lb blocks

### DIFF
--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -126,9 +126,6 @@ $imgpath: '../../uids/assets/images';
 
   // @todo Where should this live?
   .block-inline-blockuiowa-text-area {
-    //width: 100%;
-    //flex: 1 0 auto;
-    flex-basis: 100%;
     min-width: 0;
 
     &[class*="bg--"],

--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -10,7 +10,12 @@ $imgpath: '../../uids/assets/images';
 .layout__region {
 
   .block,
-  .view {
+  .view,
+  .card,
+  .banner,
+  .cta__wrapper,
+  .slider,
+  .stat {
     flex-basis: 100%;
   }
 }


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->
Closes #3571 
<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
Add every block (please forgive me haha) from layout builder
Make sure, after you save the page, that the block has a `flex-basis: 100%` style applied to it