### PR TITLE
Strictly manage composer version.

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -14,7 +14,7 @@ mysql_version: ""
 nfs_mount_enabled: false
 mutagen_enabled: true
 use_dns_when_possible: true
-composer_version: ""
+composer_version: "2.2.5"
 disable_settings_management: true
 
 # Key features of ddev's config.yaml:

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,15 @@
         "sort-packages": true,
         "platform": {
             "php": "7.4"
+        },
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "acquia/blt": true,
+            "acquia/blt-phpcs": true,
+            "drupal/core-composer-scaffold": true,
+            "oomphinc/composer-installers-extender": true
         }
     },
     "require": {


### PR DESCRIPTION
It was reported that different versions of Composer were causing problems, mostly https://getcomposer.org/doc/06-config.md#allow-plugins. Unfortunately, setting the ddev `composer_version` to `2` did not seem to get any updates. That lines up with a comment in the ddev config file: `# After first project 'ddev start' this will not be updated until it changes` - I had version 2 installed already.

This PR sets the latest Composer version in ddev config. We'll have to update this going forward. Note that all Composer commands should be run on ddev.

# How to test

- `ddev composer -- --version`
- `ddev restart`
- `ddev composer -- --version`
- `ddev composer install`

There should be no interaction required and no changes to composer.json.
