### PR TITLE
Remove gradient if page title is hidden.

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/banner.scss
+++ b/docroot/themes/custom/uids_base/scss/components/banner.scss
@@ -158,11 +158,6 @@
   font-size: containerClamp(2.5rem, 4.7rem);
 }
 
-// Remove the gradient overlay if the page title is hidden.
-.banner--gradient-bottom.layout--title--hidden::after {
-  background: none;
-}
-
 .banner__image {
   .contextual-region {
     // Remove contextual position for logged in view of banner image

--- a/docroot/themes/custom/uids_base/scss/components/banner.scss
+++ b/docroot/themes/custom/uids_base/scss/components/banner.scss
@@ -158,6 +158,11 @@
   font-size: containerClamp(2.5rem, 4.7rem);
 }
 
+// Remove the gradient overlay if the page title is hidden.
+.banner--gradient-bottom.layout--title--hidden::after {
+  background: none;
+}
+
 .banner__image {
   .contextual-region {
     // Remove contextual position for logged in view of banner image

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -540,7 +540,8 @@ function uids_base_preprocess_layout(&$variables) {
       if ($variables['banner_settings']['transparent']) {
         $variables['attributes']['class'][] = 'banner--transparent';
       }
-      else {
+      // Don't set the gradient classes unless the title is hidden.
+      elseif ($title_hidden === FALSE) {
         $variables['attributes']['class'][] = 'banner--gradient-bottom';
         $variables['attributes']['class'][] = 'banner--gradient-dark';
       }
@@ -560,6 +561,7 @@ function uids_base_preprocess_layout(&$variables) {
 
         if ($title_hidden) {
           $variables['attributes']['class'][] = 'layout--title--hidden';
+          $variables['attributes']['class'][] = 'banner--transparent';
         }
       }
     }

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -537,11 +537,10 @@ function uids_base_preprocess_layout(&$variables) {
       $variables['banner_settings'] = $variables['banner_settings'] + $defaults;
 
       // Set default for banner gradient.
-      if ($variables['banner_settings']['transparent']) {
+      if ($variables['banner_settings']['transparent'] || $title_hidden) {
         $variables['attributes']['class'][] = 'banner--transparent';
       }
-      // Don't set the gradient classes unless the title is hidden.
-      elseif ($title_hidden === FALSE) {
+      else {
         $variables['attributes']['class'][] = 'banner--gradient-bottom';
         $variables['attributes']['class'][] = 'banner--gradient-dark';
       }
@@ -561,7 +560,6 @@ function uids_base_preprocess_layout(&$variables) {
 
         if ($title_hidden) {
           $variables['attributes']['class'][] = 'layout--title--hidden';
-          $variables['attributes']['class'][] = 'banner--transparent';
         }
       }
     }


### PR DESCRIPTION
Resolves #4531 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
~`yarn workspace uids_base build`~ (not necessary if you've built off of main recently)
Sync a site
Check a page with a featured image
If the title is not hidden, a gradient overlay should be present on the banner image (`linear-gradient(180deg,transparent 0,rgba(0,0,0,.65) 70%)`)
If the title is hidden, no gradient overlay should be present