### PR TITLE
Hotfix: home page underline style

### DIFF
--- a/docroot/themes/custom/uids_base/scss/layouts/fourcol.scss
+++ b/docroot/themes/custom/uids_base/scss/layouts/fourcol.scss
@@ -28,6 +28,11 @@
     text-align: center;
     margin-bottom: 2rem;
   }
+  .layout--fourcol.grid--1-3 .layout__region--first .bold-headline--underline:after,
+  .layout--fourcol.grid--1-3 .layout__region--first .headline--underline:after {
+    margin-left: auto;
+    margin-right: auto;
+  }
   .layout--fourcol.grid--1-3  .layout__region--second {
     grid-area: 2 / 1 / 6 / 2;
   }


### PR DESCRIPTION
This is a quick fix that fixes the underline alignment when using the `Layout: Grid 1x3` style on the home page. 

`blt --site=uiowa.edu`
`yarn workspace uids_base build`

Before:

<img width="854" alt="Screen Shot 2021-12-17 at 12 42 35 PM" src="https://user-images.githubusercontent.com/1036433/146592770-578e4d85-3edc-465e-943d-988dbcbc0e8c.png">

After:

<img width="862" alt="Screen Shot 2021-12-17 at 12 42 28 PM" src="https://user-images.githubusercontent.com/1036433/146592777-a53feb2f-9f78-42af-adb2-10bc9852b608.png">

