### PR TITLE
Move stage_file_proxy origin setting to postBis instead of active config.

### DIFF
--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -228,7 +228,6 @@ class ReplaceCommands extends BltTasks {
 \$config['stage_file_proxy.settings']['origin'] = '$origin';
 EOD;
 
-
       $this->taskWriteToFile($this->getConfigValue('repo.root') . "/docroot/sites/$site/settings/local.settings.php")
         ->append()
         ->text($text)

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -214,6 +214,27 @@ class ReplaceCommands extends BltTasks {
    * @hook post-command source:build:settings
    */
   public function postSourceBuildSettings() {
+    foreach ($this->getConfigValue('multisites') as $site) {
+      $this->switchSiteContext($site);
+
+      $origin = $this->getConfigValue('uiowa.stage_file_proxy.origin');
+
+      if (!$origin) {
+        $origin = 'https://' . $this->getConfigValue('site');
+      }
+
+      $text = <<<EOD
+
+\$config['stage_file_proxy.settings']['origin'] = '$origin';
+EOD;
+
+
+      $this->taskWriteToFile($this->getConfigValue('repo.root') . "/docroot/sites/$site/settings/local.settings.php")
+        ->append()
+        ->text($text)
+        ->run();
+    }
+
     $from = $this->getConfigValue('repo.root') . '/tmp/local.blt.yml';
 
     if (file_exists($from)) {
@@ -264,47 +285,6 @@ class ReplaceCommands extends BltTasks {
       $chromeDriverPort = $this->getConfigValue('tests.chromedriver.port');
       $this->getContainer()->get('executor')->killProcessByPort($chromeDriverPort);
     }
-  }
-
-  /**
-   * Set custom configuration after syncing a site.
-   *
-   * @hook post-command drupal:sync:default:site
-   */
-  public function postDrupalSyncDefaultSite() {
-    $this->setStageFileProxyOrigin();
-  }
-
-  /**
-   * Set custom configuration after syncing all sites.
-   *
-   * @hook post-command drupal:sync:all-sites
-   */
-  public function postDrupalSyncAllSites() {
-    foreach ($this->getConfigValue('multisites') as $site) {
-      $this->switchSiteContext($site);
-      $this->setStageFileProxyOrigin();
-    }
-  }
-
-  /**
-   * Helper method to set stage_file_proxy.settings origin.
-   */
-  protected function setStageFileProxyOrigin() {
-    $origin = $this->getConfigValue('uiowa.stage_file_proxy.origin');
-
-    if (!$origin) {
-      $origin = 'https://' . $this->getConfigValue('site');
-    }
-
-    $this->taskDrush()
-      ->drush('config:set')
-      ->args([
-        'stage_file_proxy.settings',
-        'origin',
-        $origin,
-      ])
-      ->run();
   }
 
 }


### PR DESCRIPTION
Follow up from #4673 

Using active config leaves sites in a config diff. Config ignoring just the stage_file_proxy.settings:origin did not work. This PR moves the setting to local settings file override after bis is run.

# How to test

- `blt bis`
- See docroot/sites/175.uiowa.edu/settings/local.settings.php has origin set to prod URL.
- See docroot/sites/sandbox.uiowa.edu/settings/local.settings.php has origin set to internal prod URL. That is set from the doroot/sites/sandbox.uiowa.edu/blt.yml file.
- Sync a few sites via `blt dsa`.
- `blt ume cst`
- There should be no config diffs.
