### PR TITLE
i3577 - added a margin to the empty-events class

### DIFF
--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -13,6 +13,9 @@ $imgpath: '../../uids/assets/images';
   .view {
     flex-basis: 100%;
   }
+  .events-empty {
+    margin-right: 10px;
+  }
 }
 
 // Unset equal height columns


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->
Closes #3577 
<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
1. Checkout branch
2. blt ds --site=cinematicarts.uiowa.edu
3. blt frontend
4. Look at the 'Upcoming Events' block and make sure there's a margin between the 'no events to display' text and the button