### PR TITLE
Fix Brand Lockup Digest

### DIFF
--- a/docroot/sites/brand.uiowa.edu/modules/brand_core/src/Commands/BrandCoreCommands.php
+++ b/docroot/sites/brand.uiowa.edu/modules/brand_core/src/Commands/BrandCoreCommands.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\brand_core\Commands;
 
+use Drupal\Core\Session\UserSession;
 use Drush\Commands\DrushCommands;
 use Drupal\Core\Url;
 
@@ -27,7 +28,7 @@ class BrandCoreCommands extends DrushCommands {
   public function lockupDigest($options = ['msg' => FALSE]) {
     // Switch to the admin user to get hidden view result.
     $accountSwitcher = \Drupal::service('account_switcher');
-    $accountSwitcher->switchTo(new \Drupal\Core\Session\UserSession(['uid' => 1]));
+    $accountSwitcher->switchTo(new UserSession(['uid' => 1]));
 
     $view = views_get_view_result('lockup_moderation', 'block_review');
     if (!empty($view)) {

--- a/docroot/sites/brand.uiowa.edu/modules/brand_core/src/Commands/BrandCoreCommands.php
+++ b/docroot/sites/brand.uiowa.edu/modules/brand_core/src/Commands/BrandCoreCommands.php
@@ -25,6 +25,10 @@ class BrandCoreCommands extends DrushCommands {
    *  Ideally this is done as a crontab that is only sent once a day.
    */
   public function lockupDigest($options = ['msg' => FALSE]) {
+    // Switch to the admin user to get hidden view result.
+    $accountSwitcher = \Drupal::service('account_switcher');
+    $accountSwitcher->switchTo(new \Drupal\Core\Session\UserSession(['uid' => 1]));
+
     $view = views_get_view_result('lockup_moderation', 'block_review');
     if (!empty($view)) {
       $results = count($view);
@@ -66,6 +70,8 @@ class BrandCoreCommands extends DrushCommands {
     if ($options['msg']) {
       $this->output()->writeln('Hey! Way to go above and beyond!');
     }
+    // Switch user back.
+    $accountSwitcher->switchBack();
   }
 
 }


### PR DESCRIPTION
Site owners have not been getting Lockup Generator needs review emails since our recent permissions change. This is because drush does not "see" the unpublished lockup revisions. No results = no email.

This switches to user 1 to see the results and switches back after the email is sent.

## Story

As a site owner of brand.uiowa.edu I should expect a daily digest email if there are lockups to be reviewed.

## To Test

- pull and `blt ds --site=brand.uiowa.edu`
- create a lockup with the review moderation state. https://brand.local.drupal.uiowa.edu/node/add/lockup
- see https://brand.local.drupal.uiowa.edu/admin/structure/views/view/lockup_moderation and there should be your needs review lockup.
- `drush @brand.local brand-ld` should error because of reroute_email but should indicated that an email was prepared with results but not set. `Lockup Review Digest Not Sent` instead of `Lockup Review Digest - No items to review`