### PR TITLE
Person Type Status fix

### DIFF
--- a/docroot/modules/custom/sitenow_people/sitenow_people.module
+++ b/docroot/modules/custom/sitenow_people/sitenow_people.module
@@ -269,7 +269,7 @@ function _person_types_callback(array &$form, FormStateInterface $form_state) {
   //   the triggering element is the person types filter? Currently
   //   we're skipping if we're on a node form, but scoping could be
   //   more specific.
-  if ($form['#form_id'] === 'node_person_form') {
+  if (in_array($form['#form_id'], ['node_person_form', 'node_person_edit_form'])) {
     return $form;
   }
   $type = $form_state->getValue([

--- a/docroot/modules/custom/sitenow_people/sitenow_people.module
+++ b/docroot/modules/custom/sitenow_people/sitenow_people.module
@@ -266,7 +266,12 @@ function _sitenow_people_exposed_filters_validate(array &$form, FormStateInterfa
  */
 function _person_types_callback(array &$form, FormStateInterface $form_state) {
   // @todo Do these modifications need to be scoped to just run when
-  //   the triggering element is the person types filter?
+  //   the triggering element is the person types filter? Currently
+  //   we're skipping if we're on a node form, but scoping could be
+  //   more specific.
+  if ($form['#form_id'] === 'node_person_form') {
+    return $form;
+  }
   $type = $form_state->getValue([
     'settings',
     'override',


### PR DESCRIPTION
Resolves #3662

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

As a site editor creating a new person, I should see all available person type status options (eg Former Faculty) based on my currently selected person type(s), both when creating a new person and when editing an existing person.