### PR TITLE
Update to covid data import header

### DIFF
--- a/docroot/sites/coronavirus.uiowa.edu/modules/uiowa_covid/src/Plugin/Block/CovidDataBlock.php
+++ b/docroot/sites/coronavirus.uiowa.edu/modules/uiowa_covid/src/Plugin/Block/CovidDataBlock.php
@@ -138,7 +138,7 @@ class CovidDataBlock extends BlockBase implements ContainerFactoryPluginInterfac
           ],
           'report' => [
             'reported_heading' => [
-              '#markup' => $this->t('Self-reported COVID-19 positive test results'),
+              '#markup' => $this->t('Self-reported COVID-19 positive test results updated every Monday, Wednesday, and Friday'),
               '#prefix' => '<h3 class="h5">',
               '#suffix' => '</h3>',
             ],


### PR DESCRIPTION
Original request:

> On this page (COVID-19 by the Numbers | Novel Coronavirus (COVID-19) - The University of Iowa (uiowa.edu)) we are trying to make it extremely obvious that these numbers are updated every Monday, Wednesday, and Friday so we would like to change a sentence above the students/employees positive test results but since that info is automated, I was hoping you could help. I’ve attached a screenshot of the block I’m talking about.

> We would like to change the bolded sentence “Self-reported COVID-19 positive test results” to “Self-reported COVID-19 positive test results updated every Monday, Wednesday, and Friday.” Is this possible? If not, that’s ok, I also updated the block next to it to include that information.

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
`blt ds --site=coronavirus.uiowa.edu`
Visit https://coronavirus.uiowa.ddev.site/covid-19-numbers
Check that the data feed block's header text is updated to "Self-reported COVID-19 positive test results updated every Monday, Wednesday, and Friday"