### PR TITLE
Feature: Admissions internal pdf links

### DIFF
--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/pdf.scss
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/pdf.scss
@@ -68,6 +68,12 @@ em {
       display: inline;
       color: #999;
     }
+    // Internal links, beginning with "/"
+    &[href^="/"] {
+      &:after {
+        content: " (https://admissions.uiowa.edu" attr(href) ")";
+      }
+    }
   }
 }
 


### PR DESCRIPTION
# How to test
```
blt ds --site=admissions.uiowa.edu
yarn workspace admissions_core build
drush @admissions.local cr
drush @admissions.local uli
```
- Go to https://admissions.local.drupal.uiowa.edu/print/pdf/node/2566 and verify that internal links now have admissions url printing out with node id. 
- Verify there are no spelling errors in admissions.uiowa.edu.