### PR TITLE
add tag filter to content overview, moderated content

### DIFF
--- a/config/default/views.view.content.yml
+++ b/config/default/views.view.content.yml
@@ -2,8 +2,11 @@ uuid: 7f810d8c-2c52-4025-9b55-cd4d9e461105
 langcode: en
 status: true
 dependencies:
+  config:
+    - taxonomy.vocabulary.tags
   module:
     - node
+    - taxonomy
     - user
 _core:
   default_config_hash: tS8PbpJX90aRFC3-UTgXzdqkq7_2frk2pz4TMijEebM
@@ -488,34 +491,38 @@ display:
           plugin_id: boolean
           entity_type: node
           entity_field: status
-        langcode:
-          id: langcode
-          table: node_field_data
-          field: langcode
+        field_tags_target_id:
+          id: field_tags_target_id
+          table: node__field_tags
+          field: field_tags_target_id
           relationship: none
           group_type: group
           admin_label: ''
-          operator: in
+          operator: or
           value: {  }
           group: 1
           exposed: true
           expose:
-            operator_id: langcode_op
-            label: Language
+            operator_id: field_tags_target_id_op
+            label: Tags
             description: ''
             use_operator: false
-            operator: langcode_op
-            identifier: langcode
+            operator: field_tags_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_tags_target_id
             required: false
             remember: false
-            multiple: false
+            multiple: true
             remember_roles:
               authenticated: authenticated
               anonymous: '0'
+              viewer: '0'
+              editor: '0'
+              publisher: '0'
+              webmaster: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -528,9 +535,20 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: language
-          entity_type: node
-          entity_field: langcode
+          reduce_duplicates: false
+          type: textfield
+          limit: true
+          vid: tags
+          hierarchy: false
+          error_message: true
+          parent: 0
+          level_labels: ''
+          force_deepest: false
+          save_lineage: false
+          hierarchy_depth: 0
+          required_depth: 0
+          none_label: '- Please select -'
+          plugin_id: taxonomy_index_tid
         status_extra:
           id: status_extra
           table: node_field_data

--- a/config/default/views.view.moderated_content.yml
+++ b/config/default/views.view.moderated_content.yml
@@ -3,10 +3,12 @@ langcode: en
 status: true
 dependencies:
   config:
+    - taxonomy.vocabulary.tags
     - workflows.workflow.editorial
   module:
     - content_moderation
     - node
+    - taxonomy
     - user
 _core:
   default_config_hash: 1UIjNd6iIhogbx50cJPDN7Me8cUQx2xCP2IBgrKG6Ms
@@ -673,34 +675,38 @@ display:
             group_items: {  }
           entity_type: node
           plugin_id: moderation_state_filter
-        langcode:
-          id: langcode
-          table: node_field_revision
-          field: langcode
-          relationship: none
+        field_tags_target_id:
+          id: field_tags_target_id
+          table: node__field_tags
+          field: field_tags_target_id
+          relationship: nid
           group_type: group
           admin_label: ''
-          operator: in
+          operator: or
           value: {  }
           group: 1
           exposed: true
           expose:
-            operator_id: langcode_op
-            label: Language
+            operator_id: field_tags_target_id_op
+            label: Tags
             description: ''
             use_operator: false
-            operator: langcode_op
-            identifier: langcode
+            operator: field_tags_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_tags_target_id
             required: false
             remember: false
-            multiple: false
+            multiple: true
             remember_roles:
               authenticated: authenticated
               anonymous: '0'
+              viewer: '0'
+              editor: '0'
+              publisher: '0'
+              webmaster: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -713,9 +719,20 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: langcode
-          plugin_id: language
+          reduce_duplicates: false
+          type: textfield
+          limit: true
+          vid: tags
+          hierarchy: false
+          error_message: true
+          parent: 0
+          level_labels: ''
+          force_deepest: false
+          save_lineage: false
+          hierarchy_depth: 0
+          required_depth: 0
+          none_label: '- Please select -'
+          plugin_id: taxonomy_index_tid
         moderation_state_1:
           id: moderation_state_1
           table: node_field_revision
@@ -809,6 +826,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
@@ -829,6 +847,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:


### PR DESCRIPTION
Resolves #781

All this tag talk got me thinking about the early days of d8 and #781. simple change allowing folks to find content by tag.

Original proposed solution was to programmatically add the filter to the view. I think that is moot considering we have already "forked" the view by capturing it in default config and by creating it programmatically we have a greater risk of this breaking if the filter array options change.

<img width="1222" alt="Screen Shot 2021-08-23 at 3 24 12 PM" src="https://user-images.githubusercontent.com/4663676/130514407-c757c6cc-4f5b-43d4-88e5-64c2054deaa1.png">