### PR TITLE
Hotfix: split aggregator block for admissions entity print.

### DIFF
--- a/config/sites/admissions.uiowa.edu/config_split.patch.core.entity_view_display.block_content.uiowa_aggregator.default.yml
+++ b/config/sites/admissions.uiowa.edu/config_split.patch.core.entity_view_display.block_content.uiowa_aggregator.default.yml
@@ -1,0 +1,6 @@
+adding:
+  hidden:
+    entity_print_view_epub: true
+    entity_print_view_pdf: true
+    entity_print_view_word_docx: true
+removing: {  }


### PR DESCRIPTION
Follow up from #4561. 

### Problem

Syncing/deploying admissions.uiowa.edu results in a config diff:
```
 --------------------------------------- ----------- 
  Name                                    State      
 --------------------------------------- ----------- 
  core.entity_view_display.block_conten   Different  
  t.uiowa_aggregator.default                         
 --------------------------------------- ----------- 
```

### How to test

- `blt sync --site admissions.uiowa.edu`
- See no diff.
