### PR TITLE
Enable webform for region items.

### DIFF
--- a/config/default/core.entity_view_display.fragment.region_item.default.yml
+++ b/config/default/core.entity_view_display.fragment.region_item.default.yml
@@ -54,7 +54,8 @@ third_party_settings:
         System: {  }
         'University of Iowa Alerts': {  }
         User: {  }
-        Webform: {  }
+        Webform:
+          - webform_block
         core: {  }
       blacklisted_blocks: {  }
       allowed_layouts:

--- a/docroot/themes/custom/uids_base/scss/components/form/forms.scss
+++ b/docroot/themes/custom/uids_base/scss/components/form/forms.scss
@@ -721,6 +721,7 @@
   & .block-webform {
 
     input[id^='edit-actions-submit'],
+    input[id^='edit-submit'],
     input#edit-actions-submit {
       @include bttn--secondary;
       border: 1px solid $secondary;


### PR DESCRIPTION
Resolves #4389 , #4387

# How to test

1. Create a webform.
2. Create new region item in region settings.
2. Edit its layout.
3. Add the newly-created webform to the layout.
4. Save.
5. Add it to the prefooter region.
6. Save.
7. Go to the site's homepage.
8. Test prefooter's webform styling.
