### PR TITLE
Feauture: UIDS hash update for 10/25/21

### DIFF
--- a/docroot/themes/custom/uids_base/package.json
+++ b/docroot/themes/custom/uids_base/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "ISC",
   "dependencies": {
-    "@uiowa/uids": "uiowa/uids#ebcb66c",
+    "@uiowa/uids": "uiowa/uids#9ad02d5",
     "autoprefixer": "^9.8.8",
     "breakpoint-sass": "^2.7.1",
     "cssnano": "^4.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1447,9 +1447,9 @@
   dependencies:
     "@types/node" "*"
 
-"@uiowa/uids@uiowa/uids#ebcb66c":
+"@uiowa/uids@uiowa/uids#9ad02d5":
   version "3.4.5"
-  resolved "https://codeload.github.com/uiowa/uids/tar.gz/ebcb66c32cfcaa556e823a0e8bc97865f64cb632"
+  resolved "https://codeload.github.com/uiowa/uids/tar.gz/9ad02d546c865fb272e0caf45c771f9a681200c4"
   dependencies:
     autoprefixer "^9.8.6"
     cssnano "^4.1.11"


### PR DESCRIPTION
Added a few utility classes to use the `column-count` property: https://github.com/uiowa/uids/pull/602.

# How to test

Review files changed and verify hash id matches latest commit on https://github.com/uiowa/uids/commits/main. 