### PR TITLE
Feature: `<a>` tags in event description

### DIFF
--- a/docroot/modules/custom/sitenow_events/includes/sitenow_events.teaser.inc
+++ b/docroot/modules/custom/sitenow_events/includes/sitenow_events.teaser.inc
@@ -81,8 +81,8 @@ function template_preprocess_sitenow_events_teaser(array &$variables) {
     'all_day' => $variables['event']['instance_all_day'],
   ]);
 
-  if (isset($variables['event']['description_text'])) {
-    $variables['event']['description_text'] = Xss::filter($variables['event']['description_text']);
-    $variables['event']['description_text'] = Unicode::truncate($variables['event']['description_text'], 500, TRUE, TRUE);
+  if (isset($variables['event']['description'])) {
+    $variables['event']['description'] = Xss::filter($variables['event']['description']);
+    $variables['event']['description'] = Unicode::truncate($variables['event']['description'], 500, TRUE, TRUE);
   }
 }

--- a/docroot/modules/custom/sitenow_events/includes/sitenow_events.teaser.inc
+++ b/docroot/modules/custom/sitenow_events/includes/sitenow_events.teaser.inc
@@ -5,9 +5,9 @@
  * Teaser theme functions.
  */
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Url;
+use Drupal\smart_trim\Truncate\TruncateHTML;
 
 /**
  * Theme function for an event teaser.
@@ -83,7 +83,9 @@ function template_preprocess_sitenow_events_teaser(array &$variables) {
 
   if (isset($variables['event']['description'])) {
     $allowed_tags = ['a', 'strong', 'em'];
+    $trim_suffix = '...';
+    $truncate = new TruncateHTML();
     $variables['event']['description'] = Xss::filter($variables['event']['description'], $allowed_tags);
-    $variables['event']['description'] = Unicode::truncate($variables['event']['description'], 500, TRUE, TRUE);
+    $variables['event']['description'] = $truncate->truncateChars($variables['event']['description'], 400, $trim_suffix);
   }
 }

--- a/docroot/modules/custom/sitenow_events/includes/sitenow_events.teaser.inc
+++ b/docroot/modules/custom/sitenow_events/includes/sitenow_events.teaser.inc
@@ -89,6 +89,6 @@ function template_preprocess_sitenow_events_teaser(array &$variables) {
     // Use smart_trim's helper to safely truncate without breaking HTML.
     $truncate = new TruncateHTML();
     $trim_suffix = '...';
-    $variables['event']['description'] = $truncate->truncateChars($variables['event']['description'], 400, $trim_suffix);
+    $variables['event']['description'] = $truncate->truncateChars($variables['event']['description'], 500, $trim_suffix);
   }
 }

--- a/docroot/modules/custom/sitenow_events/includes/sitenow_events.teaser.inc
+++ b/docroot/modules/custom/sitenow_events/includes/sitenow_events.teaser.inc
@@ -82,10 +82,13 @@ function template_preprocess_sitenow_events_teaser(array &$variables) {
   ]);
 
   if (isset($variables['event']['description'])) {
+    // Limit what html is allowed.
     $allowed_tags = ['a', 'strong', 'em'];
-    $trim_suffix = '...';
-    $truncate = new TruncateHTML();
     $variables['event']['description'] = Xss::filter($variables['event']['description'], $allowed_tags);
+
+    // Use smart_trim's helper to safely truncate without breaking HTML.
+    $truncate = new TruncateHTML();
+    $trim_suffix = '...';
     $variables['event']['description'] = $truncate->truncateChars($variables['event']['description'], 400, $trim_suffix);
   }
 }

--- a/docroot/modules/custom/sitenow_events/includes/sitenow_events.teaser.inc
+++ b/docroot/modules/custom/sitenow_events/includes/sitenow_events.teaser.inc
@@ -82,7 +82,8 @@ function template_preprocess_sitenow_events_teaser(array &$variables) {
   ]);
 
   if (isset($variables['event']['description'])) {
-    $variables['event']['description'] = Xss::filter($variables['event']['description']);
+    $allowed_tags = ['a', 'strong', 'em'];
+    $variables['event']['description'] = Xss::filter($variables['event']['description'], $allowed_tags);
     $variables['event']['description'] = Unicode::truncate($variables['event']['description'], 500, TRUE, TRUE);
   }
 }

--- a/docroot/modules/custom/sitenow_events/sitenow_events.info.yml
+++ b/docroot/modules/custom/sitenow_events/sitenow_events.info.yml
@@ -7,3 +7,4 @@ configure: sitenow_events.settings_form
 dependencies:
   - drupal:options
   - drupal:imagecache_external
+  - drupal:smart_trim

--- a/docroot/themes/custom/uids_base/templates/misc/sitenow-events-teaser.html.twig
+++ b/docroot/themes/custom/uids_base/templates/misc/sitenow-events-teaser.html.twig
@@ -44,7 +44,7 @@
   'card_link_url': event.url,
   'card_subtitle': event.date_string,
   'headline_level': event.heading_size,
-  'card_text': event.description_text|render,
+  'card_text': event.description|render|trim|t,
   'event_icon': event_icon|trans,
   'card_tag': event_location|render,
 } %}


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/4477. 
Resolves https://github.com/uiowa/uiowa/issues/4085. 

# How to test

This pr changes the events module to use the `description` instead of the `description_text` from content hub.

- Test on any site using an events block.   
- You should see the text formatted and links active if they haven't been truncated.   
- Libraries has a lot of links if you set the event count to 20 for testing.