### PR TITLE
Create sitenow update to cc all and change engineering media title/alt fields.

### DIFF
--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -16,10 +16,12 @@ use Drupal\Core\Entity\Sql\SqlContentEntityStorageException;
 use Drupal\Core\Site\Settings;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\file\Entity\File;
 use Drupal\filter\Plugin\Filter\FilterHtmlCorrector;
 use Drupal\layout_builder\InlineBlockUsage;
 use Drupal\layout_builder\Section;
 use Drupal\layout_builder\SectionComponent;
+use Drupal\media\Entity\Media;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\Entity\Node;
 use Drupal\paragraphs\Entity\Paragraph;
@@ -3268,5 +3270,40 @@ function sitenow_update_9014() {
     $storage_handler = \Drupal::entityTypeManager()->getStorage('block_content');
     $entities = $storage_handler->loadMultiple($result);
     $storage_handler->delete($entities);
+  }
+}
+
+/**
+ * Clear cache for lazy update and update engineering migrated files metadata.
+ */
+function sitenow_update_9015() {
+  drupal_flush_all_caches();
+
+  $site_path = \Drupal::service('site.path');
+
+  if ($site_path == 'sites/engineering.uiowa.edu') {
+    $query = \Drupal::entityTypeManager()->getStorage('media')->getQuery();
+
+    $ids = $query
+      ->condition('bundle', 'image')
+      ->condition('name', 'title')
+      ->execute();
+
+    if ($ids) {
+      $controller = \Drupal::entityTypeManager()->getStorage('media');
+      $entities = $controller->loadMultiple($ids);
+
+      /** @var Media $media */
+      foreach ($entities as $media) {
+        $file = File::load($media->get('field_media_image')->target_id);
+
+        if ($file && $filename = $file->getFilename()) {
+          $no_ext = pathinfo($filename, PATHINFO_FILENAME);
+          $media->field_media_image->alt = $no_ext;
+          $media->setName($no_ext);
+          $media->save();
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Resolves #3870

I'm not sure how to connect to the D7 database to make this better. If someone has an idea of how to do that, I think this could be closed in favor of that approach as it'd probably have better alt/title fields.

While syncing this site, I got a fatal error related to #3745 so I included a cc all in the update hook.

### Setup
```
blt sync --site engineering.uiowa.edu
```

### Stories
- As an engineering site content creator, I can browse and search media by name.
- As an engineering site content creator, I can embed images with decent alt text.