### PR TITLE
DDEV Fixes

### DIFF
--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -190,6 +190,7 @@ class ReplaceCommands extends BltTasks {
     $this->taskExecStack()
       ->dir($this->getConfigValue('docroot'))
       ->exec('rm sites/*/settings/local.settings.php')
+      ->exec('rm sites/*/local.drush.yml')
       ->run();
   }
 


### PR DESCRIPTION
Fixes https://github.com/uiowa/uiowa/issues/4539

This can be solved manually by deleting the local.drush.yml file in your default site directory

## To Test

- Comment out multisites array in local.blt.yml
- run `blt bis`
- run `blt ds` the database name should be `uiowa` and sync successfully

This deletes and replaces local.drush.yml files. Though the uri in the replacement file is the same for each site, it just works.