### PR TITLE
Feature: A few hr fixes

### DIFF
--- a/docroot/sites/hr.uiowa.edu/modules/hr_core/templates/block--views-block--units-block-contact-info.html.twig
+++ b/docroot/sites/hr.uiowa.edu/modules/hr_core/templates/block--views-block--units-block-contact-info.html.twig
@@ -31,6 +31,7 @@
     'bg--gray',
     'block-margin__bottom',
     'block-margin__top',
+    'block--word-break',
     'block-padding__all--md',
     'block',
     'block-' ~ configuration.provider|clean_class,

--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -5,7 +5,7 @@ $imgpath: '../../uids/assets/images';
 @import "../uids/assets/scss/_base.scss";
 
 
-a {
+.block--word-break a {
   word-break: break-word;
 }
 

--- a/docroot/themes/custom/uids_base/scss/layouts/page--left-sidebar.scss
+++ b/docroot/themes/custom/uids_base/scss/layouts/page--left-sidebar.scss
@@ -6,6 +6,10 @@
   flex-wrap: wrap;
 }
 
+.layout .layout__region.layout__region--sidebar {
+  display: block;
+}
+
 .container.container--title,
 .sidebar-invisible.layout--has-sidebar .container.container--title {
   padding-right: 1.25rem;


### PR DESCRIPTION
# How to test

Review code changes or pull down hr.uiowa.edu and run`yarn workspace uids_base build`.

This issue fixes sidebars like:

<img width="1489" alt="Screen Shot 2021-09-22 at 11 04 03 AM" src="https://user-images.githubusercontent.com/1036433/134380332-46c295ba-2b3c-436c-a9af-193a7d1adcfc.png">

This also scopes the `word-break` rule to a utility class for now to avoid issues like:

<img width="993" alt="Screen Shot 2021-09-22 at 10 37 35 AM" src="https://user-images.githubusercontent.com/1036433/134380684-e2d7c785-4642-4045-a4d7-63c6c7cda1b1.png">

<img width="1040" alt="Screen Shot 2021-09-22 at 11 07 29 AM" src="https://user-images.githubusercontent.com/1036433/134380728-df9a5c01-5dcc-452c-8c57-ad7cc689a7e1.png">

