### PR TITLE
Feature: Quick topics page fix

### DIFF
--- a/config/features/topic_page/core.entity_view_display.node.topic_collection.default.yml
+++ b/config/features/topic_page/core.entity_view_display.node.topic_collection.default.yml
@@ -181,8 +181,9 @@ third_party_settings:
         layout_settings:
           label: ''
           layout_builder_styles_style:
-            - section_background_style_gray
-            - section_margin_fixed_width_container
+            0: section_background_style_gray
+            1: section_margin_fixed_width_container
+            section_alignment_start: section_alignment_start
         components:
           -
             uuid: 5fde834e-0dd0-4ace-8d35-e08d22cba5cf

--- a/config/features/topic_page/core.entity_view_display.node.topic_collection.default.yml
+++ b/config/features/topic_page/core.entity_view_display.node.topic_collection.default.yml
@@ -69,27 +69,6 @@ third_party_settings:
             additional: {  }
             weight: 4
           -
-            uuid: 4155b5f3-5ddd-4c84-b687-0f5ea256f28c
-            region: content
-            configuration:
-              id: 'field_block:node:topic_collection:field_topic_collection_tags'
-              label: null
-              provider: layout_builder
-              label_display: null
-              formatter:
-                label: above
-                type: entity_reference_label
-                settings:
-                  link: true
-                third_party_settings:
-                  field_delimiter:
-                    delimiter: ','
-              context_mapping:
-                entity: layout_builder.entity
-                view_mode: view_mode
-            additional: {  }
-            weight: -5
-          -
             uuid: 9ea10fa1-6f6b-448a-974f-5fff1b257d5b
             region: content
             configuration:
@@ -119,6 +98,28 @@ third_party_settings:
                 type: metatag_empty_formatter
             additional: {  }
             weight: -4
+          -
+            uuid: d78149d2-01f4-4531-bf35-146375560830
+            region: content
+            configuration:
+              id: 'views_block:topic_page_browse_by_tag-block_4'
+              label: null
+              provider: views
+              label_display: null
+              views_label: ''
+              items_per_page: none
+              headline:
+                headline: 'Browse by tag:'
+                hide_headline: 0
+                heading_size: h2
+                headline_style: default
+                child_heading_size: h2
+              pager: some
+              exposed_filter_values: null
+              layout_builder_styles: {  }
+              context_mapping: {  }
+            additional: {  }
+            weight: -2
         third_party_settings: {  }
       -
         layout_id: layout_onecol

--- a/config/features/topic_page/views.view.topic_page_browse_by_tag.yml
+++ b/config/features/topic_page/views.view.topic_page_browse_by_tag.yml
@@ -2,8 +2,6 @@ uuid: c778cc6e-65f7-4c01-94c1-b203b2114730
 langcode: en
 status: true
 dependencies:
-  config:
-    - field.storage.node.field_topic_collection_tags
   module:
     - node
     - taxonomy
@@ -752,7 +750,7 @@ display:
           exclude: false
           alter:
             alter_text: false
-            text: '<a class="bttn bttn--full bttn--outline bttn--tertiary bttn--sans-serif bttn--lowercase" href="{{ view_taxonomy_term }}">{{ name }} ({{ nid }})</a> '
+            text: ''
             make_link: false
             path: ''
             absolute: false

--- a/config/features/topic_page/views.view.topic_page_browse_by_tag.yml
+++ b/config/features/topic_page/views.view.topic_page_browse_by_tag.yml
@@ -2,6 +2,8 @@ uuid: c778cc6e-65f7-4c01-94c1-b203b2114730
 langcode: en
 status: true
 dependencies:
+  config:
+    - field.storage.node.field_topic_collection_tags
   module:
     - node
     - taxonomy
@@ -126,7 +128,21 @@ display:
             operator_limit_selection: false
             operator_list: {  }
           group: 1
-      sorts: {  }
+      sorts:
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: standard
       title: 'Browse by tag w/count'
       header: {  }
       footer: {  }
@@ -139,162 +155,6 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - user.permissions
-      tags: {  }
-  block_1:
-    display_plugin: block
-    id: block_1
-    display_title: 'Browse by tag'
-    position: 1
-    display_options:
-      display_extenders:
-        metatag_display_extender: {  }
-      display_description: ''
-      title: 'Browse by tag'
-      defaults:
-        title: false
-        fields: false
-        relationships: false
-        arguments: false
-        style: false
-        row: false
-        css_class: false
-      fields:
-        name:
-          id: name
-          table: taxonomy_term_field_data
-          field: name
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: '<p>{{ name }} </p>'
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: false
-            ellipsis: false
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings:
-            link_to_entity: true
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          convert_spaces: false
-          entity_type: taxonomy_term
-          entity_field: name
-          plugin_id: term_name
-      relationships:
-        reverse__node__field_topic_collection_tags:
-          id: reverse__node__field_topic_collection_tags
-          table: taxonomy_term_field_data
-          field: reverse__node__field_topic_collection_tags
-          relationship: none
-          group_type: group
-          admin_label: field_topic_collection_tags
-          required: false
-          entity_type: taxonomy_term
-          plugin_id: entity_reverse
-      arguments:
-        nid:
-          id: nid
-          table: node_field_data
-          field: nid
-          relationship: reverse__node__field_topic_collection_tags
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: node
-          default_argument_options: {  }
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: false
-          not: false
-          entity_type: node
-          entity_field: nid
-          plugin_id: node_nid
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-      row:
-        type: fields
-        options:
-          default_field_elements: true
-          inline:
-            name: name
-          separator: ','
-          hide_empty: false
-      css_class: topic-page--tag
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
         - user.permissions
       tags: {  }
   block_2:
@@ -850,6 +710,180 @@ display:
           entity_field: nid
           plugin_id: node_nid
       css_class: 'grid--fourcol--25 topic-page--count'
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline:
+            name: name
+          separator: ''
+          hide_empty: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - user.permissions
+      tags: {  }
+  block_4:
+    display_plugin: block
+    id: block_4
+    display_title: 'Browse by tag'
+    position: 2
+    display_options:
+      display_extenders:
+        metatag_display_extender: {  }
+      fields:
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: '<a class="bttn bttn--full bttn--outline bttn--tertiary bttn--sans-serif bttn--lowercase" href="{{ view_taxonomy_term }}">{{ name }} ({{ nid }})</a> '
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: '0'
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: true
+          convert_spaces: false
+          set_precision: false
+          precision: 0
+          decimal: .
+          format_plural: 0
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: term_name
+      defaults:
+        fields: false
+        title: false
+        group_by: false
+        relationships: false
+        arguments: false
+        css_class: false
+        style: false
+        row: false
+      title: 'Browse by tag'
+      display_description: ''
+      group_by: true
+      relationships:
+        nid:
+          id: nid
+          table: taxonomy_index
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: node
+          required: false
+          plugin_id: standard
+        reverse__node__field_topic_collection_tags:
+          id: reverse__node__field_topic_collection_tags
+          table: taxonomy_term_field_data
+          field: reverse__node__field_topic_collection_tags
+          relationship: none
+          group_type: group
+          admin_label: field_topic_collection_tags
+          required: false
+          entity_type: taxonomy_term
+          plugin_id: entity_reverse
+      arguments:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: reverse__node__field_topic_collection_tags
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+      css_class: topic-page--tag
       style:
         type: default
         options:

--- a/docroot/modules/custom/studentlife_topics/sass/topic-collection.scss
+++ b/docroot/modules/custom/studentlife_topics/sass/topic-collection.scss
@@ -37,11 +37,14 @@
   .field__item {
     display: inline;
   }
-  .views-row  + .views-row {
-    &:before {
+  .views-row {
+    &:after {
       content: ",";
       padding-right: $xsm;
       margin-left: -3px;
+    }
+    &:last-child:after {
+      content: "";
     }
   }
 }

--- a/docroot/modules/custom/studentlife_topics/sass/topic-collection.scss
+++ b/docroot/modules/custom/studentlife_topics/sass/topic-collection.scss
@@ -113,6 +113,8 @@
   }
   .item-list {
     break-inside: avoid;
+    display: inline-block;
+    width: 100%;
     ul {
       break-inside: avoid;
     }

--- a/docroot/modules/custom/studentlife_topics/sass/topic-collection.scss
+++ b/docroot/modules/custom/studentlife_topics/sass/topic-collection.scss
@@ -36,16 +36,7 @@
   .views-row,
   .field__item {
     display: inline;
-  }
-  .views-row {
-    &:after {
-      content: ",";
-      padding-right: $xsm;
-      margin-left: -3px;
-    }
-    &:last-child:after {
-      content: "";
-    }
+    padding-right: 0.2rem;
   }
 }
 

--- a/docroot/modules/custom/studentlife_topics/sass/topic-collection.scss
+++ b/docroot/modules/custom/studentlife_topics/sass/topic-collection.scss
@@ -6,7 +6,7 @@
 }
 
 .page-node-type-topic-collection .layout--onecol--background .block-uiowa-core-search-block,
-.page-node-type-topic-collection .layout--onecol--background .field--name-field-topic-collection-tags {
+.page-node-type-topic-collection .layout--onecol--background .block-views-blocktopic-page-browse-by-tag-block-4  {
   max-width: 700px;
   margin: 0 auto;
 }
@@ -26,18 +26,47 @@
   }
 }
 
-.page-node-type-topic-collection .banner {
-  .field--name-field-topic-collection-tags {
-    .field__label {
-      color: white;
+.block-views-blocktopic-page-browse-by-tag-block-4 {
+  .headline {
+    font-size: 1.2rem;
+  }
+}
+
+.topic-page--tag {
+  .views-row,
+  .field__item {
+    display: inline;
+  }
+  .views-row  + .views-row {
+    &:before {
+      content: ",";
+      padding-right: $xsm;
+      margin-left: -3px;
     }
-    .field__items {
+  }
+}
+
+
+.page-node-type-topic-collection .banner {
+  .block-views-blocktopic-page-browse-by-tag-block-4  {
+    .headline {
+      color: #fff;
+    }
+    .views-row  + .views-row {
+      &:before {
+        color: #fff;
+      }
+    }
+    .field__item {
+      color: #fff;
       a {
         color: #fff;
       }
     }
   }
 }
+
+
 
 .page-node-type-topic-collection {
   .field--name-field-topic-collection-tags {

--- a/docroot/modules/custom/studentlife_topics/studentlife_topics.module
+++ b/docroot/modules/custom/studentlife_topics/studentlife_topics.module
@@ -67,17 +67,6 @@ function studentlife_topics_preprocess_layout(&$variables) {
 }
 
 /**
- * Implements hook_theme_suggestions_HOOK_alter().
- */
-function studentlife_topics_theme_suggestions_field_alter(array &$suggestions, array $variables) {
-  switch ($variables["element"]["#field_name"]) {
-    case 'field_topic_collection_tags':
-      $suggestions[] = 'field__comma_separated';
-      break;
-  }
-}
-
-/**
  * Implements hook_theme().
  */
 function studentlife_topics_theme($existing, $type, $theme, $path) {


### PR DESCRIPTION
Fixing bugs that I noticed during demo

- Switched views to sort alphabetically
- Removed tags field from layout builder template and replaced with a view so we can sort alphabetically

# How to test

```
blt ds --site=sandbox.uiowa.edu
blt frontend
Enable `topic_page` split at admin/config/development/configuration/config-split
drush @sandbox.local cim
```

- Add a topic collection page: https://sandbox.local.drupal.uiowa.edu/node/add/topic_collection
- Add body, tags, and featured image

- Verify that all of the tag views are listed alphabetical no matter the weight of their listing on the node edit screen. 
- Verify that the commas are white when there is a featured image and black when there is not a featured image. 
- Verify that the "Browse by all" section does not have weird content splits if you only have one or two items tagged. 
