### PR TITLE
Feature: card events/four column height fix

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/card.scss
+++ b/docroot/themes/custom/uids_base/scss/components/card.scss
@@ -184,6 +184,12 @@
   }
 }
 
+// Fix for adding padding if images are hidden within stack format.
+.card.hide-images.card--stacked.card--enclosed .card__body,
+.card.hide-images.card--stacked.card--enclosed .card__media + .card__body {
+  padding: 2rem!important;
+}
+
 // Card__head styles
 
 .card {

--- a/docroot/themes/custom/uids_base/scss/layouts/fourcol.scss
+++ b/docroot/themes/custom/uids_base/scss/layouts/fourcol.scss
@@ -2,9 +2,6 @@
 @import "uids/assets/scss/_utilities.scss";
 
 .layout--fourcol {
-  .layout__region {
-    height: 100%;
-  }
   .layout__spacing_container {
     @include grid-base;
     @include breakpoint(sm) {


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/4365
Resolves https://github.com/uiowa/uiowa/issues/4367

# How to test

Cards:  https://github.com/uiowa/uiowa/issues/4367

- `yarn workspace uids_base build`
- Add events list to a page with the settings used in this screenshot: https://user-images.githubusercontent.com/1036433/139129860-809cb993-7ebe-4fc0-9a02-35ebd2356714.png.  Verify that it doesn't look like https://user-images.githubusercontent.com/1036433/139129722-8b477ddb-80d8-49c3-8dfa-dfbdfeb3da36.png. 
- This will also effect aggregator, and any other block lists that use the "hide-images" class with cards. 

Stats: https://github.com/uiowa/uiowa/issues/4365

- `blt ds --site=socialwork.uiowa.edu`
- Test stats in 4-column layout on home page with "vertically align to top" selected on the section. 
- Verify that stats align to the top.