### PR TITLE
Feature: people multiple title/positions on the people list block and sitenow people page

### DIFF
--- a/config/default/views.view.people_list_block.yml
+++ b/config/default/views.view.people_list_block.yml
@@ -526,7 +526,7 @@ display:
           delta_reversed: false
           delta_first_last: false
           multi_type: separator
-          separator: ', '
+          separator: '<br />'
           field_api_classes: false
           plugin_id: field
       filters:

--- a/docroot/themes/custom/uids_base/scss/views/view-display-id-people.scss
+++ b/docroot/themes/custom/uids_base/scss/views/view-display-id-people.scss
@@ -2,6 +2,9 @@
 @import "uids/assets/scss/_utilities.scss";
 
 .view-id-people {
+  .card__subtitle .field--label-visually_hidden .field__items {
+    display: grid;
+  }
   .view-header {
     width: 100%;
   }


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/3677. 


# How to test

`blt ds --site=cs.uiowa.edu`
`yarn workspace uids_base gulp --development`
`drush @cs.local cr`
`drush @cs.local uli`

- Test that multiple Title/Position(s) are listed on separate lines on https://cs.local.drupal.uiowa.edu/people and https://cs.local.drupal.uiowa.edu/people/faculty. 
- 
<!-- Include detailed steps for how to test this PR. -->
