### PR TITLE
Disable AJAX refocus on hours date input change.

### DIFF
--- a/docroot/modules/custom/uiowa_hours/src/Form/HoursFilterForm.php
+++ b/docroot/modules/custom/uiowa_hours/src/Form/HoursFilterForm.php
@@ -87,6 +87,7 @@ class HoursFilterForm extends FormBase {
         '#ajax' => [
           'callback' => [$this, 'dateFilterCallback'],
           'event' => 'finishedinput',
+          'disable-refocus' => TRUE,
         ],
       ];
     }


### PR DESCRIPTION
Page jumps to the top after changing the date field on one of the bottom forms on https://recserv.uiowa.edu/hours.

# How to test

- `blt sync --site recserv.uiowa.edu`
- Go to https://recserv.uiowa.ddev.site/hours and change the date input for one of the bottom datepickers. 
- Page should not scroll up.
