### PR TITLE
Linkit Webform Matcher Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -270,6 +270,9 @@
                 "Section dependency on layout plugin configuration form": "https://www.drupal.org/files/issues/2019-08-23/layout_builder_styles-3062261-%2310.patch",
                 "Grouping of layout builder styles": "https://www.drupal.org/files/issues/2021-03-16/3075502-18_0.patch"
             },
+            "drupal/linkit": {
+                "Add Webform Matcher": "https://www.drupal.org/files/issues/2021-09-15/2657060-18.patch"
+            },
             "drupal/menu_block": {
                 "Hide block title if menu tree contains no links": "https://www.drupal.org/files/issues/2020-02-12/menu_block-hide_block_if_no_links-2757215-13.patch",
                 "Suppress display of regular system menu blocks in Layout Builder": "https://www.drupal.org/files/issues/2019-12-11/menu_block-remove_duplicates-3062278-11.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c1c3538b2ac50901cb58df7f733044c",
+    "content-hash": "8704fd79f5377f36b3def3767affcfa7",
     "packages": [
         {
             "name": "acquia/blt",

--- a/config/default/linkit.linkit_profile.default.yml
+++ b/config/default/linkit.linkit_profile.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - node
+    - webform
 _core:
   default_config_hash: sIFcf8s0DbI2ilmXJaz2HcrpKtz_TGjWhMLBnhOWVc4
 id: default
@@ -13,7 +14,7 @@ matchers:
   556010a3-e317-48b3-b4ed-854c10f4b950:
     uuid: 556010a3-e317-48b3-b4ed-854c10f4b950
     id: 'entity:node'
-    weight: 0
+    weight: -10
     settings:
       metadata: 'created by [node:author] | updated [node:changed]'
       bundles: {  }
@@ -24,7 +25,7 @@ matchers:
   71deb6e8-67cb-4ef3-ae69-36a3849daa32:
     uuid: 71deb6e8-67cb-4ef3-ae69-36a3849daa32
     id: 'entity:media'
-    weight: 0
+    weight: -8
     settings:
       metadata: 'type [media:field_media_file:entity:extension] | updated [media:field_media_file:entity:changed]'
       bundles:
@@ -35,5 +36,15 @@ matchers:
   36a7abf7-f57a-4d95-8d57-cc8d6775ea87:
     uuid: 36a7abf7-f57a-4d95-8d57-cc8d6775ea87
     id: email
-    weight: 0
+    weight: -7
     settings: {  }
+  257e7402-9995-423c-88f6-2d019f8341b5:
+    uuid: 257e7402-9995-423c-88f6-2d019f8341b5
+    id: 'entity:webform'
+    weight: -9
+    settings:
+      metadata: 'created by [webform:author]'
+      bundles: null
+      group_by_bundle: null
+      substitution_type: canonical
+      limit: 100


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/1442

This relies on an uncommitted patch to Linkit.

# Story

As a web editor, I want to easily link to a webform on my site using the internal link capabilities to prevent the absolute url from breaking.

# To Test

- sync any site (assumes the default webform "contact" has not be deleted from the site)
- Add or edit content with a WYSIWYG area. Click the link button and start typing "contact." If the webform exists, it should show as a result under a webform heading.
- select the result and save the page. the page should link to the contact form.
- try with other forms on the site or create new forms.