### PR TITLE
Brand - Change Lockup Organization field to dropdown

### DIFF
--- a/config/brand.uiowa.edu/core.entity_form_display.node.lockup.default.yml
+++ b/config/brand.uiowa.edu/core.entity_form_display.node.lockup.default.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.node.lockup.field_lockup_s_unit_stacked
     - field.field.node.lockup.field_lockup_sub_unit
     - node.type.lockup
-    - workflows.workflow.editorial
+    - workflows.workflow.lockup
   module:
     - content_moderation
     - path
@@ -26,13 +26,9 @@ content:
     third_party_settings: {  }
   field_lockup_org:
     weight: 1
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-      match_limit: 10
+    settings: {  }
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: options_select
     region: content
   field_lockup_p_unit_stacked:
     weight: 4


### PR DESCRIPTION
Resolves #3690 

## Story

As a collaborator on the brand.uiowa.edu website, I want see the organization options available to me instead of having to guess and type possible options.

## Test

- `blt ds --site=brand.uiowa.edu`
- create a lockup while masquerading as a collaborator user
- See that you can easily select an organization from the dropdown.