### PR TITLE
Fix: Changed breakpoint for container top padding

### DIFF
--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -35,7 +35,7 @@ $imgpath: '../../uids/assets/images';
   // This will be overridden by a subsequent style for 1+n containers.
   padding-top: $mobile-width-gutter;
 
-  @include breakpoint(container) {
+  @include breakpoint(sm) {
     padding-top: $desktop-width-gutter;
     padding-bottom: $desktop-width-gutter;
   }


### PR DESCRIPTION
Resolves #3720 

# How to test
* As a content editor, when I apply the "Add extra top spacing" style to a Layout Builder section, I don't see a change in padding size when I adjust the size of the viewport past the normal width container breakpoint.

