### PR TITLE
fix card aria

### DIFF
--- a/docroot/themes/custom/uids_base/templates/uids/card.html.twig
+++ b/docroot/themes/custom/uids_base/templates/uids/card.html.twig
@@ -34,7 +34,7 @@
 {% endif %}
 
 {# Do not show the aria-describedby attribute if title AND link text are not both present. #}
-{% if link_element != 'title' %}
+{% if link_element != 'title' or card_link_title == ''%}
   {% set card_aria_describedby = '' %}
 {% endif %}
 
@@ -108,7 +108,7 @@
             </a>
           {% else %}
             {# Display as a pseudo-link. #}
-            <div aria-hidden="true" {{ button_attributes.addclass(card_button_classes) }}  {% if card_aria_describedby %} id="{{ card_aria_describedby }}"{% endif %}>
+            <div aria-hidden="true" {{ button_attributes.addclass(card_button_classes) }}  {% if (card_aria_describedby != '') %} id="{{ card_aria_describedby }}"{% endif %}>
               {{ card_link_title }}
               <i role="presentation" class="fas fa-arrow-right"></i>
             </div>


### PR DESCRIPTION
fixes #4611

## To testerino

1. sync down sandbox
2. go to `https://sandbox.uiowa.ddev.site/cards`
3. test that the card indicator cards do not have `aria-describedby` id's anymore, and that the headline isn't pointing to them.
4. ?????
5. This joke is old.
