### PR TITLE
Require dispatch signup form email field, change submit message and add headline field.

### DIFF
--- a/docroot/modules/custom/sitenow_dispatch/sitenow_dispatch.module
+++ b/docroot/modules/custom/sitenow_dispatch/sitenow_dispatch.module
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Contains sitenow_dispatch.module.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_alter().
+ */
+function sitenow_dispatch_form_layout_builder_add_block_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Checks to see if there is an API key set, and if not we shouldn't be able to add the block, so remove the button.
+  if (empty(\Drupal::config('sitenow_dispatch.settings')->get('api_key'))) {
+    $form['actions']['submit']['#access'] = FALSE;
+  }
+}

--- a/docroot/modules/custom/sitenow_dispatch/src/Form/SubscribeForm.php
+++ b/docroot/modules/custom/sitenow_dispatch/src/Form/SubscribeForm.php
@@ -120,8 +120,9 @@ class SubscribeForm extends ConfigFormBase {
 
     $this->messenger()->addStatus(
       $this->t(
-        '"@first @last" has been added to the subscription list with the email "@email"',
-        ['@first' => $first, '@last' => $last, '@email' => $email]
+        '@email has been added to the subscription list.', [
+          '@email' => $email,
+        ]
       )
     );
   }

--- a/docroot/modules/custom/sitenow_dispatch/src/Form/SubscribeForm.php
+++ b/docroot/modules/custom/sitenow_dispatch/src/Form/SubscribeForm.php
@@ -65,6 +65,7 @@ class SubscribeForm extends ConfigFormBase {
       '#type' => 'email',
       '#title' => $this->t('Email'),
       '#default_value' => $this->config('sitenow_dispatch.subscribe_form')->get('email'),
+      '#required' => TRUE,
     ];
     $form['first'] = [
       '#type' => 'textfield',

--- a/docroot/modules/custom/sitenow_dispatch/src/Plugin/Block/SignUpFormBlock.php
+++ b/docroot/modules/custom/sitenow_dispatch/src/Plugin/Block/SignUpFormBlock.php
@@ -91,6 +91,15 @@ class SignUpFormBlock extends BlockBase implements ContainerFactoryPluginInterfa
         ]),
       ];
 
+//      $form['no_submit'] = [
+//        '#type' => 'submit',
+//        '#title' => $this->t('Population'),
+//        '#description' => $this->t('Select a population to use.'),
+//        '#default_value' => $this->configuration['population'] ?? '',
+//        '#required' => FALSE,
+//        '#options' => $populationOptions,
+//      ];
+
       return $form;
     }
 

--- a/docroot/modules/custom/sitenow_dispatch/src/Plugin/Block/SignUpFormBlock.php
+++ b/docroot/modules/custom/sitenow_dispatch/src/Plugin/Block/SignUpFormBlock.php
@@ -91,15 +91,6 @@ class SignUpFormBlock extends BlockBase implements ContainerFactoryPluginInterfa
         ]),
       ];
 
-//      $form['no_submit'] = [
-//        '#type' => 'submit',
-//        '#title' => $this->t('Population'),
-//        '#description' => $this->t('Select a population to use.'),
-//        '#default_value' => $this->configuration['population'] ?? '',
-//        '#required' => FALSE,
-//        '#options' => $populationOptions,
-//      ];
-
       return $form;
     }
 

--- a/docroot/modules/custom/sitenow_dispatch/src/Plugin/Block/SignUpFormBlock.php
+++ b/docroot/modules/custom/sitenow_dispatch/src/Plugin/Block/SignUpFormBlock.php
@@ -8,6 +8,7 @@ use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
+use Drupal\uiowa_core\HeadlineHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -101,6 +102,13 @@ class SignUpFormBlock extends BlockBase implements ContainerFactoryPluginInterfa
       }
     }
 
+    $form['headline'] = HeadlineHelper::getElement([
+      'headline' => $this->configuration['headline'] ?? NULL,
+      'hide_headline' => $this->configuration['hide_headline'] ?? 0,
+      'heading_size' => $this->configuration['heading_size'] ?? 'h2',
+      'headline_style' => $this->configuration['headline_style'] ?? 'default',
+    ], FALSE);
+
     $form['population'] = [
       '#type' => 'select',
       '#title' => $this->t('Population'),
@@ -116,17 +124,29 @@ class SignUpFormBlock extends BlockBase implements ContainerFactoryPluginInterfa
   /**
    * {@inheritdoc}
    */
-  public function build() {
-    $build['content'] = $this->formBuilder->getForm('Drupal\sitenow_dispatch\Form\SubscribeForm', $this->configuration['population']);
-    return $build;
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    foreach ($form_state->getValues()['headline']['container'] as $name => $value) {
+      $this->configuration[$name] = $value;
+    }
+
+    $this->configuration['population'] = $form_state->getValue('population');
+    parent::blockSubmit($form, $form_state);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function blockSubmit($form, FormStateInterface $form_state) {
-    $this->configuration['population'] = $form_state->getValue('population');
-    parent::blockSubmit($form, $form_state);
+  public function build() {
+    $build['heading'] = [
+      '#theme' => 'uiowa_core_headline',
+      '#headline' => $this->configuration['headline'],
+      '#hide_headline' => $this->configuration['hide_headline'],
+      '#heading_size' => $this->configuration['heading_size'],
+      '#headline_style' => $this->configuration['headline_style'],
+    ];
+
+    $build['form'] = $this->formBuilder->getForm('Drupal\sitenow_dispatch\Form\SubscribeForm', $this->configuration['population']);
+    return $build;
   }
 
 }

--- a/docroot/modules/custom/uiowa_core/src/HeadlineHelper.php
+++ b/docroot/modules/custom/uiowa_core/src/HeadlineHelper.php
@@ -50,7 +50,7 @@ class HeadlineHelper {
    *
    * @todo Investigate creating a custom render element for this.
    */
-  public static function getElement(array $defaults) {
+  public static function getElement(array $defaults, $has_children = TRUE) {
     $heading_size_options = self::getHeadingOptions();
 
     $element['container'] = [

--- a/docroot/modules/custom/uiowa_core/src/HeadlineHelper.php
+++ b/docroot/modules/custom/uiowa_core/src/HeadlineHelper.php
@@ -92,7 +92,7 @@ class HeadlineHelper {
       '#type' => 'select',
       '#title' => t('Headline size'),
       '#options' => $heading_size_options,
-      '#description' => t('The heading size for the block title. Children headings will be set one level lower.'),
+      '#description' => t('The heading size for the block title.'),
       '#default_value' => $defaults['heading_size'],
       '#states' => [
         'visible' => [
@@ -121,23 +121,27 @@ class HeadlineHelper {
       ],
     ];
 
-    // Add an additional option for children headings.
-    $heading_size_options['h6'] = 'Heading 6';
+    if ($has_children) {
+      $element['container']['heading_size']['#description'] .= ' Children headings will be set one level lower.';
 
-    $element['container']['child_heading_size'] = [
-      '#type' => 'select',
-      '#title' => t('Child content heading size'),
-      '#options' => $heading_size_options,
-      '#default_value' => $defaults['child_heading_size'],
-      '#description' => t('The heading size for all children headings.'),
-      '#states' => [
-        'visible' => [
-          ':input[id="uiowa-headline-field"]' => [
-            'filled' => FALSE,
+      // Add an additional option for children headings.
+      $heading_size_options['h6'] = 'Heading 6';
+
+      $element['container']['child_heading_size'] = [
+        '#type' => 'select',
+        '#title' => t('Child content heading size'),
+        '#options' => $heading_size_options,
+        '#default_value' => $defaults['child_heading_size'],
+        '#description' => t('The heading size for all children headings.'),
+        '#states' => [
+          'visible' => [
+            ':input[id="uiowa-headline-field"]' => [
+              'filled' => FALSE,
+            ],
           ],
         ],
-      ],
-    ];
+      ];
+    }
 
     return $element;
   }


### PR DESCRIPTION
Follow up to #3823.

### Setup 
- Configure SiteNow Dispatch settings with csi.drupal API key.
- Add a signup form to a page.

### Stories
- As someone subscribing to a list, I cannot submit the form without entering my email.
- As someone subscribing to a list, I see a confirmation message that makes sense when I submit the form.
- As a site user, I can add a signup form to a page with a headline appropriately sized and styled.

### Alan's added story
- As someone trying to add a sign up form block, I cannot add the block to the page until I have configured an API key.