### PR TITLE
Update all multisite default.local.settings.php files.

### DIFF
--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -181,6 +181,10 @@ class ReplaceCommands extends BltTasks {
    * @hook pre-command source:build:settings
    */
   public function preSourceBuildSettings() {
+    if (!$this->confirm('This will delete all local.settings.php files for defined multisites. Are you sure?')) {
+      throw new BltException('Aborted.');
+    }
+
     $yaml = YamlMunge::parseFile($this->getConfigValue('repo.root') . '/blt/local.blt.yml');
 
     if (isset($yaml['multisites'])) {

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -183,7 +183,7 @@ class ReplaceCommands extends BltTasks {
   public function preSourceBuildSettings() {
     $yaml = YamlMunge::parseFile($this->getConfigValue('repo.root') . '/blt/local.blt.yml');
 
-    if (isset($yaml['multisites'])) {
+    if (isset($yaml['multisites']) && !empty($yaml['multisites'])) {
       throw new \Exception('Multisites overridden in local.blt.yml file. Remove multisites override before running this command.');
     }
 

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -193,6 +193,7 @@ class ReplaceCommands extends BltTasks {
 
     $this->taskExecStack()
       ->dir($this->getConfigValue('docroot'))
+      ->exec('rm sites/*/settings/default.local.settings.php')
       ->exec('rm sites/*/settings/local.settings.php')
       ->exec('rm sites/*/local.drush.yml')
       ->run();

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -181,14 +181,14 @@ class ReplaceCommands extends BltTasks {
    * @hook pre-command source:build:settings
    */
   public function preSourceBuildSettings() {
-    if (!$this->confirm('This will delete all local.settings.php files for defined multisites. Are you sure?')) {
-      throw new BltException('Aborted.');
-    }
-
     $yaml = YamlMunge::parseFile($this->getConfigValue('repo.root') . '/blt/local.blt.yml');
 
     if (isset($yaml['multisites'])) {
-      $this->logger->warning('Multisites overridden in local.blt.yml file. Only those sites will have local.settings.php files regenerated.');
+      throw new \Exception('Multisites overridden in local.blt.yml file. Remove multisites override before running this command.');
+    }
+
+    if (!$this->confirm('This will delete all local.settings.php files for all multisites. Are you sure?')) {
+      throw new \Exception('Aborted.');
     }
 
     $this->taskExecStack()

--- a/docroot/sites/175.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/175.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/3ddesign.studio.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/3ddesign.studio.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/3mlearning.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/3mlearning.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/47things.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/47things.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/91stmeridian.iwp.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/91stmeridian.iwp.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/academicmusiciowa.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/academicmusiciowa.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/academics.athletics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/academics.athletics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/accel.education.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/accel.education.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/accessibility101.course.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/accessibility101.course.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/accreditation.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/accreditation.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ace.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ace.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each
- * bin to change the default configuration provided by Drupal core in core.services.yml.
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ace.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ace.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/admissions.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/admissions.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/adsforruralamerica.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/adsforruralamerica.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/advising.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/advising.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/advisingcenter.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/advisingcenter.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/afpcc.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/afpcc.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/africanamericancouncil.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/africanamericancouncil.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/africanamericanstudies.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/africanamericanstudies.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/alphachisigma-alphatheta.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/alphachisigma-alphatheta.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/amcs.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/amcs.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/americanstudies.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/americanstudies.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/andersen.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/andersen.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/anthropology.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/anthropology.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/anunsettledbody.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/anunsettledbody.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ap-purchasing.fo.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ap-purchasing.fo.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/appliedphys.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/appliedphys.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/arsc.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/arsc.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/arts.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/arts.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/asce.engineering.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/asce.engineering.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/asg.clas.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/asg.clas.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/asian-slavic.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/asian-slavic.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/asl.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/asl.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/assessment.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/assessment.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/attanasio.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/attanasio.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/audiogenomics.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/audiogenomics.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/audit.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/audit.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/auditoryresearch.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/auditoryresearch.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/autismcenter.centerforconferences.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/autismcenter.centerforconferences.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/avclub.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/avclub.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/awards.studentlife.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/awards.studentlife.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each
- * bin to change the default configuration provided by Drupal core in core.services.yml.
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/bam.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/bam.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/bands.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/bands.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/baran.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/baran.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/basbls.uc.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/basbls.uc.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/basicneeds.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/basicneeds.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/basinanalysis.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/basinanalysis.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/bcbl.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/bcbl.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/beckergroup.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/beckergroup.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/benson.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/benson.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/bhattacherjee.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/bhattacherjee.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/billing.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/billing.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/biomonitoring.shl.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/biomonitoring.shl.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/biomost.engineering.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/biomost.engineering.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/blsa.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/blsa.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/blumberg.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/blumberg.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each
- * bin to change the default configuration provided by Drupal core in core.services.yml.
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/bme.engineering.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/bme.engineering.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/bmess.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/bmess.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/boes.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/boes.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/book.grad.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/book.grad.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/boudreau.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/boudreau.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/brand.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/brand.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/brogden.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/brogden.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/buchholz.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/buchholz.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/businessmanager.fo.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/businessmanager.fo.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/businsvc.fo.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/businsvc.fo.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/byrne.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/byrne.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/callctr.dentistry.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/callctr.dentistry.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cam.fo.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cam.fo.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each
- * bin to change the default configuration provided by Drupal core in core.services.yml.
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/camps.athletics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/camps.athletics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/car.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/car.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/careers.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/careers.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/carlisle.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/carlisle.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/carterradiochem.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/carterradiochem.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/carvour.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/carvour.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cbig.iibi.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cbig.iibi.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cd2h.org/settings/default.local.settings.php
+++ b/docroot/sites/cd2h.org/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cda.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cda.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cdd.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cdd.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/celebrationofexcellence.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/celebrationofexcellence.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cerebralvascular.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cerebralvascular.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cerebrovascular.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cerebrovascular.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cfclincore.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cfclincore.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cgsa.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cgsa.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/chapleau.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/chapleau.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/chauhan.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/chauhan.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/chaurasia.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/chaurasia.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cheatum.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cheatum.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/chinesereadingworld.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/chinesereadingworld.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/chowdhury.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/chowdhury.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/chtc.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/chtc.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ci.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ci.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cifra.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cifra.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cinematicarts.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cinematicarts.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cio.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cio.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cjones.iihr.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cjones.iihr.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/classics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/classics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/classrooms.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/classrooms.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/clcl.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/clcl.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cld.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cld.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/climatecollective.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/climatecollective.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cmdd.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cmdd.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cnm.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cnm.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/coepe.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/coepe.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cogaresearch.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cogaresearch.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cognitivecontrol.psychology.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cognitivecontrol.psychology.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cogscilang.grad.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cogscilang.grad.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/coleresearchgroup.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/coleresearchgroup.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/collections.pharmacy.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/collections.pharmacy.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/colleen-campbell.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/colleen-campbell.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/comeron.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/comeron.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/communicationstudies.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/communicationstudies.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/compliance.athletics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/compliance.athletics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/compliance.fo.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/compliance.fo.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/computational-symposium.psychiatry.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/computational-symposium.psychiatry.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/conflictmanagement.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/conflictmanagement.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/coronavirus.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/coronavirus.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cot.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cot.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/counseling.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/counseling.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/covidresponse.research.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/covidresponse.research.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/covidtesting.shl.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/covidtesting.shl.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/coworkcommons.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/coworkcommons.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cpl.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cpl.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/crisp.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/crisp.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/critical-incident-plan.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/critical-incident-plan.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cs.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cs.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/csars.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/csars.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/csd.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/csd.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/csi.its.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/csi.its.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/csomaycenter.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/csomaycenter.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/csw.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/csw.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/cuhal.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/cuhal.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/currents.iihr.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/currents.iihr.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/daackhirsch.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/daackhirsch.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/dai.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/dai.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/dailey.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/dailey.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/dale-stille.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/dale-stille.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/dasblatt.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/dasblatt.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/datascience-workshop.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/datascience-workshop.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/debate.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/debate.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/default/settings/default.local.settings.php
+++ b/docroot/sites/default/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each
- * bin to change the default configuration provided by Drupal core in core.services.yml.
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/dei.athletics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/dei.athletics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/dentistry.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/dentistry.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/deroo.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/deroo.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/designcenter.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/designcenter.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/desmoines.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/desmoines.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/developmental-psychopathology.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/developmental-psychopathology.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/dietrich.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/dietrich.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/distance.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/distance.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/diversity.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/diversity.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/doublebass.studio.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/doublebass.studio.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/dune.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/dune.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/dwllc.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/dwllc.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/dwllcdishesanddips.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/dwllcdishesanddips.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/edgeofspace.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/edgeofspace.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/education.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/education.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ees.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ees.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/eforms.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/eforms.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/efre.iihr.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/efre.iihr.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ejanderson.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ejanderson.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/electronicmusic.studio.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/electronicmusic.studio.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/emeritus-faculty.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/emeritus-faculty.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/emfisis.physics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/emfisis.physics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/endingviolence.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/endingviolence.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/engage.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/engage.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/engagement.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/engagement.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/engineering.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/engineering.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/enrollment.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/enrollment.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/enterpriseriskmanagement.fo.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/enterpriseriskmanagement.fo.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/environmentalsciences.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/environmentalsciences.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/epx.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/epx.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/equityimplemented.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/equityimplemented.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/esl.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/esl.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/etc.engineering.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/etc.engineering.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ethicspublicpolicy.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ethicspublicpolicy.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/executive.jobs.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/executive.jobs.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/faculty-senate.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/faculty-senate.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/facultyhonors.clas.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/facultyhonors.clas.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/fallgiving.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/fallgiving.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/familyphysician.centerforconferences.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/familyphysician.centerforconferences.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/faraci.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/faraci.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/fbis.fo.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/fbis.fo.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/fblynn.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/fblynn.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/felder.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/felder.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/fiegel.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/fiegel.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/finance.clas.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/finance.clas.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/firstgen.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/firstgen.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/flare.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/flare.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/folland.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/folland.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/forbes.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/forbes.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/freementalhealthclinic.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/freementalhealthclinic.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/freespeech.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/freespeech.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/french-italian.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/french-italian.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/frg.physics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/frg.physics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/fric.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/fric.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/frrbp.medicine.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/frrbp.medicine.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/fskiff.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/fskiff.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/fsl.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/fsl.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ftoor.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ftoor.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/fys.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/fys.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/gaine.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/gaine.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/gconstantinescu.iihr.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/gconstantinescu.iihr.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/generalstores.fo.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/generalstores.fo.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/genetics.grad.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/genetics.grad.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/genome.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/genome.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each
- * bin to change the default configuration provided by Drupal core in core.services.yml.
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/geography.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/geography.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/geriatricpain.org/settings/default.local.settings.php
+++ b/docroot/sites/geriatricpain.org/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/german.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/german.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/getinvolved.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/getinvolved.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/gis.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/gis.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/glam.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/glam.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/glefevre.iihr.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/glefevre.iihr.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/globalhealthstudies.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/globalhealthstudies.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/govrel.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/govrel.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/gpsg.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/gpsg.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/grad.admissions.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/grad.admissions.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/grad.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/grad.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/grantsupport.clas.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/grantsupport.clas.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/gravbox.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/gravbox.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/grok.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/grok.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each
- * bin to change the default configuration provided by Drupal core in core.services.yml.
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/grueter.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/grueter.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/grumbach.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/grumbach.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/gss.grad.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/gss.grad.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/gsurgres.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/gsurgres.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/gvillarini.iihr.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/gvillarini.iihr.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/gwss-sj.course.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/gwss-sj.course.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/gwsstellmagazine.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/gwsstellmagazine.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/haa.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/haa.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/haar.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/haar.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/habelhah.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/habelhah.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/halosat.physics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/halosat.physics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/harwani.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/harwani.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/hawkeyecaucus.com/settings/default.local.settings.php
+++ b/docroot/sites/hawkeyecaucus.com/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/hawkeyemarchingband.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/hawkeyemarchingband.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/hawkit.athletics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/hawkit.athletics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/hbrl-neurosurgery.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/hbrl-neurosurgery.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/health-research-network.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/health-research-network.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/healthydata.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/healthydata.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/hefti.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/hefti.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/help.maui.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/help.maui.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/hhpatuiowa.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/hhpatuiowa.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/hipaa.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/hipaa.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/history.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/history.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/historyoftechnology.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/historyoftechnology.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/historyofuigeography.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/historyofuigeography.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/hoadley.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/hoadley.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/homecoming.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/homecoming.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/honorary-degrees.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/honorary-degrees.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/honors.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/honors.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/horn.studio.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/horn.studio.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/hot.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/hot.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/howes.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/howes.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/hr.clas.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/hr.clas.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/hr.fo.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/hr.fo.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/hr.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/hr.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/hrandbusiness.centerforconferences.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/hrandbusiness.centerforconferences.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/human-auditory-neuroscience-group.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/human-auditory-neuroscience-group.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/humanimmunology.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/humanimmunology.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/humanities.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/humanities.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/humanitiesiowa.org/settings/default.local.settings.php
+++ b/docroot/sites/humanitiesiowa.org/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/iba.biology.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/iba.biology.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/icarc.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/icarc.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/icomm.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/icomm.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/icred.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/icred.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/icru.research.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/icru.research.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/icsa.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/icsa.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/iddrc.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/iddrc.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/idrs2020.org/settings/default.local.settings.php
+++ b/docroot/sites/idrs2020.org/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/igec.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/igec.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ighn.international.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ighn.international.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/iisc.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/iisc.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/iisicca.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/iisicca.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ilg.course.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ilg.course.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/imfaculty.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/imfaculty.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/immuno.grad.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/immuno.grad.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/imu.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/imu.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/inclusionteam.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/inclusionteam.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/indiancinema.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/indiancinema.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/indianstudentalliance.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/indianstudentalliance.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/informatics.grad.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/informatics.grad.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/iniworkshop.conference.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/iniworkshop.conference.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/interdepartmentalstudies.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/interdepartmentalstudies.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/interdisciplinaryprograms.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/interdisciplinaryprograms.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/intermediatechinesereader.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/intermediatechinesereader.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/international.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/international.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/internationalstudies.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/internationalstudies.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/inventionofwriting.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/inventionofwriting.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/iowafloodmaps.iihr.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/iowafloodmaps.iihr.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/iowahousehotel.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/iowahousehotel.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/iowajpec.org/settings/default.local.settings.php
+++ b/docroot/sites/iowajpec.org/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/iowaneuroscienceclub.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/iowaneuroscienceclub.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/iowaresearch.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/iowaresearch.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/iowasummermusiccamps.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/iowasummermusiccamps.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/iowasummerwritingfestival.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/iowasummerwritingfestival.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/iowasuperfund.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/iowasuperfund.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ipol.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ipol.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ippl.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ippl.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/irbr.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/irbr.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/isba.law.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/isba.law.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ishla.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ishla.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/issuree.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/issuree.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/itaccessibility.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/itaccessibility.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/italymba.tippie.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/italymba.tippie.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/itcommunities.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/itcommunities.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/iti.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/iti.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/itpmo.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/itpmo.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/itprivacy.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/itprivacy.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/itu.physics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/itu.physics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/iwp.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/iwp.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/jabbari.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/jabbari.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/jacobsoninstitute.org/settings/default.local.settings.php
+++ b/docroot/sites/jacobsoninstitute.org/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/jaynesresearchgroup.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/jaynesresearchgroup.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/jcl.law.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/jcl.law.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/jian-zhang.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/jian-zhang.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/journalism.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/journalism.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/jprineas.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/jprineas.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/jrg.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/jrg.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/jtucker.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/jtucker.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/kang.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/kang.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/karandikar.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/karandikar.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/kardon.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/kardon.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/kawai.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/kawai.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/kennelty.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/kennelty.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/kidneeds.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/kidneeds.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/klesney-tait.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/klesney-tait.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/kliemann.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/kliemann.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/kochanska.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/kochanska.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each
- * bin to change the default configuration provided by Drupal core in core.services.yml.
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/korn.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/korn.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/kroska.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/kroska.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/krysan.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/krysan.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/kuehn.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/kuehn.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/kumar.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/kumar.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/laborcenter.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/laborcenter.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/lalumiere.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/lalumiere.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/lamp-mission.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/lamp-mission.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each
- * bin to change the default configuration provided by Drupal core in core.services.yml.
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/languagetech.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/languagetech.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/latinamericanstudies.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/latinamericanstudies.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/latinxcouncil.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/latinxcouncil.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/latinxstudies.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/latinxstudies.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/laundry.fo.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/laundry.fo.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/law.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/law.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/leadandengage.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/leadandengage.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each
- * bin to change the default configuration provided by Drupal core in core.services.yml.
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/legalclinic.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/legalclinic.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/legge.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/legge.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/lentz.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/lentz.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/lgbtq-council.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/lgbtq-council.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/lhpdc.law.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/lhpdc.law.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/li.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/li.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/liberalartsbeyondbars.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/liberalartsbeyondbars.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/licensing.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/licensing.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/limoli.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/limoli.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/linguistics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/linguistics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/logsdon.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/logsdon.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/london.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/london.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/looc.course.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/looc.course.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/lungimaging.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/lungimaging.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/luo.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/luo.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/lweber.iihr.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/lweber.iihr.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/magazine.engineering.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/magazine.engineering.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/mailloux.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/mailloux.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/majorshadowuiowa.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/majorshadowuiowa.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/mangalam.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/mangalam.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/matfab.research.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/matfab.research.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/mbhd2022.conference.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/mbhd2022.conference.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/mcallister.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/mcallister.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/mccleery.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/mccleery.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/media.journalism.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/media.journalism.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/mentalhealth.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/mentalhealth.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/mentor.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/mentor.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/merlino.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/merlino.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/messingham.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/messingham.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/meurice.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/meurice.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/mew.conference.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/mew.conference.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/meyerholz.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/meyerholz.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/mgnait.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/mgnait.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/michaelewright.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/michaelewright.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/michaelson.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/michaelson.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/microvascularphys.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/microvascularphys.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/midwestdnarepair.centerforconferences.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/midwestdnarepair.centerforconferences.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/mikiw2022.pharmacy.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/mikiw2022.pharmacy.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each
- * bin to change the default configuration provided by Drupal core in core.services.yml.
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/miles.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/miles.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/mlk.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/mlk.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/mnfreund.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/mnfreund.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/mnh.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/mnh.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/molcellcog.org/settings/default.local.settings.php
+++ b/docroot/sites/molcellcog.org/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/moore.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/moore.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/mootcourt.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/mootcourt.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/morl.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/morl.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/movementfellowship.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/movementfellowship.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/moyerowley.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/moyerowley.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/multicultural.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/multicultural.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/multilingualsyntax.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/multilingualsyntax.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/mural-film.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/mural-film.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/museumstudies.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/museumstudies.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/nachtman.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/nachtman.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/nads.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/nads.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/nativeamericancouncil.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/nativeamericancouncil.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/nativeamericanstudies.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/nativeamericanstudies.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ncec.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ncec.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/neiman.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/neiman.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/nejadnik.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/nejadnik.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/neuroimaging.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/neuroimaging.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/neuroscience.grad.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/neuroscience.grad.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/newmoonmagazine.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/newmoonmagazine.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/news.engineering.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/news.engineering.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/newstudents.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/newstudents.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/nightatthesciencelabs.conference.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/nightatthesciencelabs.conference.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/nlp.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/nlp.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/nrcfcp.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/nrcfcp.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/nsfurmsts.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/nsfurmsts.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/nsslha.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/nsslha.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/nursing.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/nursing.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/nutrition.athletics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/nutrition.athletics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/obermann.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/obermann.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/obgynnewsletter.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/obgynnewsletter.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/obgynprotocols.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/obgynprotocols.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/occsafety.course.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/occsafety.course.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ofirl.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ofirl.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ogallala.research.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ogallala.research.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ohsc.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ohsc.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/oldcap.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/oldcap.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ombudsperson.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ombudsperson.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/omicron.engineering.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/omicron.engineering.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/oniowa.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/oniowa.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/osc.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/osc.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/pac.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/pac.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/paleorepository.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/paleorepository.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/parents.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/parents.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/passport.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/passport.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/pchs.lhpdc.law.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/pchs.lhpdc.law.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/peacebypeace.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/peacebypeace.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/peate.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/peate.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/pediatricaudiology.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/pediatricaudiology.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/pediatriccardiology.centerforconferences.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/pediatriccardiology.centerforconferences.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/pennathur.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/pennathur.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/pentacrestmuseums.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/pentacrestmuseums.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/perlman.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/perlman.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/pharmacy.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/pharmacy.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/phibetadelta.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/phibetadelta.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/philosophylyceum.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/philosophylyceum.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/physics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/physics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/physicsresearch.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/physicsresearch.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/pier.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/pier.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each
- * bin to change the default configuration provided by Drupal core in core.services.yml.
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/pinnaro.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/pinnaro.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/pinyin.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/pinyin.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/planning-and-development.fo.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/planning-and-development.fo.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/police.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/police.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/policy.clas.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/policy.clas.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/postsecular-novel.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/postsecular-novel.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/prahlad.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/prahlad.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/prairierestoration.course.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/prairierestoration.course.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/president.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/president.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/presidentialsearch.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/presidentialsearch.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/printmail.fo.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/printmail.fo.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/protostudios.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/protostudios.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/provost.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/provost.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/psp.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/psp.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/psycholinguistics.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/psycholinguistics.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/publishing-gallery.iwp.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/publishing-gallery.iwp.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/queerhorrorfestival2021.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/queerhorrorfestival2021.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/quench.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/quench.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/quenchiowa.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/quenchiowa.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/qulat.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/qulat.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ratner.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ratner.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/reconnect.psychology.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/reconnect.psychology.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/recserv.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/recserv.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/registrar.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/registrar.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/reinhardt.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/reinhardt.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/reno.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/reno.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/resch.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/resch.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/research2.education.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/research2.education.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/researchcollections.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/researchcollections.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/rise.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/rise.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/riskmanagement.fo.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/riskmanagement.fo.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/robotics.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/robotics.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/rodgers.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/rodgers.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/roman.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/roman.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/rvap.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/rvap.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ryan.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ryan.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each
- * bin to change the default configuration provided by Drupal core in core.services.yml.
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/saa.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/saa.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/sabharwal.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/sabharwal.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/salondeclase.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/salondeclase.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/sandbox.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/sandbox.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/sbirt.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/sbirt.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/schnieders.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/schnieders.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/scholardev.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/scholardev.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/schultz.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/schultz.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/screendancefest.dance.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/screendancefest.dance.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/sdg.grad.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/sdg.grad.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/sdo.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/sdo.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/sds.studentlife.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/sds.studentlife.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/se.iowastem.org/settings/default.local.settings.php
+++ b/docroot/sites/se.iowastem.org/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/sem.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/sem.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/seru.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/seru.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/sewell.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/sewell.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/shared-governance.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/shared-governance.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/shawgroup.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/shawgroup.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/shl.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/shl.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/shpe.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/shpe.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/shse.iwp.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/shse.iwp.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/silkroutes.iwp.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/silkroutes.iwp.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/sim-ia.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/sim-ia.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/simonsburnett.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/simonsburnett.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/sinapselab.ece.engineering.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/sinapselab.ece.engineering.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each
- * bin to change the default configuration provided by Drupal core in core.services.yml.
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/singh.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/singh.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/sitenow.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/sitenow.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/sivitz.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/sivitz.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/sla2021.conference.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/sla2021.conference.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/slis.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/slis.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/snyder.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/snyder.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/socialwork.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/socialwork.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/song.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/song.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/spanish-portuguese.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/spanish-portuguese.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/speakout.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/speakout.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/sportsmedicine.athletics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/sportsmedicine.athletics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/sppa.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/sppa.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/staff-council.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/staff-council.uiowa.edu/settings/default.local.settings.php
@@ -5,39 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
-global $_acsf_site_name;
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = [
-  'default' =>
-  [
-    'default' =>
-    [
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ],
-  ],
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
 ];
 
-$dir = dirname(DRUPAL_ROOT);
-
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -143,27 +131,17 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path.
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  // phpcs:ignore
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.

--- a/docroot/sites/staffcouncil.clas.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/staffcouncil.clas.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/stanleymuseum.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/stanleymuseum.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/star.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/star.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/startalkchinese.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/startalkchinese.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/statefair.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/statefair.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/stephens.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/stephens.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/stocktaken.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/stocktaken.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/stoltz.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/stoltz.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/stonewall50.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/stonewall50.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/strategicplan.clas.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/strategicplan.clas.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/strategicplan.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/strategicplan.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/strathearn.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/strathearn.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/strength.athletics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/strength.athletics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/studenthealth.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/studenthealth.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/studentlegal.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/studentlegal.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/studentlife.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/studentlife.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/studentspace.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/studentspace.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/studentsuccess.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/studentsuccess.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/studentwellness.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/studentwellness.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/success.course.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/success.course.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/surplus.fo.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/surplus.fo.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/sustainabilitycommittee.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/sustainabilitycommittee.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/talbert.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/talbert.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/tanas.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/tanas.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/teachabc.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/teachabc.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/teachonline.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/teachonline.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/techforum.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/techforum.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/tedabel.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/tedabel.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/theatrelobby.studio.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/theatrelobby.studio.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/themaclab.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/themaclab.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/theranostics.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/theranostics.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/thiel.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/thiel.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/tippie.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/tippie.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/tippieconsultingclub.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/tippieconsultingclub.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/toxicology.grad.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/toxicology.grad.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/tracers.physics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/tracers.physics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/trans-resources.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/trans-resources.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/translateui.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/translateui.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/translation.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/translation.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/transportation.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/transportation.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/tucker.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/tucker.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/tutor.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/tutor.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uc.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uc.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ui-lsamp.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ui-lsamp.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uiadvise.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uiadvise.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uiarc.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uiarc.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uibio.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uibio.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uibtaa.centerforconferences.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uibtaa.centerforconferences.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uichr.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uichr.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uiems.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uiems.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uimsa.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uimsa.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uiobl.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uiobl.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uip.pharmacy.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uip.pharmacy.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uipda.grad.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uipda.grad.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uiprehealth.conference.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uiprehealth.conference.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uipress.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uipress.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uira.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uira.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uirf.research.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uirf.research.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uisdaa.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uisdaa.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uiservicecenter.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uiservicecenter.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uisps.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uisps.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uisrm-internship.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uisrm-internship.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uiugf.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uiugf.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uiventures.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uiventures.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/umallik.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/umallik.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/university-shared-services.fo.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/university-shared-services.fo.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/uppu.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/uppu.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/upsa.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/upsa.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/usg.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/usg.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/vakhtangidarjania.studio.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/vakhtangidarjania.studio.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/vanallen.physics.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/vanallen.physics.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/vanallenprobes.centerforconferences.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/vanallenprobes.centerforconferences.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/vanotterloo.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/vanotterloo.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/ventilator.course.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/ventilator.course.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/veterans.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/veterans.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/viewbook.engineering.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/viewbook.engineering.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/virtualdance.studio.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/virtualdance.studio.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/voice-academy.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/voice-academy.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/vote.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/vote.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/waldschmidt.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/waldschmidt.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/webcommunity.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/webcommunity.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/weber.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/weber.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/wei.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/wei.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/weigel.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/weigel.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/weiss.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/weiss.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/whitmanweb.iwp.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/whitmanweb.iwp.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/wics.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/wics.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/wild.education.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/wild.education.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/wilken.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/wilken.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/windschitl.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/windschitl.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/wise.org.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/wise.org.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/witry.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/witry.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/wkrajewski.iihr.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/wkrajewski.iihr.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/wni.sites.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/wni.sites.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/wohlgenannt.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/wohlgenannt.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/wrac.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/wrac.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/writinguniversity.org/settings/default.local.settings.php
+++ b/docroot/sites/writinguniversity.org/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/wu.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/wu.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/xie.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/xie.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/yahr.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/yahr.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/yangs.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/yangs.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/yorek.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/yorek.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/youth.dance.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/youth.dance.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/zabner.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/zabner.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];

--- a/docroot/sites/zingman.lab.uiowa.edu/settings/default.local.settings.php
+++ b/docroot/sites/zingman.lab.uiowa.edu/settings/default.local.settings.php
@@ -5,38 +5,27 @@
  * Local development override configuration feature.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (isset($_acsf_site_name)) {
-  $db_name .= '_' . $_acsf_site_name;
-}
 
 /**
  * Database configuration.
  */
-$databases = array(
-  'default' =>
-  array(
-    'default' =>
-    array(
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
-
-$dir = dirname(DRUPAL_ROOT);
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
+];
 
 // Use development service parameters.
-$settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
-$settings['container_yamls'][] = $dir . '/docroot/sites/blt.development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/blt.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;
@@ -108,18 +97,17 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
- * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * Note: you should test with the config, bootstrap, and discovery caches
+ * enabled to test that metadata is cached as expected. However, in the early
+ * stages of development, you may want to disable them. Overrides to these bins
+ * must be explicitly set for each bin to change the default configuration
+ * provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
- // $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
- // $settings['cache']['bins']['discovery'] = 'cache.backend.null';
- // $settings['cache']['bins']['config'] = 'cache.backend.null';
-
-
+// $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
+// $settings['cache']['bins']['discovery'] = 'cache.backend.null';
+// $settings['cache']['bins']['config'] = 'cache.backend.null';
 /**
  * Enable access to rebuild.php.
  *
@@ -143,32 +131,23 @@ $settings['rebuild_access'] = FALSE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Temporary file path:
- *
- * A local file system path where temporary files will be stored. This
- * directory should not be accessible over the web.
- *
- * Note: Caches need to be cleared when this value is changed.
- *
- * See https://www.drupal.org/node/1928898 for more information
- * about global configuration override.
+ * Files paths.
  */
-$config['system.file']['path']['temporary'] = '/tmp';
-
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
 /**
- * Private file path.
+ * Site path.
+ *
+ * @var string $site_path
+ * This is always set and exposed by the Drupal Kernel.
  */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($_acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$_acsf_site_name";
-}
+// phpcs:ignore
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.
  *
  * See full description in default.settings.php.
  */
-$settings['trusted_host_patterns'] = array(
+$settings['trusted_host_patterns'] = [
   '^.+$',
-);
+];


### PR DESCRIPTION
While looking into https://github.com/uiowa/uiowa/issues/4242#issuecomment-1011432303, I noticed that all of our multisite local settings are out of date compared to what is in BLT upstream. This PR changes the `blt bis` command, again, to remove all `default.local.settings.php` files so the BLT default.local.settings.php file is copied in. We can use this command to manage local settings going forward, for example when updating blt.

Here are the recent updates to local.settings.php we are getting: https://github.com/acquia/blt/commits/main/settings/default.local.settings.php

Additional changes:
- require removal of multisites override in local.blt.yml so all files are regenerated
- Prompt for confirmation since developers may have config overrides or other settings set in local.settings.php files.

Devs probably don't need to run `blt bis` that frequently. Only when updating all settings files as part of a BLT update or when needing to work with a new site locally.

# How to test

`blt sync`
Poke around the site.
`blt sync --site mysite.com`
Poke around the site.



