### PR TITLE
Feature: hotfix to prevent add section dialog from appearing on the left

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/css/layout_builder_custom.overrides.css
+++ b/docroot/modules/custom/layout_builder_custom/css/layout_builder_custom.overrides.css
@@ -74,4 +74,5 @@
 
 .ui-dialog.ui-dialog-off-canvas:not(.ui-dialog-resizing) {
   left: auto!important;
+  right: 0;
 }


### PR DESCRIPTION
This pr fixes this bug that was created by the changes made in https://github.com/uiowa/uiowa/pull/4211.

<img width="1762" alt="Screen Shot 2021-09-30 at 11 26 59 AM" src="https://user-images.githubusercontent.com/1036433/135495246-5eaa31a4-79af-4f2e-bfb4-d216bdeef667.png">

It sets the tray to have `right: 0` as the default positioning. 

# How to test

- Clear the cache on a local site after running `yarn workspace uids_base build` and verify that add section tray appears on the right. 