### PR TITLE
Fix ReplicatorEvents error

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/src/EventSubscriber/ReplicateSubscriber.php
+++ b/docroot/modules/custom/layout_builder_custom/src/EventSubscriber/ReplicateSubscriber.php
@@ -69,9 +69,11 @@ class ReplicateSubscriber implements EventSubscriberInterface {
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() {
-    return [
-      ReplicatorEvents::AFTER_SAVE => 'onReplicateAfterSave',
-    ];
+    $events = [];
+    if (class_exists('\Drupal\replicate\Events\ReplicatorEvents')) {
+      $events[ReplicatorEvents::AFTER_SAVE] = 'onReplicateAfterSave';
+    }
+    return $events;
   }
 
   /**


### PR DESCRIPTION
Resolves #4527 

Acquia Cloud tasks are throwing an error, not liking the use of the class constant in event name subscriber. In looking through d.o issues and modules, it seems it's an issue with the order classes get loaded, and the workarounds are either to use string constants or check for class existence first (a core example here:  https://api.drupal.org/api/drupal/core%21modules%21content_translation%21src%21ContentTranslationUpdatesManager.php/8.2.x). 

Checking for the class existence first shouldn't effect any functionality, but should circumvent the error.

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
Sync a site, replicate a page.
Check that the layout has successfully been replicated, and that new blocks have been created
(A quick way for the above is to use `drush @site.local sqlc` and run `SELECT count(*) FROM block_content` before and after replicating).

# Followup test

After merging, check tasks in acquia cloud, and see that the error is no longer appearing.

```
Error: Class &#039;Drupal\replicate\Events\ReplicatorEvents&#039; not found in Drupal\layout_builder_custom\EventSubscriber\ReplicateSubscriber::getSubscribedEvents() (line 73 of /mnt/www/html/uiowa02dev/docroot/modules/custom/layout_builder_custom/src/EventSubscriber/ReplicateSubscriber.php).
```