### PR TITLE
Clear each sites plugin cache to prevent missing layouts.

### DIFF
--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -63,6 +63,8 @@ class ReplaceCommands extends BltTasks {
             // @see: https://github.com/drush-ops/drush/pull/4345
             $tmp = "/tmp/.drush-cache-{$app}/{$env}/{$multisite}";
 
+            // Clear the plugin cache for discovery and potential layout issue.
+            // @see: https://github.com/uiowa/uiowa/issues/3585.
             $this->taskDrush()
               ->drush('cc plugin')
               ->option('define', "drush.paths.cache-directory={$tmp}")

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -68,7 +68,6 @@ class ReplaceCommands extends BltTasks {
             $this->taskDrush()
               ->drush('cc plugin')
               ->option('define', "drush.paths.cache-directory={$tmp}")
-              ->printMetadata(FALSE)
               ->run();
 
             // Ensure BLT uses the site-specific cache directory. For some

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -59,11 +59,20 @@ class ReplaceCommands extends BltTasks {
           }
 
           try {
-            // Define a site-specific cache directory. For some reason, putenv
-            // did not work here. This would not be necessary if Drush
-            // supported per-site config file loading.
+            // Define a site-specific cache directory.
             // @see: https://github.com/drush-ops/drush/pull/4345
-            $_ENV['DRUSH_PATHS_CACHE_DIRECTORY'] = "/tmp/.drush-cache-{$app}/{$env}/{$multisite}";
+            $tmp = "/tmp/.drush-cache-{$app}/{$env}/{$multisite}";
+
+            $this->taskDrush()
+              ->drush('cc plugin')
+              ->option('define', "drush.paths.cache-directory={$tmp}")
+              ->printMetadata(FALSE)
+              ->run();
+
+            // Ensure BLT uses the site-specific cache directory. For some
+            // reason, putenv did not work here. This would not be necessary if
+            // Drush supported per-site config file loading.
+            $_ENV['DRUSH_PATHS_CACHE_DIRECTORY'] = $tmp;
             $this->invokeCommand('drupal:update');
             $this->logger->info("Finished deploying updates to <comment>{$multisite}</comment>.");
           }


### PR DESCRIPTION
Marking as resolves #3585 but it doesn't really. I'd still be ok with this closing #3585 - its still there for future reference.

### Testing
- `blt auda`
- Should see something like the below for each site:
```
[Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/uiowa/vendor/bin/drush @self cc plugin --define='drush.paths.cache-directory=/tmp/.drush-cache-local/local/default' --no-interaction --ansi in /var/www/uiowa/docroot
 [success] 'plugin' cache was cleared.
``` 