### PR TITLE
AOS - prevent link trim

### DIFF
--- a/config/features/areas_of_study/views.view.areas_of_study.yml
+++ b/config/features/areas_of_study/views.view.areas_of_study.yml
@@ -1576,7 +1576,7 @@ display:
           click_sort_column: uri
           type: link
           settings:
-            trim_length: 80
+            trim_length: null
             url_only: true
             url_plain: true
             rel: '0'


### PR DESCRIPTION
Background: https://iowaweb.slack.com/archives/C01LA6Y2XGV/p1633122145048900

## To Test

- Search for "world" on https://education.prod.drupal.uiowa.edu/areas-study/program-finder
- Try to click the link to B.A. World Language Education. You should get a 404 based on it being cut down and appended with ellipses.
- Checkout this branch and on local do the same thing. Success!