### PR TITLE
Change description text to white when on black background.

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/form/forms.scss
+++ b/docroot/themes/custom/uids_base/scss/components/form/forms.scss
@@ -750,5 +750,8 @@
         background-color: $secondary;
       }
     }
+    .description {
+      color: $white !important;
+    }
   }
 }

--- a/docroot/themes/custom/uids_base/scss/components/form/forms.scss
+++ b/docroot/themes/custom/uids_base/scss/components/form/forms.scss
@@ -751,7 +751,16 @@
       }
     }
     .description {
-      color: $white !important;
+      color: $white;
+    }
+  }
+}
+
+[class*="bg--black"]  {
+  & .block-webform[class*="bg--gray"],
+  & .block-webform[class*="bg--white"] {
+    .description {
+      color: inherit;
     }
   }
 }


### PR DESCRIPTION
Resolves #4385 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
`git checkout forms-description && git pull`
`yarn workspace uids_base build`
Add a new webform or edit an existing, and add some description text to field(s)
Add the webform to various sections, at least one section having a black or black patterned background
See that the description text adapts appropriately to each background
Try various changes to the description text (adding link, styles, etc) and check that nothing breaks