### PR TITLE
Feature: Updated UUID for event series default for admissions

### DIFF
--- a/config/sites/admissions.uiowa.edu/core.entity_view_display.node.event_series.default.yml
+++ b/config/sites/admissions.uiowa.edu/core.entity_view_display.node.event_series.default.yml
@@ -1,4 +1,4 @@
-uuid: 2d4a37b5-6575-41a5-a6ac-09e07996554e
+uuid: cdba22cc-e70f-4904-8f29-b26df511c4b1
 langcode: en
 status: true
 dependencies:


### PR DESCRIPTION
This pr fixes a duplicate UUID issue with the admissions event series default display.  It conflicts with the `topic_page` UUID. 

# How to test

`blt ds --site=admissions.uiowa.edu`