### PR TITLE
update facebook to 3.0.0-beta2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -150,7 +150,7 @@
         "drupal/linkit_media_library": "^1.0",
         "drupal/mailsystem": "^4.1",
         "drupal/masquerade": "^2.0@beta",
-        "drupal/media_entity_facebook": "^2.0@beta",
+        "drupal/media_entity_facebook": "^3.0@beta",
         "drupal/media_entity_file_replace": "^1.0@beta",
         "drupal/media_entity_instagram": "^3.0",
         "drupal/media_entity_twitter": "^2.4",
@@ -263,11 +263,6 @@
             "drupal/layout_builder_styles": {
                 "Section dependency on layout plugin configuration form": "https://www.drupal.org/files/issues/2019-08-23/layout_builder_styles-3062261-%2310.patch",
                 "Grouping of layout builder styles": "https://www.drupal.org/files/issues/2021-03-16/3075502-18_0.patch"
-            },
-            "drupal/media_entity_facebook": {
-                "Allow creation of new Facebook media entities using the Media Browser": "https://www.drupal.org/files/issues/2020-03-31/3120085-media-library-add-5.patch",
-                "Support for Facebook API - Not a long term solution": "https://www.drupal.org/files/issues/2020-10-26/3176739-4.patch",
-                "undefined function file_unmanaged_copy": "https://www.drupal.org/files/issues/2020-07-19/3160072-6.patch"
             },
             "drupal/menu_block": {
                 "Hide block title if menu tree contains no links": "https://www.drupal.org/files/issues/2020-02-12/menu_block-hide_block_if_no_links-2757215-13.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "529cfbedafcc074e5d52e376f16769e3",
+    "content-hash": "9b8fd7922359cac0e4379fbb4226f8cf",
     "packages": [
         {
             "name": "acquia/blt",
@@ -7509,17 +7509,17 @@
         },
         {
             "name": "drupal/media_entity_facebook",
-            "version": "2.0.0-beta1",
+            "version": "3.0.0-beta2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/media_entity_facebook.git",
-                "reference": "8.x-2.0-beta1"
+                "reference": "3.0.0-beta2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/media_entity_facebook-8.x-2.0-beta1.zip",
-                "reference": "8.x-2.0-beta1",
-                "shasum": "e86980153bebf13d46fbbb8a52bc8d73ac64d7cd"
+                "url": "https://ftp.drupal.org/files/projects/media_entity_facebook-3.0.0-beta2.zip",
+                "reference": "3.0.0-beta2",
+                "shasum": "524e0c701fb9bc868a801b200fdc387ab0fda6ae"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
@@ -7527,8 +7527,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.0-beta1",
-                    "datestamp": "1594950036",
+                    "version": "3.0.0-beta2",
+                    "datestamp": "1616204308",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -7561,7 +7561,7 @@
                     "homepage": "https://www.drupal.org/user/744628"
                 }
             ],
-            "description": "Media entity Facebook provider.",
+            "description": "Media entity source provider for embedding Facebook posts.",
             "homepage": "https://www.drupal.org/project/media_entity_facebook",
             "support": {
                 "source": "https://git.drupalcode.org/project/media_entity_facebook"
@@ -21902,5 +21902,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/config/default/media_entity_facebook.settings.yml
+++ b/config/default/media_entity_facebook.settings.yml
@@ -1,0 +1,2 @@
+facebook_app_id: ''
+facebook_app_secret: ''


### PR DESCRIPTION
Replaces https://github.com/uiowa/uiowa/pull/3896

## Story

As a site editor I can successfully embed facebook posts using the facebook media method.

## To Test

- Facebook embeds render locally if you have the secret credentials (I can DM you the credentials for testing) and not like a blockquote (e.g. https://sitenow.uiowa.edu/documentation/media/social-media-embed)
- Media Library Facebook Add form still is available
- No facebook warning message on a blt ds