### PR TITLE
Remove blt:init:settings from sync.commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ multisites:
 ```
 
 ### Common Tasks
-Multisites will not be able to bootstrap without a `local.settings.php` file. The `blt:init:settings` (or `bis` for short) command will generate local settings files _only_ for the multisite defined in BLT configuration. By default, this is all multisites but be aware that the `local.blt.yml` change documented above will override that.
+Multisites will not be able to bootstrap without a `local.settings.php` file. The `blt:init:settings` (or `bis` for short) command will generate local settings files _only_ for the multisite defined in BLT configuration. By default, this is all multisites but be aware that the `local.blt.yml` change documented above will override that. You can temporarily remove that override if you need to generate settings files for all multisites.
 
 The `blt frontend` command will install and compile frontend assets.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ multisites:
 ```
 
 ### Common Tasks
-The `drupal:sync:all-sites` command will generate local settings files by invoking `blt:init:settings` (or `bis` for short) _only_ if they do not exist. If you want to re-generate all multisite local settings files, you can run `rm -f docroot/sites/*/settings/local.settings.php` and then `blt bis`.
+Multisites will not be able to bootstrap without a `local.settings.php` file. The `blt:init:settings` (or `bis` for short) command will generate local settings files _only_ for the multisite defined in BLT configuration. By default, this is all multisites but be aware that the `local.blt.yml` change documented above will override that.
 
 The `blt frontend` command will install and compile frontend assets.
 

--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -55,9 +55,9 @@ cm:
     install_from_config: true
 sync:
   commands:
-    - 'blt:init:settings'
     - 'drupal:sync:db'
     - 'drupal:update'
+    - 'uiowa:multisite:noop'
     - 'uiowa:multisite:noop'
     - 'uiowa:multisite:noop'
 

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -100,13 +100,11 @@ class ReplaceCommands extends BltTasks {
   public function replacePostDbCopy($site, $target_env, $db_name, $source_env) {
     foreach ($this->getConfigValue('multisites') as $multisite) {
       $this->switchSiteContext($multisite);
-
       $db = $this->getConfigValue('drupal.db.database');
 
       // Trigger drupal:update for this site.
       if ($db_name == $db) {
         $this->logger->info("Deploying updates to <comment>{$multisite}</comment>...");
-        $this->switchSiteContext($multisite);
         $this->taskDrush()->drush('cache:rebuild')->run();
         $this->invokeCommand('drupal:update');
         $this->logger->info("Finished deploying updates to <comment>{$multisite}</comment>.");

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -6,7 +6,6 @@ use Acquia\Blt\Robo\BltTasks;
 use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Acquia\Blt\Robo\Common\YamlMunge;
 use Acquia\Blt\Robo\Exceptions\BltException;
-use Uiowa\Multisite;
 
 /**
  * BLT override commands.

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -4,7 +4,9 @@ namespace Uiowa\Blt\Plugin\Commands;
 
 use Acquia\Blt\Robo\BltTasks;
 use Acquia\Blt\Robo\Common\EnvironmentDetector;
+use Acquia\Blt\Robo\Common\YamlMunge;
 use Acquia\Blt\Robo\Exceptions\BltException;
+use Uiowa\Multisite;
 
 /**
  * BLT override commands.
@@ -178,6 +180,28 @@ class ReplaceCommands extends BltTasks {
     else {
       $this->logger->notice('Skipping percy snapshot in non-CI environment.');
     }
+  }
+
+  /**
+   * Remove all local settings file beforehand, so they are recreated.
+   *
+   * The source:build:settings command will only recreate local settings files
+   * if they do not already exist. This can be confusing if you change BLT
+   * configuration and expect to see the differences in the file.
+   *
+   * @hook pre-command source:build:settings
+   */
+  public function preSourceBuildSettings() {
+    $yaml = YamlMunge::parseFile($this->getConfigValue('repo.root') . '/blt/local.blt.yml');
+
+    if (isset($yaml['multisites'])) {
+      $this->logger->warning('Multisites overridden in local.blt.yml file. Only those sites will have local.settings.php files regenerated.');
+    }
+
+    $this->taskExecStack()
+      ->dir($this->getConfigValue('docroot'))
+      ->exec('rm sites/*/settings/local.settings.php')
+      ->run();
   }
 
 }


### PR DESCRIPTION
https://github.com/acquia/blt/issues/4428

# Testing
- On main, run `blt sync --site sandbox.uiowa.edu`
- See that the output from Drush is syncing the default site, not sandbox.
- Check out this branch and run it again.
- See the correct site is synced.

We could leave this out permanently as it doesn't really need to run per-site for every sync. People would just need to remember to run `blt bis` to regenerate local.settings.php files when necessary.
