### PR TITLE
Retain periods in MyUI urls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -245,7 +245,7 @@
                 "Themes have no context of the entity being rendered in preprocessing a layout when using Layout builder": "https://www.drupal.org/files/issues/2020-02-11/3111192-entity-14.patch",
                 "Add Views EntityReference filter to be available for all entity reference fields": "https://www.drupal.org/files/issues/2021-06-15/2429699-414.patch",
                 "Views Block Display skips preBlockBuild() call on ajax rebuild": "https://www.drupal.org/files/issues/2021-03-05/2605218-61.patch",
-                "Periods in query strings are replaced by underscores": "https://www.drupal.org/files/issues/2021-06-16/fix-mangled-query-parameter-names-2984272-59.patch"
+                "Periods in query strings are replaced by underscores": "https://www.drupal.org/files/issues/2020-06-25/fix-mangled-query-parameter-names-2984272-36.patch"
             },
             "drupal/default_content": {
                 "Add a Normalizer and Denormalizer to support Layout Builder": "https://www.drupal.org/files/issues/2020-08-24/default_content-add-normalizer-denormalizer-for-layout-builder-3160146-25.patch",

--- a/composer.json
+++ b/composer.json
@@ -244,7 +244,8 @@
                 "Temporary Hotfix for YouTube oEmbeds": "https://www.drupal.org/files/issues/2020-12-04/3186415-8.9.x-youtube-headers-html.patch",
                 "Themes have no context of the entity being rendered in preprocessing a layout when using Layout builder": "https://www.drupal.org/files/issues/2020-02-11/3111192-entity-14.patch",
                 "Add Views EntityReference filter to be available for all entity reference fields": "https://www.drupal.org/files/issues/2021-06-15/2429699-414.patch",
-                "Views Block Display skips preBlockBuild() call on ajax rebuild": "https://www.drupal.org/files/issues/2021-03-05/2605218-61.patch"
+                "Views Block Display skips preBlockBuild() call on ajax rebuild": "https://www.drupal.org/files/issues/2021-03-05/2605218-61.patch",
+                "Periods in query strings are replaced by underscores": "https://www.drupal.org/files/issues/2021-06-16/fix-mangled-query-parameter-names-2984272-59.patch"
             },
             "drupal/default_content": {
                 "Add a Normalizer and Denormalizer to support Layout Builder": "https://www.drupal.org/files/issues/2020-08-24/default_content-add-normalizer-denormalizer-for-layout-builder-3160146-25.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "155466bff33d9bb9803f09cd522edf40",
+    "content-hash": "ce4b64392b8089bbc84240c0a9db65f3",
     "packages": [
         {
             "name": "acquia/blt",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96d62052590a07180269a56bd7d991ac",
+    "content-hash": "155466bff33d9bb9803f09cd522edf40",
     "packages": [
         {
             "name": "acquia/blt",

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -890,15 +890,6 @@ function _layout_builder_custom_add_lbs_heading(&$form) {
 function layout_builder_custom_preprocess_block(&$variables) {
 
   switch ($variables['elements']['#plugin_id']) {
-    case 'inline_block:uiowa_card':
-      if (isset($variables['content']['field_uiowa_card_link']) &&
-        !empty($variables['content']['field_uiowa_card_link'][0]['#url'])) {
-        $variables['content']['field_uiowa_card_link'][0]['#url'] = [
-          '#markup' => $variables['content']['field_uiowa_card_link'][0]['#url']->getUri(),
-          '#type' => 'markup',
-        ];
-      }
-      break;
 
     case 'inline_block:featured_content':
       // Take control of the referenced entity renders to pass in heading size.

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -890,7 +890,6 @@ function _layout_builder_custom_add_lbs_heading(&$form) {
 function layout_builder_custom_preprocess_block(&$variables) {
 
   switch ($variables['elements']['#plugin_id']) {
-
     case 'inline_block:featured_content':
       // Take control of the referenced entity renders to pass in heading size.
       unset($variables['content']['field_featured_content_item']);

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -890,6 +890,16 @@ function _layout_builder_custom_add_lbs_heading(&$form) {
 function layout_builder_custom_preprocess_block(&$variables) {
 
   switch ($variables['elements']['#plugin_id']) {
+    case 'inline_block:uiowa_card':
+      if (isset($variables['content']['field_uiowa_card_link']) &&
+        !empty($variables['content']['field_uiowa_card_link'][0]['#url'])) {
+        $variables['content']['field_uiowa_card_link'][0]['#url'] = [
+          '#markup' => $variables['content']['field_uiowa_card_link'][0]['#url']->getUri(),
+          '#type' => 'markup',
+        ];
+      }
+      break;
+
     case 'inline_block:featured_content':
       // Take control of the referenced entity renders to pass in heading size.
       unset($variables['content']['field_featured_content_item']);


### PR DESCRIPTION
Resolves #4003 

URL rendering replaces periods in url query strings with underscores (https://www.drupal.org/project/drupal/issues/2984272), which breaks certain MyUI links, and others, when used in link fields (https://sandbox.prod.drupal.uiowa.edu/link-test).

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

As a content editor, I can place external URLs which contain query strings with periods into my content, and my site visitors will reach this intended destination.

Can use https://myui.uiowa.edu/my-ui/courses/by-department.page?q.academicUnitId=541&showResults=1 as a test URL.

Known areas where the issue crops up: Card link field, menu links, page redirects. Likely other areas that use link fields. Does not affect links placed in WYSIWYG text fields.

<!-- Include detailed steps for how to test this PR. -->
