### PR TITLE
Left Sidebar updates

### DIFF
--- a/docroot/themes/custom/uids_base/scss/layouts/page--left-sidebar.scss
+++ b/docroot/themes/custom/uids_base/scss/layouts/page--left-sidebar.scss
@@ -48,7 +48,7 @@
 .content__container .layout__container.layout--no-sidebar,
 .content__container .layout__container.layout--has-sidebar.sidebar-invisible {
   margin-bottom: 0;
-  .layout__region--main {
+  .layout__region--content {
     @include breakpoint(menu) {
       @include inner-grid(75);
     }
@@ -69,7 +69,7 @@
       display: none;
     }
 
-    .layout__region--main {
+    .layout__region--content {
       @include breakpoint(menu) {
         flex: 0 1 100%;
       }
@@ -77,7 +77,7 @@
   }
 }
 
-.layout--has-sidebar .layout__region--main {
+.layout--has-sidebar .layout__region--content {
   min-width: 0;
   @include breakpoint(menu) {
     flex: 0 1 72.75%;

--- a/docroot/themes/custom/uids_base/templates/layouts/page--left-sidebar/layout--page--left-sidebar.html.twig
+++ b/docroot/themes/custom/uids_base/templates/layouts/page--left-sidebar/layout--page--left-sidebar.html.twig
@@ -26,35 +26,6 @@
 %}
 {{ attach_library('uids_base/page--left-sidebar') }}
 
-{% if content %}
-  <div{{ attributes.addClass(classes) }}>
-    <div class="layout__spacing_container">
-      {% if sidebar %}
-        <div class="layout__region layout__region--sidebar">
-          {% if region_attributes.sidebar.storage['data-region'] %}
-          {{ attach_library('uids_base/admin') }}
-          <div {{ region_attributes.sidebar.addClass('flex__wrapper') }}>
-            {% endif %}
-            {{ sidebar }}
-            {% if region_attributes.sidebar.storage['data-region'] %}
-          </div>
-          {% endif %}
-        </div>
-      {% endif %}
+{% set attributes = attributes.addClass(classes) %}
 
-      {% if content.content %}
-        <div class="layout__region layout__region--main">
-          {% if region_attributes.content.storage['data-region'] %}
-          {{ attach_library('uids_base/admin') }}
-          <div {{ region_attributes.content.addClass('flex__wrapper') }}>
-            {% endif %}
-            {{ content.content }}
-            {% if region_attributes.content.storage['data-region'] %}
-          </div>
-          {% endif %}
-        </div>
-      {% endif %}
-    </div>
-  </div>
-
-{% endif %}
+{% include '@uids_base/layouts/layout.html.twig' %}


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/3652 

# How to test

Create a new page, add a section below the left sidebar section. Add a text area. Throw in some text. Save. See if there's too much space between the page title and text. See screenshot below.

![image](https://user-images.githubusercontent.com/52135878/122814225-83eb5780-d299-11eb-81bc-a7754e06433c.png)

User stories:
- As a V3 site owner, I can have an empty page with left sidebar sections in my layout and not have them render on the publish page.
- As a V2 site owner, I can continue to use the default layout and have a sidebar/hide the sidebar region/hide the page title.