### PR TITLE
Feature: Quick minimal UIDS update fix

### DIFF
--- a/docroot/themes/custom/uids_base/package.json
+++ b/docroot/themes/custom/uids_base/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "ISC",
   "dependencies": {
-    "@uiowa/uids": "uiowa/uids#feb51be",
+    "@uiowa/uids": "uiowa/uids#29e64f5",
     "autoprefixer": "^9.8.6",
     "breakpoint-sass": "^2.7.1",
     "cssnano": "^4.1.10",

--- a/docroot/themes/custom/uids_base/package.json
+++ b/docroot/themes/custom/uids_base/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "ISC",
   "dependencies": {
-    "@uiowa/uids": "uiowa/uids#2db794a",
+    "@uiowa/uids": "uiowa/uids#e7d2e97",
     "autoprefixer": "^9.8.6",
     "breakpoint-sass": "^2.7.1",
     "cssnano": "^4.1.10",

--- a/docroot/themes/custom/uids_base/package.json
+++ b/docroot/themes/custom/uids_base/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "ISC",
   "dependencies": {
-    "@uiowa/uids": "uiowa/uids#29e64f5",
+    "@uiowa/uids": "uiowa/uids#2db794a",
     "autoprefixer": "^9.8.6",
     "breakpoint-sass": "^2.7.1",
     "cssnano": "^4.1.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,9 +1050,9 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
-"@uiowa/uids@uiowa/uids#2db794a":
+"@uiowa/uids@uiowa/uids#e7d2e97":
   version "3.4.5"
-  resolved "https://codeload.github.com/uiowa/uids/tar.gz/2db794aaa7fc4c1cc754cc8405bc2c596b05789e"
+  resolved "https://codeload.github.com/uiowa/uids/tar.gz/e7d2e97c71b6bf681e675d4c38e811818682fca6"
   dependencies:
     autoprefixer "^9.8.6"
     cssnano "^4.1.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,9 +1050,9 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
-"@uiowa/uids@uiowa/uids#29e64f5":
+"@uiowa/uids@uiowa/uids#2db794a":
   version "3.4.5"
-  resolved "https://codeload.github.com/uiowa/uids/tar.gz/29e64f55bcab5e1e26a834c572ac39e539f87ada"
+  resolved "https://codeload.github.com/uiowa/uids/tar.gz/2db794aaa7fc4c1cc754cc8405bc2c596b05789e"
   dependencies:
     autoprefixer "^9.8.6"
     cssnano "^4.1.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,9 +1050,9 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
-"@uiowa/uids@uiowa/uids#feb51be":
+"@uiowa/uids@uiowa/uids#29e64f5":
   version "3.4.5"
-  resolved "https://codeload.github.com/uiowa/uids/tar.gz/feb51beecb1ca0eb2403ddb2c8e7089cbdd82573"
+  resolved "https://codeload.github.com/uiowa/uids/tar.gz/29e64f55bcab5e1e26a834c572ac39e539f87ada"
   dependencies:
     autoprefixer "^9.8.6"
     cssnano "^4.1.11"


### PR DESCRIPTION
This contains:
-  An `.h1` class update that I missed in the previous pull request: https://github.com/uiowa/uids/blob/main/src/components/typography/headings/headings.scss#L19-L25. 
- Intro text size update from https://github.com/uiowa/uids/pull/563. 