### PR TITLE
Find Text updates--menu searching and new placement

### DIFF
--- a/docroot/modules/custom/sitenow_find_text/css/sitenow_find_text.icon.css
+++ b/docroot/modules/custom/sitenow_find_text/css/sitenow_find_text.icon.css
@@ -1,5 +1,7 @@
-.toolbar .toolbar-icon.toolbar-icon-sitenow-find-text-search-form::before {
-  background-image: url("/core/themes/claro/images/icons/868686/magnifier.svg");
-  width: 2.25rem;
-  left: 0.1667em;
+.toolbar-icon-sitenow-find-text-search-form::before {
+  font-family: 'Font Awesome 5 Free';
+  font-weight: 900;
+  font-size: 16px;
+  top: 0.67em !important;
+  content: '\f002' !important;
 }

--- a/docroot/modules/custom/sitenow_find_text/css/sitenow_find_text.icon.css
+++ b/docroot/modules/custom/sitenow_find_text/css/sitenow_find_text.icon.css
@@ -1,7 +1,5 @@
-.toolbar-icon-sitenow-find-text-search-form::before {
-  font-family: 'Font Awesome 5 Free';
-  font-weight: 900;
-  font-size: 16px;
-  top: 0.67em !important;
-  content: '\f002' !important;
+.toolbar .toolbar-icon.toolbar-icon-sitenow-find-text-search-form::before {
+  background-image: url("/core/themes/claro/images/icons/868686/magnifier.svg");
+  width: 2.25rem;
+  left: 0.1667em;
 }

--- a/docroot/modules/custom/sitenow_find_text/css/sitenow_find_text.icon.css
+++ b/docroot/modules/custom/sitenow_find_text/css/sitenow_find_text.icon.css
@@ -1,0 +1,7 @@
+.toolbar-icon-sitenow-find-text-search-form::before {
+  font-family: 'Font Awesome 5 Free';
+  font-weight: 900;
+  font-size: 16px;
+  top: 0.67em !important;
+  content: '\f002' !important;
+}

--- a/docroot/modules/custom/sitenow_find_text/css/sitenow_find_text.results.css
+++ b/docroot/modules/custom/sitenow_find_text/css/sitenow_find_text.results.css
@@ -1,3 +1,3 @@
 span.find-text-match {
-  background-color: #dfd;
+  background-color: #77f177;
 }

--- a/docroot/modules/custom/sitenow_find_text/css/sitenow_find_text.results.css
+++ b/docroot/modules/custom/sitenow_find_text/css/sitenow_find_text.results.css
@@ -1,0 +1,3 @@
+span.find-text-match {
+  background-color: #dfd;
+}

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.info.yml
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.info.yml
@@ -4,3 +4,5 @@ description: Search all text fields for a specific string.
 package: Sitenow
 core: 8.x
 core_version_requirement: ^8 || ^9
+libraries:
+  - sitenow_find_text/toolbar-icon

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.info.yml
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.info.yml
@@ -5,4 +5,5 @@ package: Sitenow
 core: 8.x
 core_version_requirement: ^8 || ^9
 libraries:
-  - sitenow_find_text/toolbar-icon
+  - sitenow_find_text/icon
+  - sitenow_find_text/results

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.libraries.yml
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.libraries.yml
@@ -3,4 +3,3 @@ icon:
   css:
     theme:
       css/sitenow_find_text.icon.css: {}
-      libraries/fontawesome/css/all.min.css: {}

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.libraries.yml
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.libraries.yml
@@ -3,3 +3,4 @@ icon:
   css:
     theme:
       css/sitenow_find_text.icon.css: {}
+      libraries/fontawesome/css/all.min.css: {}

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.libraries.yml
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.libraries.yml
@@ -4,3 +4,9 @@ icon:
     theme:
       css/sitenow_find_text.icon.css: {}
       /libraries/fontawesome/css/all.min.css: {}
+
+results:
+  version: 1.0
+  css:
+    theme:
+      css/sitenow_find_text.results.css: {}

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.libraries.yml
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.libraries.yml
@@ -1,0 +1,5 @@
+icon:
+  version: 1.0
+  css:
+    theme:
+      css/sitenow_find_text.icon.css: {}

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.libraries.yml
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.libraries.yml
@@ -3,3 +3,4 @@ icon:
   css:
     theme:
       css/sitenow_find_text.icon.css: {}
+      /libraries/fontawesome/css/all.min.css: {}

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.links.menu.yml
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.links.menu.yml
@@ -1,5 +1,6 @@
-sitenow_find_text.settings_form:
+sitenow_find_text.search_form:
   title: 'Find Text'
   description: Perform a content search.
-  parent: system.admin_config_sitenow
+  parent: system.admin
   route_name: sitenow_find_text.search_form
+  weight: 90

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
@@ -156,10 +156,38 @@ function search_fields(string $needle, bool $regexed = FALSE, bool $render = FAL
           ]);
         }
         else {
-          $row->value = new FormattableMarkup("<strong>@name</strong><br/>@value", [
+          // Find and mark all instances of our match.
+          $tokenized = preg_replace('%' . $needle . '%i', '[TOKEN]$0[TOKEN]', $row->$value_column);
+          // Break it apart into an array of matches and nonmatches.
+          $exploded = explode('[TOKEN]', $tokenized);
+          $counter = 0;
+          $replacements = [];
+          foreach ($exploded as &$part) {
+            // If we have a match, then we want to surround it
+            // with our targeted span class, but otherwise leave
+            // it alone. It will be part of the rendered markup.
+            if (preg_match('%' . $needle . '%i', $part)) {
+              $part = '<span class="find-text-match">' . $part . '</span>';
+            }
+            // If we didn't match, then we want it as part of the
+            // replacements, so that HTML will not be rendered.
+            else {
+              // Add it to our list of replacements, and
+              // replace it in the render string with its
+              // respective marker.
+              $replacements['@match' . $counter] = $part;
+              $part = '@match' . $counter++;
+            }
+          }
+          // Combine all our updated strings and markers.
+          $highlighted_string = implode('', $exploded);
+          // Create a formatted markup string with our edited
+          // highlighted string. Matches will be targeted with our
+          // classed spans, and nonmatch sections will be displayed
+          // without rendering their HTML tags.
+          $row->value = new FormattableMarkup("<strong>@name</strong><br/>" . $highlighted_string, array_merge([
             '@name' => prettify_machine_name($value_column),
-            '@value' => $row->$value_column,
-          ]);
+          ], $replacements));
         }
         // Fetch_parent will grab the parent node nid if able,
         // or else return false if the parent couldn't be found.

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
@@ -149,6 +149,8 @@ function search_fields(string $needle, bool $regexed = FALSE, bool $render = FAL
         // Prepend the result with the field name to help
         // in results displaying later.
         if ($render) {
+          // Surround matches with a class we can target.
+          $row->$value_column = preg_replace('%' . $needle . '%i', '<span class="find-text-match">$0</span>', $row->$value_column);
           $row->value = new FormattableMarkup("<strong>@name</strong><br/>" . $row->$value_column, [
             '@name' => prettify_machine_name($value_column),
           ]);

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
@@ -145,7 +145,10 @@ function search_fields(string $needle, bool $regexed = FALSE) {
       foreach ($temp_results as $id => $row) {
         // Prepend the result with the field name to help
         // in results displaying later.
-        $row->value = implode(': ', [$value_column, $row->$value_column]);
+        $row->value = implode(': ', [
+          prettify_machine_name($value_column),
+          $row->$value_column,
+        ]);
         // Fetch_parent will grab the parent node nid if able,
         // or else return false if the parent couldn't be found.
         if ($value_column != 'title') {
@@ -309,4 +312,23 @@ function fetch_parent(array $ids, string $type) {
     default:
       return $ids;
   }
+}
+
+/**
+ * Simple helper to make machine names more user friendly.
+ *
+ * @param string $machine_name
+ *   The string to pretty print.
+ *
+ * @return string
+ *   The more readable string.
+ */
+function prettify_machine_name(string $machine_name) {
+  // Drop 'field' and 'uiowa' designators,
+  // which don't really add anything for the editor.
+  // Ditto with all the extra "values" that get added.
+  $machine_name = preg_replace('@(field\_)|(uiowa\_)|(\_value)@', '', $machine_name);
+  // Replace underscores with spaces.
+  $machine_name = preg_replace('|\_|', ' ', $machine_name);
+  return ucwords($machine_name);
 }

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
@@ -107,11 +107,13 @@ function get_text_field_tables() {
  *   The string for which to search.
  * @param bool $regexed
  *   Whether a regex condition should be used over base LIKE.
+ * @param bool $render
+ *   Whether the results should be returned as a rendered HTML.
  *
  * @return array
  *   The search results.
  */
-function search_fields(string $needle, bool $regexed = FALSE) {
+function search_fields(string $needle, bool $regexed = FALSE, bool $render = FALSE) {
   $results = [];
   $tables = get_text_field_tables();
   $db = Database::getConnection();
@@ -146,10 +148,17 @@ function search_fields(string $needle, bool $regexed = FALSE) {
       foreach ($temp_results as $id => $row) {
         // Prepend the result with the field name to help
         // in results displaying later.
-        $row->value = new FormattableMarkup("<strong>@name</strong><br/>@value", [
-          '@name' => prettify_machine_name($value_column),
-          '@value' => $row->$value_column,
-        ]);
+        if ($render) {
+          $row->value = new FormattableMarkup("<strong>@name</strong><br/>" . $row->$value_column, [
+            '@name' => prettify_machine_name($value_column),
+          ]);
+        }
+        else {
+          $row->value = new FormattableMarkup("<strong>@name</strong><br/>@value", [
+            '@name' => prettify_machine_name($value_column),
+            '@value' => $row->$value_column,
+          ]);
+        }
         // Fetch_parent will grab the parent node nid if able,
         // or else return false if the parent couldn't be found.
         if ($value_column != 'title') {

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
@@ -149,8 +149,10 @@ function search_fields(string $needle, bool $regexed = FALSE, bool $render = FAL
         // Prepend the result with the field name to help
         // in results displaying later.
         if ($render) {
-          // Surround matches with a class we can target.
-          $row->$value_column = preg_replace('%' . $needle . '%i', '<span class="find-text-match">$0</span>', $row->$value_column);
+          // @todo Surround matches with a class we can target.
+          //   This may need to be handled in a post-render process,
+          //   as if it is added here, we risk breaking HTML tags
+          //   prior to creating our formatted markup.
           $row->value = new FormattableMarkup("<strong>@name</strong><br/>" . $row->$value_column, [
             '@name' => prettify_machine_name($value_column),
           ]);

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
@@ -39,41 +39,60 @@ function get_text_field_tables() {
     }
   }
   foreach ($fields as $entity_type_id => $field_map) {
-    // Currently we're only searching the major content areas.
-    // This will leave out things like menu areas, taxonomies, etc.
-    // which we may want to add later.
-    if (!in_array($entity_type_id, ['block_content', 'node', 'paragraph'])) {
-      continue;
-    }
-    // Grab the storage, field, and table definitions/mappings.
-    $entity_storage = $entity_type_manager->getStorage($entity_type_id);
-    $field_storage_definitions = $entity_field_manager->getFieldStorageDefinitions($entity_type_id);
-    $table_mapping = $entity_storage->getTableMapping($field_storage_definitions);
-    foreach (array_intersect_key($field_storage_definitions, $field_map) as $field_storage_definition) {
-      $field_name = $field_storage_definition->getName();
-      try {
-        $table_name = $table_mapping->getFieldTableName($field_name);
-        // We use a custom value function here. The built-in value fetcher
-        // will leave out extra columns for link and text_with_summary fields.
-        $value_columns = value_columns($field_name, $field_storage_definition->getType());
-        $parent_type = ['entity_id', 'revision_id'];
-        // Titles are handled a little differently, and at this time
-        // are the only fields handled this way.
-        if ($field_name == 'title') {
-          $parent_type = ['nid'];
-          $value_columns = ['title'];
+    // Check what type of entity we're working with.
+    // Some can be handled in the same manner, but some
+    // like menus need to be handled separately.
+    // And some, we just don't support at the moment.
+    switch ($entity_type_id) {
+      case 'block_content':
+      case 'node':
+      case 'paragraph':
+        // Grab the storage, field, and table definitions/mappings.
+        $entity_storage = $entity_type_manager->getStorage($entity_type_id);
+        $field_storage_definitions = $entity_field_manager->getFieldStorageDefinitions($entity_type_id);
+        $table_mapping = $entity_storage->getTableMapping($field_storage_definitions);
+        foreach (array_intersect_key($field_storage_definitions, $field_map) as $field_storage_definition) {
+          $field_name = $field_storage_definition->getName();
+          try {
+            $table_name = $table_mapping->getFieldTableName($field_name);
+            // We use a custom value function here. The built-in value fetcher
+            // will leave out extra columns for link and text_with_summary fields.
+            $value_columns = value_columns($field_name, $field_storage_definition->getType());
+            $parent_type = ['entity_id', 'revision_id'];
+            // Titles are handled a little differently, and at this time
+            // are the only fields handled this way.
+            if ($field_name == 'title') {
+              $parent_type = ['nid'];
+              $value_columns = ['title'];
+            }
+            // Set our table info that will get used in various places later.
+            $tables[$table_name] = [
+              'values' => $value_columns,
+              'parent' => $parent_type,
+              'type' => $entity_type_id,
+              'field_name' => $field_name,
+            ];
+          }
+          catch (SqlContentEntityStorageException $e) {
+            continue;
+          }
         }
-        // Set our table info that will get used in various places later.
-        $tables[$table_name] = [
-          'values' => $value_columns,
-          'parent' => $parent_type,
+        break;
+
+      case 'menu_link_content':
+        $tables['menu_link_content'] = [
+          'values' => [
+            'title',
+            'link_uri',
+          ],
+          'parent' => ['id'],
           'type' => $entity_type_id,
-          'field_name' => $field_name,
+          'field_name' => 'menu',
         ];
-      }
-      catch (SqlContentEntityStorageException $e) {
+        break;
+
+      default:
         continue;
-      }
     }
   }
   // This function can be used to clean up some extra tables

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
@@ -146,7 +146,7 @@ function search_fields(string $needle, bool $regexed = FALSE) {
       foreach ($temp_results as $id => $row) {
         // Prepend the result with the field name to help
         // in results displaying later.
-        $row->value = new FormattableMarkup('<strong>@name:</strong> @value', [
+        $row->value = new FormattableMarkup("<strong>@name</strong><br/> @value", [
           '@name' => prettify_machine_name($value_column),
           '@value' => $row->$value_column,
           ]);

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
@@ -149,10 +149,11 @@ function search_fields(string $needle, bool $regexed = FALSE, bool $render = FAL
         // Prepend the result with the field name to help
         // in results displaying later.
         if ($render) {
-          // @todo Surround matches with a class we can target.
-          //   This may need to be handled in a post-render process,
-          //   as if it is added here, we risk breaking HTML tags
-          //   prior to creating our formatted markup.
+          // Surround matches with a class we can target.
+          // Targets strings that do not appear after an
+          // opening tag marker if there is a corresponding
+          // closing tag marker.
+          $row->$value_column = preg_replace('%(?![^<]*>)' . $needle . '%i', '<span class="find-text-match">$0</span>', $row->$value_column);
           $row->value = new FormattableMarkup("<strong>@name</strong><br/>" . $row->$value_column, [
             '@name' => prettify_machine_name($value_column),
           ]);

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
@@ -334,7 +334,7 @@ function prettify_machine_name(string $machine_name) {
 }
 
 /**
- * Implements hook_toolbar_alter()
+ * Implements hook_toolbar_alter().
  */
 function sitenow_find_text_toolbar_alter(&$items) {
   $items['administration']['#attached']['library'][] = 'sitenow_find_text/icon';

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
@@ -56,7 +56,7 @@ function get_text_field_tables() {
           try {
             $table_name = $table_mapping->getFieldTableName($field_name);
             // We use a custom value function here. The built-in value fetcher
-            // will leave out extra columns for link and text_with_summary fields.
+            // leaves out extra columns for link and text_with_summary fields.
             $value_columns = value_columns($field_name, $field_storage_definition->getType());
             $parent_type = ['entity_id', 'revision_id'];
             // Titles are handled a little differently, and at this time
@@ -90,9 +90,6 @@ function get_text_field_tables() {
           'field_name' => 'menu',
         ];
         break;
-
-      default:
-        continue;
     }
   }
   // This function can be used to clean up some extra tables

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
@@ -333,7 +333,7 @@ function prettify_machine_name(string $machine_name) {
   return ucwords($machine_name);
 }
 
-/*
+/**
  * Implements hook_toolbar_alter()
  */
 function sitenow_find_text_toolbar_alter(&$items) {

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
@@ -80,10 +80,10 @@ function get_text_field_tables() {
         break;
 
       case 'menu_link_content':
-        $tables['menu_link_content'] = [
+        $tables['menu_link_content_data'] = [
           'values' => [
             'title',
-            'link_uri',
+            'link__uri',
           ],
           'parent' => ['id'],
           'type' => $entity_type_id,
@@ -157,21 +157,22 @@ function search_fields(string $needle, bool $regexed = FALSE) {
             'revision_id' => $row->revision_id,
           ];
           $new_id = fetch_parent($ids, $details['type']);
-          // Unset the old entity_id and replace with the new id.
-          // If we didn't find a result in our fetch_parent,
-          // we don't know what node has it anyway,
-          // and so our results will be broken--so go ahead
-          // and unset it outside of the new_id check.
-          unset($temp_results[$id]);
+          // If we found a new id from fetch_parent, we want to
+          // update the results table to the new id and unset the
+          // old value to avoid possible collisions in subsequent
+          // loops.
+          // @todo Check on the type, and update indexing to allow
+          // for same ids for different entity types.
           if ($new_id) {
             $temp_results[$new_id['id']] = $row;
+            unset($temp_results[$id]);
           }
         }
       }
       // Add our new results to our collected results, keyed
-      // by node id.
-      foreach ($temp_results as $nid => $value) {
-        $results[$nid][] = $value;
+      // by entity id.
+      foreach ($temp_results as $id => $value) {
+        $results[$details['type']][$id][] = $value;
       }
     }
   }

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
@@ -160,19 +160,25 @@ function search_fields(string $needle, bool $regexed = FALSE) {
           // If we found a new id from fetch_parent, we want to
           // update the results table to the new id and unset the
           // old value to avoid possible collisions in subsequent
-          // loops.
-          // @todo Check on the type, and update indexing to allow
-          // for same ids for different entity types.
+          // loops. We unset it first, so that even if the id
+          // is the same, we don't lose anything.
+          unset($temp_results[$id]);
           if ($new_id) {
             $temp_results[$new_id['id']] = $row;
-            unset($temp_results[$id]);
           }
         }
       }
       // Add our new results to our collected results, keyed
       // by entity id.
       foreach ($temp_results as $id => $value) {
-        $results[$details['type']][$id][] = $value;
+        // All node, block_content, and paragraph entity types
+        // will be displayed at the end as being a "node" result.
+        $type = (in_array($details['type'], [
+          'node',
+          'block_content',
+          'paragraph',
+        ])) ? 'node' : $details['type'];
+        $results[$type][$id][] = $value;
       }
     }
   }
@@ -250,13 +256,6 @@ function cleanup_tables(array &$tables) {
 function fetch_parent(array $ids, string $type) {
   $db = Database::getConnection();
   switch ($type) {
-    case 'node':
-      // We're assuming the node is the uppermost
-      // parent. May not always be the case in the future,
-      // but mostly, even if it's an entity reference to a node,
-      // we want the referenced node for editing anyway.
-      return $ids;
-
     case 'paragraph':
       $result = $db->select('entity_usage')
         ->fields('entity_usage', [
@@ -302,6 +301,15 @@ function fetch_parent(array $ids, string $type) {
       // in the future, if we have nested blocks.
       $ids['id'] = $result[0]->entity_id;
       $ids['revision_id'] = $result[0]->revision_id;
+      return $ids;
+
+    // We're assuming the node is the uppermost
+    // parent. May not always be the case in the future,
+    // but mostly, even if it's an entity reference to a node,
+    // we want the referenced node for editing anyway. Same
+    // for some other entity types, such as menu links.
+    case 'node':
+    default:
       return $ids;
   }
 }

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
@@ -332,3 +332,10 @@ function prettify_machine_name(string $machine_name) {
   $machine_name = preg_replace('|\_|', ' ', $machine_name);
   return ucwords($machine_name);
 }
+
+/*
+ * Implements hook_toolbar_alter()
+ */
+function sitenow_find_text_toolbar_alter(&$items) {
+  $items['administration']['#attached']['library'][] = 'sitenow_find_text/icon';
+}

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
@@ -146,10 +146,10 @@ function search_fields(string $needle, bool $regexed = FALSE) {
       foreach ($temp_results as $id => $row) {
         // Prepend the result with the field name to help
         // in results displaying later.
-        $row->value = new FormattableMarkup("<strong>@name</strong><br/> @value", [
+        $row->value = new FormattableMarkup("<strong>@name</strong><br/>@value", [
           '@name' => prettify_machine_name($value_column),
           '@value' => $row->$value_column,
-          ]);
+        ]);
         // Fetch_parent will grab the parent node nid if able,
         // or else return false if the parent couldn't be found.
         if ($value_column != 'title') {

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.module
@@ -9,6 +9,7 @@
  * @see https://www.drupal.org/node/2217931
  */
 
+use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Entity\Sql\SqlContentEntityStorageException;
 use Drupal\Core\Database\Database;
 
@@ -145,10 +146,10 @@ function search_fields(string $needle, bool $regexed = FALSE) {
       foreach ($temp_results as $id => $row) {
         // Prepend the result with the field name to help
         // in results displaying later.
-        $row->value = implode(': ', [
-          prettify_machine_name($value_column),
-          $row->$value_column,
-        ]);
+        $row->value = new FormattableMarkup('<strong>@name:</strong> @value', [
+          '@name' => prettify_machine_name($value_column),
+          '@value' => $row->$value_column,
+          ]);
         // Fetch_parent will grab the parent node nid if able,
         // or else return false if the parent couldn't be found.
         if ($value_column != 'title') {

--- a/docroot/modules/custom/sitenow_find_text/sitenow_find_text.routing.yml
+++ b/docroot/modules/custom/sitenow_find_text/sitenow_find_text.routing.yml
@@ -1,7 +1,7 @@
 sitenow_find_text.search_form:
-  path: '/admin/config/sitenow/sitenow-find-text'
+  path: '/admin/find-text'
   defaults:
-    _title: 'Sitenow Find Text'
+    _title: 'Find Text'
     _form: 'Drupal\sitenow_find_text\Form\SearchForm'
   requirements:
     _permission: 'administer sitenow_find_text configuration'

--- a/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
+++ b/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
@@ -206,7 +206,10 @@ class SearchForm extends ConfigFormBase {
           break;
 
         default:
-          continue;
+          $entity_value = FALSE;
+      }
+      if (!$entity_value) {
+        continue;
       }
       $rows[] = [
         'id' => [

--- a/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
+++ b/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
@@ -77,7 +77,7 @@ class SearchForm extends ConfigFormBase {
     $form['render'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Render markup'),
-      '#description' => $this->t('Should the results be returned as rendered HTML? This may hide parts of the results, such as text matched within HTML tags.'),
+      '#description' => $this->t('Display the results as rendered HTML. This may hide parts of the results, such as text matched within HTML tags.'),
       '#default_value' => 0,
     ];
     $form['regexed'] = [

--- a/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
+++ b/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
@@ -200,7 +200,7 @@ class SearchForm extends ConfigFormBase {
           break;
 
         case 'menu_link_content':
-          $entity_value = new FormattableMarkup('Menu: @mid (<a href="/admin/structure/menu/item/@mid/edit">edit</a>)', [
+          $entity_value = new FormattableMarkup('Menu: @mid (<a href="/admin/structure/menu/item/@mid/edit?destination=/admin/find-text">edit</a>)', [
             '@mid' => $id,
           ]);
           break;

--- a/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
+++ b/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
@@ -167,19 +167,19 @@ class SearchForm extends ConfigFormBase {
           // the user will still see it in the results as a failsafe.
           $has_lb = $node && $node->hasField('layout_builder__layout');
           if ($has_lb) {
-            $entity_value = new FormattableMarkup('Node: @nid (<a href="/node/@nid/edit">edit</a>) (<a href="/node/@nid/layout">layout</a>)', [
+            $entity_value = new FormattableMarkup('<strong>Node:</strong> @nid (<a href="/node/@nid/edit">edit</a>) (<a href="/node/@nid/layout">layout</a>)', [
               '@nid' => $id,
             ]);
           }
           else {
-            $entity_value = new FormattableMarkup('Node: @nid (<a href="/node/@nid/edit">edit</a>)', [
+            $entity_value = new FormattableMarkup('<strong>Node:</strong> @nid (<a href="/node/@nid/edit">edit</a>)', [
               '@nid' => $id,
             ]);
           }
           break;
 
         case 'menu_link_content':
-          $entity_value = new FormattableMarkup('Menu: @mid (<a href="/admin/structure/menu/item/@mid/edit?destination=/admin/find-text">edit</a>)', [
+          $entity_value = new FormattableMarkup('<strong>Menu:</strong> @mid (<a href="/admin/structure/menu/item/@mid/edit?destination=/admin/find-text">edit</a>)', [
             '@mid' => $id,
           ]);
           break;

--- a/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
+++ b/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
@@ -78,7 +78,7 @@ class SearchForm extends ConfigFormBase {
       '#type' => 'checkbox',
       '#title' => $this->t('Render markup'),
       '#description' => $this->t('Display the results as rendered HTML. This may hide parts of the results, such as text matched within HTML tags.'),
-      '#default_value' => 0,
+      '#default_value' => 1,
     ];
     $form['regexed'] = [
       '#type' => 'checkbox',

--- a/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
+++ b/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
@@ -74,6 +74,12 @@ class SearchForm extends ConfigFormBase {
       '#default_value' => '',
       '#description' => $this->t('The string to search against. Wildcards % will match any number of characters and _ will match any single character. % wildcards are prepended and appended automatically when not using regex. See the <a href="https://sitenow.uiowa.edu/documentation/site-text-search">Find Text documentation</a> for more information.'),
     ];
+    $form['render'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Render markup'),
+      '#description' => $this->t('Should the results be returned as rendered HTML? This may hide parts of the results, such as text matched within HTML tags.'),
+      '#default_value' => 0,
+    ];
     $form['regexed'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('REGEXP?'),
@@ -109,7 +115,8 @@ class SearchForm extends ConfigFormBase {
   public function searchButton(array &$form, FormStateInterface $form_state) {
     $needle = $form_state->getValue('needle');
     $regexed = $form_state->getValue('regexed');
-    $results = search_fields($needle, $regexed);
+    $render = $form_state->getValue('render');
+    $results = search_fields($needle, $regexed, $render);
     $table = $this->buildResultsTable($results);
     $markup = $this->renderer->render($table);
     $form['results'] = [

--- a/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
+++ b/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
@@ -65,35 +65,14 @@ class SearchForm extends ConfigFormBase {
       '#markup' => <<< 'EOD'
         <p>Search text fields for a provided string. The search is not case-sensitive.</p>
         <p>Pre-rendered text area markup is searched, so some characters may be different; for instance, `&amp ;` may match ampersands where `&` will not.
-        Node fields and content blocks are included, but some areas such as taxonomy terms will not be searched.</p>
-        <p>Basic SQL LIKE wildcards may be used.</p>
-        <table class="responsive-enabled" data-striping="1">
-            <thead>
-                <tr>
-                    <th>Operator</th>
-                    <th>Use</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>%</td>
-                    <td>Wildcard that matches any zero, one, or many characters.<br/>
-                    `f%r` will match `fr`, `for`, `four`, and `flounder`.</td>
-                </tr>
-                <tr>
-                    <td>_</td>
-                    <td>Wildcard that matches exactly one character.<br/>
-                    `f_r` will match `for`, but not `fr`, `four`, or `flounder`.</td>
-                </tr>
-            </tbody>
-        </table>
+        Node fields and content blocks are included, but some areas such as menu links will not be searched.</p>
       EOD,
     ];
     $form['needle'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Search Text'),
       '#default_value' => '',
-      '#description' => $this->t('The string to search against. % wildcards are prepended and appended automatically when not using regex. % and _ are always treated as wildcards, and cannot be searched for directly at this time. A search for `100%` will return matches for `100`, `100%`, and `100.0`, for instance.'),
+      '#description' => $this->t('The string to search against. Wildcards % will match any number of characters and _ will match any single character. % wildcards are prepended and appended automatically when not using regex. See the <a href="https://sitenow.uiowa.edu/documentation/site-text-search">Find Text documentation</a> for more information.'),
     ];
     $form['regexed'] = [
       '#type' => 'checkbox',
@@ -156,64 +135,40 @@ class SearchForm extends ConfigFormBase {
         '#markup' => '<p class="text-align-center">No results found.</p>',
       ];
     }
-    // Rearrange and clear out the excess to make printing easier.
-    // Starting out, our results are separated by entity type.
-    foreach ($results as $type => $typed_results) {
-      // This first key will be the entity id.
-      foreach (array_keys($typed_results) as $key) {
-        // The secondary key will be a simple delta.
-        foreach (array_keys($typed_results[$key]) as $secondary_key) {
-          // Created a modified key to help us avoid collisions
-          // while rearranging our results.
-          $mod_key = implode('-', [$type, $key]);
-          $results[$mod_key][] = $results[$type][$key][$secondary_key]->value;
-        }
+    // Clear out the excess to make printing easier.
+    foreach (array_keys($results) as $key) {
+      foreach (array_keys($results[$key]) as $secondary_key) {
+        $results[$key][$secondary_key] = $results[$key][$secondary_key]->value;
       }
-      unset($results[$type]);
     }
     $rows = [];
     $node_manager = $this->entityTypeManager
       ->getStorage('node');
-    foreach ($results as $mod_key => $matches) {
-      $exploded = explode('-', $mod_key);
-      list($type, $id) = $exploded;
-      switch ($type) {
-        case 'block_content':
-        case 'paragraph':
-        case 'node':
-          $node = $node_manager->load($id);
-          // Check if we have an overridden layout or not.
-          // If we didn't successfully load a node, go ahead
-          // and treat it as a non-overridden node so that
-          // the user will still see it in the results as a failsafe.
-          $has_lb = $node && $node->hasField('layout_builder__layout');
-          if ($has_lb) {
-            $entity_value = new FormattableMarkup('Node: @nid (<a href="/node/@nid/edit">edit</a>) (<a href="/node/@nid/layout">layout</a>)', [
-              '@nid' => $id,
-            ]);
-          }
-          else {
-            $entity_value = new FormattableMarkup('Node: @nid (<a href="/node/@nid/edit">edit</a>)', [
-              '@nid' => $id,
-            ]);
-          }
-          break;
-
-        case 'menu_link_content':
-          $entity_value = new FormattableMarkup('Menu: @mid (<a href="/admin/structure/menu/item/@mid/edit?destination=/admin/find-text">edit</a>)', [
-            '@mid' => $id,
-          ]);
-          break;
-
-        default:
-          $entity_value = FALSE;
-      }
-      if (!$entity_value) {
+    foreach ($results as $nid => $matches) {
+      // @todo Clean this up. Right now, we're checking for field existence
+      //   to determine if we allow layout builder editing. It's better than
+      //   hardcoding it to entity types we've allowed, but...only just.
+      $node = $node_manager->load($nid);
+      // If we weren't able to load a node,
+      // then go ahead and skip ahead, because
+      // we won't have a result to display anyway.
+      if (!$node) {
         continue;
       }
+      $has_lb = $node->hasField('layout_builder__layout');
+      if ($has_lb) {
+        $node_value = new FormattableMarkup('@nid (<a href="/node/@nid/edit">edit</a>) (<a href="/node/@nid/layout">layout</a>)', [
+          '@nid' => $nid,
+        ]);
+      }
+      else {
+        $node_value = new FormattableMarkup('@nid (<a href="/node/@nid/edit">edit</a>)', [
+          '@nid' => $nid,
+        ]);
+      }
       $rows[] = [
-        'id' => [
-          'data' => $entity_value,
+        'nid' => [
+          'data' => $node_value,
           // Stretch the node row to cover all its matches.
           'rowspan' => count($matches),
         ],
@@ -230,7 +185,7 @@ class SearchForm extends ConfigFormBase {
     return [
       '#type' => 'table',
       '#header' => [
-        'nid' => 'Entity',
+        'nid' => 'Node',
         'field' => 'Field: Contents',
       ],
       '#rows' => $rows,

--- a/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
+++ b/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
@@ -65,7 +65,7 @@ class SearchForm extends ConfigFormBase {
       '#markup' => <<< 'EOD'
         <p>Search text fields for a provided string. The search is not case-sensitive.</p>
         <p>Pre-rendered text area markup is searched, so some characters may be different; for instance, `&amp ;` may match ampersands where `&` will not.
-        Node fields and content blocks are included, but some areas such as menu links will not be searched.</p>
+        Node fields and content blocks are included, but some areas such as taxonomy terms will not be searched.</p>
         <p>Basic SQL LIKE wildcards may be used.</p>
         <table class="responsive-enabled" data-striping="1">
             <thead>

--- a/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
+++ b/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
@@ -106,6 +106,7 @@ class SearchForm extends ConfigFormBase {
     // Unset the original, currently unused submit button.
     // It might be used at another time if settings are needed.
     unset($form['actions']['submit']);
+    $form['#attached']['library'][] = 'sitenow_find_text/results';
     return $form;
   }
 

--- a/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
+++ b/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
@@ -135,40 +135,64 @@ class SearchForm extends ConfigFormBase {
         '#markup' => '<p class="text-align-center">No results found.</p>',
       ];
     }
-    // Clear out the excess to make printing easier.
-    foreach (array_keys($results) as $key) {
-      foreach (array_keys($results[$key]) as $secondary_key) {
-        $results[$key][$secondary_key] = $results[$key][$secondary_key]->value;
+    // Rearrange and clear out the excess to make printing easier.
+    // Starting out, our results are separated by entity type.
+    foreach ($results as $type => $typed_results) {
+      // This first key will be the entity id.
+      foreach (array_keys($typed_results) as $key) {
+        // The secondary key will be a simple delta.
+        foreach (array_keys($typed_results[$key]) as $secondary_key) {
+          // Created a modified key to help us avoid collisions
+          // while rearranging our results.
+          $mod_key = implode('-', [$type, $key]);
+          $results[$mod_key][] = $results[$type][$key][$secondary_key]->value;
+        }
       }
+      unset($results[$type]);
     }
     $rows = [];
     $node_manager = $this->entityTypeManager
       ->getStorage('node');
-    foreach ($results as $nid => $matches) {
-      // @todo Clean this up. Right now, we're checking for field existence
-      //   to determine if we allow layout builder editing. It's better than
-      //   hardcoding it to entity types we've allowed, but...only just.
-      $node = $node_manager->load($nid);
-      // If we weren't able to load a node,
-      // then go ahead and skip ahead, because
-      // we won't have a result to display anyway.
-      if (!$node) {
+    foreach ($results as $mod_key => $matches) {
+      $exploded = explode('-', $mod_key);
+      list($type, $id) = $exploded;
+      switch ($type) {
+        case 'block_content':
+        case 'paragraph':
+        case 'node':
+          $node = $node_manager->load($id);
+          // Check if we have an overridden layout or not.
+          // If we didn't successfully load a node, go ahead
+          // and treat it as a non-overridden node so that
+          // the user will still see it in the results as a failsafe.
+          $has_lb = $node && $node->hasField('layout_builder__layout');
+          if ($has_lb) {
+            $entity_value = new FormattableMarkup('Node: @nid (<a href="/node/@nid/edit">edit</a>) (<a href="/node/@nid/layout">layout</a>)', [
+              '@nid' => $id,
+            ]);
+          }
+          else {
+            $entity_value = new FormattableMarkup('Node: @nid (<a href="/node/@nid/edit">edit</a>)', [
+              '@nid' => $id,
+            ]);
+          }
+          break;
+
+        case 'menu_link_content':
+          $entity_value = new FormattableMarkup('Menu: @mid (<a href="/admin/structure/menu/item/@mid/edit?destination=/admin/find-text">edit</a>)', [
+            '@mid' => $id,
+          ]);
+          break;
+
+        default:
+          $entity_value = FALSE;
+      }
+      if (!$entity_value) {
         continue;
       }
-      $has_lb = $node->hasField('layout_builder__layout');
-      if ($has_lb) {
-        $node_value = new FormattableMarkup('@nid (<a href="/node/@nid/edit">edit</a>) (<a href="/node/@nid/layout">layout</a>)', [
-          '@nid' => $nid,
-        ]);
-      }
-      else {
-        $node_value = new FormattableMarkup('@nid (<a href="/node/@nid/edit">edit</a>)', [
-          '@nid' => $nid,
-        ]);
-      }
       $rows[] = [
-        'nid' => [
-          'data' => $node_value,
+        'id' => [
+          'data' => $entity_value,
           // Stretch the node row to cover all its matches.
           'rowspan' => count($matches),
         ],
@@ -185,7 +209,7 @@ class SearchForm extends ConfigFormBase {
     return [
       '#type' => 'table',
       '#header' => [
-        'nid' => 'Node',
+        'nid' => 'Entity',
         'field' => 'Field: Contents',
       ],
       '#rows' => $rows,

--- a/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
+++ b/docroot/modules/custom/sitenow_find_text/src/Form/SearchForm.php
@@ -106,6 +106,7 @@ class SearchForm extends ConfigFormBase {
     // Unset the original, currently unused submit button.
     // It might be used at another time if settings are needed.
     unset($form['actions']['submit']);
+    // Attach our custom css for highlighting purposes.
     $form['#attached']['library'][] = 'sitenow_find_text/results';
     return $form;
   }


### PR DESCRIPTION
Resolves #4348
Resolves #4445 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

- `git checkout find-text-menus && git pull`
- `blt ds --site=sandbox.uiowa.edu` or sync any other site
- (Permissions haven't changed, but for full testing experience, the following should be completable by a webmaster).
- Use the "Find Text" toolbar link
  - It should appear in the admin toolbar, labeled "Find Text" with an appropriate icon
- Search for content in the site
- Check that you can still find content within a page, either on node fields or in layout builder blocks/paragraphs, and that the results table displays the correct node
- Check that the `edit` and `layout` links work for nodes
- Search for content that should match a menu link title or uri
- Check that the menu appears in the results table, labelled as a menu item
- Check that the `edit` link takes you to editing the menu item that matches the search string
  - After saving from the menu link, you should be redirected back to the Find Text page (though the previous results do not persist through this)
- Check that the Find Text page's help text, link to documentation work correctly, as some changes have been made as part of this as well

## Edit
 - Try using both the "render" option and not
 - Check that highlighting works for both rendered/nonrendered outputs
 - Search for strings that might match text within HTML tags
   - Rendered output should still function. Good example of this might be searching for "table" and checking that table results still render as tables.
     - There might be results without highlighting -- this would indicate that it matched only content within tags
   - When not using rendered output, tag should appear complete, but with added highlighting 
 - For all of the above, check that labels appear correctly (bolded, text makes sense for the field it refers to)