### PR TITLE
Feature: Hotfix for multiple titles on v2 people lists

### DIFF
--- a/docroot/themes/custom/uids_base/scss/content/person.scss
+++ b/docroot/themes/custom/uids_base/scss/content/person.scss
@@ -89,7 +89,8 @@
 }
 
 // For professional titles on multiple lines
-.view-people-list-block {
+.view-people-list-block,
+.view-people-block {
   .field--label-visually_hidden .field__items {
     display: grid;
   }

--- a/docroot/themes/custom/uids_base/scss/content/person.scss
+++ b/docroot/themes/custom/uids_base/scss/content/person.scss
@@ -90,7 +90,8 @@
 
 // For professional titles on multiple lines
 .view-people-list-block,
-.view-people-block {
+.view-people-block,
+.view-people {
   .field--label-visually_hidden .field__items {
     display: grid;
   }


### PR DESCRIPTION
# How to test

Testing
```
blt sync --site law.uiowa.edu &&
yarn workspace uids_base gulp --development
```
Inspect the following pages, perhaps more where this style is used that I'm not aware of.
https://law.local.drupal.uiowa.edu/faculty-and-scholarship/meet-our-faculty
https://law.local.drupal.uiowa.edu/people
