### PR TITLE
Feature: Fixes for grid regressions

### DIFF
--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -26,7 +26,10 @@ $imgpath: '../../uids/assets/images';
 
 // set equal height columns
 .layout {
-  .layout__region {
+  .layout__region--first,
+  .layout__region--second,
+  .layout__region--third,
+  .layout__region--fourth {
     @include breakpoint(sm) {
       display: grid;
     }

--- a/docroot/themes/custom/uids_base/scss/layouts/page--left-sidebar.scss
+++ b/docroot/themes/custom/uids_base/scss/layouts/page--left-sidebar.scss
@@ -6,10 +6,6 @@
   flex-wrap: wrap;
 }
 
-.layout .layout__region.layout__region--sidebar {
-  display: block;
-}
-
 .container.container--title,
 .sidebar-invisible.layout--has-sidebar .container.container--title {
   padding-right: 1.25rem;


### PR DESCRIPTION
# How to test

`yarn workspace uids_base build`

- A full carousel on hawkeyemarchingband.local.drupal.uiowa.edu/ should display fine now. 
- A card row on https://sandbox.local.drupal.uiowa.edu/cards-0 should still appear at equal heights. 