### PR TITLE
Temporary Dynamic Pager

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -1081,6 +1081,29 @@ function layout_builder_custom_views_plugins_display_alter(&$displays) {
 }
 
 /**
+ * Implements hook_views_pre_build().
+ */
+function layout_builder_custom_views_pre_build(ViewExecutable $view) {
+  // Dynamically set pager id using SharedTempStore.
+  // Temp workaround until https://www.drupal.org/project/drupal/issues/3225987.
+  // @todo Allow view config to override this (non-zero pager id?).
+  $pager = $view->display_handler->getOption('pager');
+  if (isset($pager) && $pager['type'] == 'full') {
+    $tempstore = \Drupal::service('tempstore.shared')->get('layout_builder_custom_views_pager_elements');
+    $pager_element = $tempstore->get($view->dom_id);
+    if ($pager_element) {
+      $pager['options']['id'] = $pager_element;
+    }
+    else {
+      $pager_manager = \Drupal::service('pager.manager');
+      $tempstore->set($view->dom_id, $pager_manager->getMaxPagerElementId() + 1);
+      $pager['options']['id'] = $tempstore->get($view->dom_id);
+    }
+    $view->display_handler->setOption('pager', $pager);
+  }
+}
+
+/**
  * Implements hook_views_pre_render().
  */
 function layout_builder_custom_views_pre_render(ViewExecutable $view) {


### PR DESCRIPTION
Closes https://github.com/uiowa/uiowa/pull/4501 (alternative)
Fixes https://github.com/uiowa/uiowa/issues/3661

Until https://www.drupal.org/project/drupal/issues/3225987 gets more traction, we need a solution for #3661. This uses much of the same method as https://www.drupal.org/project/drupal/issues/3225987#comment-14328472 but without altering core.

With the dom_id, a key/value pair is created/tracked in key_value_expire to set a pager id for the view. These are set to expire and regenerate after 7 days. cache rebuilds generate new dom_ids.

## To Test

The pagers on https://iti.uiowa.ddev.site/labs/worthington-lab, https://sandbox.uiowa.ddev.site/people-directory should match their view config and work correctly on-click.

