### PR TITLE
media video/remote video fix appending to classes array

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -1003,9 +1003,7 @@ function layout_builder_custom_preprocess_media(&$variables) {
 
     case 'remote_video':
     case 'video':
-      $variables['attributes'] = [
-        'class' => ['media--video'],
-      ] + $variables['attributes'];
+      $variables['attributes']['class'][] = 'media--video';
       break;
   }
 }


### PR DESCRIPTION
Video card revealed a bad classes array. Fixed how media--video is added so that it doesn't erase other classes (e.g. align-right)


## To Test

Check banner local video to make sure the potential for other classes being passed in doesn't affect render.

https://sandbox.local.drupal.uiowa.edu/

Check remote video wysiwyg alignment and general card video renderings.

https://sandbox.prod.drupal.uiowa.edu/media