### PR TITLE
Adjusted replicate node confirmation form text, fixes #4346

### DIFF
--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -126,6 +126,21 @@ function uiowa_core_form_alter(&$form, FormStateInterface $form_state, $form_id)
       }
       break;
 
+    // Customize the replicate confirm dialog to our
+    // use case (pages with titles)
+    case 'node_page_replicate_form':
+      if (isset($form['new_label_en'])) {
+        $form['new_label_en']['#title'] = 'Replicated page\'s title';
+        $form['new_label_en']['#description'] = t('This text will be used as the title of the newly replicated page.');
+        // Removes the "This action cannot be undone" text.
+        $form['description'] = ['#markup' => ''];
+        // Changes title to match the "Edit" action title
+        // (e.g. "<em>Edit</em> Home").
+        $node_title = $form_state->getFormObject()->getEntity()->$entity->getTitle();
+        $form['#title'] = t('<em>Replicate Page</em> @title', ['@title' => $node_title]);
+      }
+      break;
+
     case 'menu_link_content_menu_link_content_form':
       // All checked or unchecked this seems to do the same. Hide until we
       // have a use-case.

--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -136,7 +136,7 @@ function uiowa_core_form_alter(&$form, FormStateInterface $form_state, $form_id)
         $form['description'] = ['#markup' => ''];
         // Changes title to match the "Edit" action title
         // (e.g. "<em>Edit</em> Home").
-        $node_title = $form_state->getFormObject()->getEntity()->$entity->getTitle();
+        $node_title = $form_state->getFormObject()->getEntity()->getTitle();
         $form['#title'] = t('<em>Replicate Page</em> @title', ['@title' => $node_title]);
       }
       break;

--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -98,14 +98,18 @@ function uiowa_core_form_alter(&$form, FormStateInterface $form_state, $form_id)
       ->load($entity->bundle())
       ->label();
 
-    $form['new_label_en']['#title'] = "Replicated {$bundle_label}'s title";
-    $form['new_label_en']['#description'] = t('This text will be used as the title of the newly-replicated @type.', ['@type' => $bundle_label]);
-    // Removes the "This action cannot be undone" text.
-    $form['description'] = ['#markup' => ''];
     // Changes title to match the "Edit" action title
     // (e.g. "<em>Edit</em> Home").
     $form['#title'] = t('<em>Replicate @type</em> @title',
       ['@type' => $bundle_label, '@title' => $node_title]);
+
+    // Lowercase for the rest of the form.
+    $bundle_label = strtolower($bundle_label);
+
+    $form['new_label_en']['#title'] = t("Replicated @type content's title", ['@type' => $bundle_label]);
+    $form['new_label_en']['#description'] = t('This text will be used as the title of the newly-replicated @type.', ['@type' => $bundle_label]);
+    // Removes the "This action cannot be undone" text.
+    $form['description'] = ['#markup' => ''];
 
   }
 

--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -83,7 +83,9 @@ function uiowa_core_form_alter(&$form, FormStateInterface $form_state, $form_id)
   if ($route_name == 'entity.node.replicate') {
     // Get allowed replicate entity types.
     $allowed_types = \Drupal::config('uiowa_core.settings')->get('uiowa_core.replicate_allowed');
-    $node_type = $form_state->getFormObject()->getEntity()->bundle();
+    $entity = $form_state->getFormObject()->getEntity();
+    $node_type = $entity->bundle();
+    $node_title = $entity->getTitle();
     // Set message and prevent replicate.
     if (!in_array($node_type, $allowed_types)) {
       \Drupal::messenger()->addWarning(t('Replicating content of this type is not allowed. Please contact the ITS Help Desk about enabling this functionality for this content.'));
@@ -97,12 +99,14 @@ function uiowa_core_form_alter(&$form, FormStateInterface $form_state, $form_id)
     $form['description'] = ['#markup' => ''];
     // Changes title to match the "Edit" action title
     // (e.g. "<em>Edit</em> Home").
-    $entity = $form_state->getFormObject()->getEntity();
-    $node_title = $entity->getTitle();
-    $node_type = $entity->getType();
+
+    $bundle_label = \Drupal::entityTypeManager()
+      ->getStorage('node_type')
+      ->load($entity->bundle())
+      ->label();
 
     $form['#title'] = t('<em>Replicate @type</em> @title',
-      ['@type' => ucfirst($node_type), '@title' => $node_title]);
+      ['@type' => $bundle_label, '@title' => $node_title]);
 
   }
 

--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -93,18 +93,17 @@ function uiowa_core_form_alter(&$form, FormStateInterface $form_state, $form_id)
     }
     // Customize the replicate confirm dialog to our
     // use case (pages with titles)
-    $form['new_label_en']['#title'] = "Replicated {$node_type}'s title";
-    $form['new_label_en']['#description'] = t('This text will be used as the title of the newly replicated @type.', ['@type' => $node_type]);
-    // Removes the "This action cannot be undone" text.
-    $form['description'] = ['#markup' => ''];
-    // Changes title to match the "Edit" action title
-    // (e.g. "<em>Edit</em> Home").
-
     $bundle_label = \Drupal::entityTypeManager()
       ->getStorage('node_type')
       ->load($entity->bundle())
       ->label();
 
+    $form['new_label_en']['#title'] = "Replicated {$bundle_label}'s title";
+    $form['new_label_en']['#description'] = t('This text will be used as the title of the newly-replicated @type.', ['@type' => $bundle_label]);
+    // Removes the "This action cannot be undone" text.
+    $form['description'] = ['#markup' => ''];
+    // Changes title to match the "Edit" action title
+    // (e.g. "<em>Edit</em> Home").
     $form['#title'] = t('<em>Replicate @type</em> @title',
       ['@type' => $bundle_label, '@title' => $node_title]);
 

--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -89,6 +89,21 @@ function uiowa_core_form_alter(&$form, FormStateInterface $form_state, $form_id)
       \Drupal::messenger()->addWarning(t('Replicating content of this type is not allowed. Please contact the ITS Help Desk about enabling this functionality for this content.'));
       $form['actions']['submit']['#disabled'] = TRUE;
     }
+    // Customize the replicate confirm dialog to our
+    // use case (pages with titles)
+    $form['new_label_en']['#title'] = "Replicated {$node_type}'s title";
+    $form['new_label_en']['#description'] = t('This text will be used as the title of the newly replicated @type.', ['@type' => $node_type]);
+    // Removes the "This action cannot be undone" text.
+    $form['description'] = ['#markup' => ''];
+    // Changes title to match the "Edit" action title
+    // (e.g. "<em>Edit</em> Home").
+    $entity = $form_state->getFormObject()->getEntity();
+    $node_title = $entity->getTitle();
+    $node_type = $entity->getType();
+
+    $form['#title'] = t('<em>Replicate @type</em> @title',
+      ['@type' => ucfirst($node_type), '@title' => $node_title]);
+
   }
 
   switch ($form_id) {
@@ -123,21 +138,6 @@ function uiowa_core_form_alter(&$form, FormStateInterface $form_state, $form_id)
           \Drupal::messenger()->addWarning(t('This block is protected from deletion. Remove content from the block instead.'));
           $form['actions']['submit']['#disabled'] = TRUE;
         }
-      }
-      break;
-
-    // Customize the replicate confirm dialog to our
-    // use case (pages with titles)
-    case 'node_page_replicate_form':
-      if (isset($form['new_label_en'])) {
-        $form['new_label_en']['#title'] = 'Replicated page\'s title';
-        $form['new_label_en']['#description'] = t('This text will be used as the title of the newly replicated page.');
-        // Removes the "This action cannot be undone" text.
-        $form['description'] = ['#markup' => ''];
-        // Changes title to match the "Edit" action title
-        // (e.g. "<em>Edit</em> Home").
-        $node_title = $form_state->getFormObject()->getEntity()->getTitle();
-        $form['#title'] = t('<em>Replicate Page</em> @title', ['@title' => $node_title]);
       }
       break;
 


### PR DESCRIPTION
Trying to make the replicate page confirmation dialog a bit more friendly and more tailored to our current use case for the module: replicating pages. 

Changes:

- The title "Are you sure you want to replicate _node_ entity id [id]?" now reads "_Replicate Page_ [Page Name]," which matches the "_Edit Page_ [Page Name]" action title.
- The field label "New label (English)" now says "Replicated page's title"
- The description "This text will be used as the label of the new entity being created, in English." now says "This text will be used as the title of the newly replicated page."
- Removed the potentially confusing "This action cannot be undone." message 

Before:
<img width="925" alt="Screen Shot 2021-10-22 at 8 54 48 AM" src="https://user-images.githubusercontent.com/472923/138466103-c7812f46-bbe3-4584-85b6-71e885028530.png">

After:
<img width="984" alt="Screen Shot 2021-10-22 at 8 51 28 AM" src="https://user-images.githubusercontent.com/472923/138466120-435a477a-3e57-4337-a801-940c6ff88689.png">

# How to test

Replicate a page to see these adjustments (after clearing the cache).
