### PR TITLE
Clean up UME output.

### DIFF
--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -90,6 +90,7 @@ class MultisiteCommands extends BltTasks {
           $this->taskDrush()
             ->drush($cmd)
             ->option('define', "drush.paths.cache-directory={$tmp}")
+            ->printMetadata(FALSE)
             ->run();
         }
         else {

--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -83,6 +83,8 @@ class MultisiteCommands extends BltTasks {
         }
 
         if (!in_array($multisite, $options['exclude'])) {
+          $this->say("<info>Executing on {$multisite}...</info>");
+
           // Define a site-specific cache directory.
           // @see: https://github.com/drush-ops/drush/pull/4345
           $tmp = "/tmp/.drush-cache-{$app}/{$env}/{$multisite}";

--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -78,7 +78,7 @@ class MultisiteCommands extends BltTasks {
 
         // Skip sites whose database do not exist on the application in AH env.
         if (EnvironmentDetector::isAhEnv() && !file_exists("/var/www/site-php/{$app}/{$db}-settings.inc")) {
-          $this->say("Skipping {$multisite}. Database {$db} does not exist.");
+          $this->logger->info("Skipping {$multisite}. Database {$db} does not exist on this application.");
           continue;
         }
 


### PR DESCRIPTION
### Problem
UME output is hard to read. For example, `blt ume uiowa:database:size`:

Before
```
...
40.36 MB
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 6.496s
Skipping uiventures.uiowa.edu. Database uiventures_uiowa_edu does not exist.
Skipping umallik.lab.uiowa.edu. Database umallik_lab_uiowa_edu does not exist.
Skipping university-shared-services.fo.uiowa.edu. Database university_shared_services_fo_uiowa_edu does not exist.
Skipping uppu.lab.uiowa.edu. Database uppu_lab_uiowa_edu does not exist.
Skipping usg.uiowa.edu. Database usg_uiowa_edu does not exist.
Skipping vakhtangidarjania.studio.uiowa.edu. Database vakhtangidarjania_studio_uiowa_edu does not exist.
[Acquia\Blt\Robo\Tasks\DrushTask] Running /path/to/drupal/drush @self uiowa:database:size --define='drush.paths.cache-directory=/path/to/drush/cache/vanallen.physics.uiowa.edu' --uri=vanallen.physics.uiowa.edu --no-interaction --ansi in /path/to/drupal/docroot
34.33 MB
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 6.122s
Skipping vanallenprobes.centerforconferences.uiowa.edu. Database vanallenprobes_centerforconferences_uiowa_edu does not exist.
Skipping vanotterloo.lab.uiowa.edu. Database vanotterloo_lab_uiowa_edu does not exist.
Skipping ventilator.course.uiowa.edu. Database ventilator_course_uiowa_edu does not exist.
Skipping veterans.uiowa.edu. Database veterans_uiowa_edu does not exist.
Skipping viewbook.engineering.uiowa.edu. Database viewbook_engineering_uiowa_edu does not exist.
[Acquia\Blt\Robo\Tasks\DrushTask] Running /path/to/drupal/drush @self uiowa:database:size --define='drush.paths.cache-directory=/path/to/drush/cache/virtualdance.studio.uiowa.edu' --uri=virtualdance.studio.uiowa.edu --no-interaction --ansi in /path/to/drupal/docroot
58.08 MB
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 5.973s
Skipping voice-academy.uiowa.edu. Database voice_academy_uiowa_edu does not exist.
Skipping vote.uiowa.edu. Database vote_uiowa_edu does not exist.
Skipping waldschmidt.lab.uiowa.edu. Database waldschmidt_lab_uiowa_edu does not exist.
Skipping webcommunity.sites.uiowa.edu. Database webcommunity_sites_uiowa_edu does not exist.
Skipping weber.lab.uiowa.edu. Database weber_lab_uiowa_edu does not exist.
Skipping wei.lab.uiowa.edu. Database wei_lab_uiowa_edu does not exist.
Skipping weiss.lab.uiowa.edu. Database weiss_lab_uiowa_edu does not exist.
Skipping whitmanweb.iwp.uiowa.edu. Database whitmanweb_iwp_uiowa_edu does not exist.
Skipping wics.org.uiowa.edu. Database wics_org_uiowa_edu does not exist.
[Acquia\Blt\Robo\Tasks\DrushTask] Running /path/to/drupal/drush @self uiowa:database:size --define='drush.paths.cache-directory=/path/to/drush/cache/wilken.lab.uiowa.edu' --uri=wilken.lab.uiowa.edu --no-interaction --ansi in /path/to/drupal/docroot
39.73 MB
[Acquia\Blt\Robo\Task
...
```

After
```
...
Executing on default...
54.80 MB
Executing on admissions.uiowa.edu...
114.01 MB
Executing on brand.uiowa.edu...
76.67 MB
Executing on hr.uiowa.edu...
237.61 MB
Executing on sandbox.uiowa.edu...
49.94 MB
Executing on uiowa.edu...
57.64 MB
...
```