### PR TITLE
Feature: Response headers for transportation.uiowa.edu

### DIFF
--- a/docroot/sites/transportation.uiowa.edu/modules/transportation_calculator/src/EventSubscriber/RemoveXFrameOptionsSubscriber.php
+++ b/docroot/sites/transportation.uiowa.edu/modules/transportation_calculator/src/EventSubscriber/RemoveXFrameOptionsSubscriber.php
@@ -14,9 +14,10 @@ class RemoveXFrameOptionsSubscriber implements EventSubscriberInterface {
   /**
    * Set header 'Content-Security-Policy' and 'X-Frame options'.
    *
-   * @param ResponseEvent $event
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *   The event.
    */
-  public function RemoveXFrameOptions(ResponseEvent $event) {
+  public function removeFrameOptions(ResponseEvent $event) {
     $response = $event->getResponse();
     $response->headers->set('X-Frame-Options', 'ALLOW-FROM https://parking.uiowa.edu/');
     $response->headers->set('Content-Security-Policy', 'frame-ancestors https://parking.uiowa.edu/');
@@ -26,7 +27,7 @@ class RemoveXFrameOptionsSubscriber implements EventSubscriberInterface {
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() {
-    $events[KernelEvents::RESPONSE][] = ['RemoveXFrameOptions', -10];
+    $events[KernelEvents::RESPONSE][] = ['removeFrameOptions', -10];
     return $events;
   }
 

--- a/docroot/sites/transportation.uiowa.edu/modules/transportation_calculator/src/EventSubscriber/RemoveXFrameOptionsSubscriber.php
+++ b/docroot/sites/transportation.uiowa.edu/modules/transportation_calculator/src/EventSubscriber/RemoveXFrameOptionsSubscriber.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\transportation_calculator\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Set X-Frame options.
+ */
+class RemoveXFrameOptionsSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Set header 'Content-Security-Policy' and 'X-Frame options'.
+   *
+   * @param ResponseEvent $event
+   */
+  public function RemoveXFrameOptions(ResponseEvent $event) {
+    $response = $event->getResponse();
+    $response->headers->set('X-Frame-Options', 'ALLOW-FROM https://parking.uiowa.edu/');
+    $response->headers->set('Content-Security-Policy', 'frame-ancestors https://parking.uiowa.edu/');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[KernelEvents::RESPONSE][] = ['RemoveXFrameOptions', -10];
+    return $events;
+  }
+
+}

--- a/docroot/sites/transportation.uiowa.edu/modules/transportation_calculator/transportation_calculator.services.yml
+++ b/docroot/sites/transportation.uiowa.edu/modules/transportation_calculator/transportation_calculator.services.yml
@@ -1,0 +1,5 @@
+services:
+  remove_x_frame_options_subscriber:
+    class: Drupal\transportation_calculator\EventSubscriber\RemoveXFrameOptionsSubscriber
+    tags:
+      - { name: event_subscriber }


### PR DESCRIPTION
Updates headers for https://parking.uiowa.edu/kiosk/.

# How to test

- Open local site dev tools and click on the network tab.  
- Find "transportation.local.drupal.uiowa.edu" and click on "Headers". 
- You should see the items listed below in the Response Headers:

<img width="554" alt="Screen Shot 2021-06-25 at 4 41 07 PM" src="https://user-images.githubusercontent.com/1036433/123487767-34c46000-d5d4-11eb-97dd-72698e48fc48.png">

<img width="643" alt="Screen Shot 2021-06-25 at 4 41 13 PM" src="https://user-images.githubusercontent.com/1036433/123487772-355cf680-d5d4-11eb-9ad3-49ba84b8ca09.png">

