### PR TITLE
Replicate - set allowed to none for now

### DIFF
--- a/config/default/uiowa_core.settings.yml
+++ b/config/default/uiowa_core.settings.yml
@@ -1,7 +1,5 @@
 uiowa_core:
   gtag: 0
-  replicate_allowed:
-    - page
-    - article
+  replicate_allowed: {  }
 _core:
   default_config_hash: 5IlI1nYk4jQm6FCSIgXf_pF-odybV5PsZs4AZ9EBlEA

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -3528,6 +3528,7 @@ function sitenow_update_9020() {
       ->save();
   }
 }
+
 /**
  * Shut down replicate for now.
  */

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -3528,3 +3528,13 @@ function sitenow_update_9020() {
       ->save();
   }
 }
+/**
+ * Shut down replicate for now.
+ */
+function sitenow_update_9021() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('uiowa_core.settings');
+  $config
+    ->set('uiowa_core.replicate_allowed', [])
+    ->save();
+}


### PR DESCRIPTION
Relates to https://github.com/uiowa/uiowa/issues/4223

## To Test

- [x] New site install/sync should set the allowed entity types for replication to nada.
- [x] As a editor/webmaster/publisher/admin you can not go through with the replicate functionality (no links to do so, disabled action button)

🤞 no staging sites have tried the functionality yet...