### PR TITLE
Trim profiles API key on save.

### DIFF
--- a/docroot/modules/custom/uiowa_profiles/src/Form/SettingsForm.php
+++ b/docroot/modules/custom/uiowa_profiles/src/Form/SettingsForm.php
@@ -391,6 +391,15 @@ class SettingsForm extends ConfigFormBase {
     }
 
     foreach ($directories as $key => $directory) {
+      // Make sure the API key does not have any extra spaces before/after it.
+      $form_state->setValue([
+        'profiles_fieldset',
+        'tabs_container',
+        'directories',
+        $key,
+        'api_key',
+      ], trim($directory['api_key']));
+
       $path = $this->aliasCleaner->cleanAlias($directory['path']);
 
       /** @var \Drupal\Core\Url $url */


### PR DESCRIPTION
### Setup
- Follow setup from original Profiles PR: #3644 

### Stories
- As a webmaster configuring SiteNow Profiles, I can copy/paste API keys with leading or trailing spaces for multiple directories and things just work.