### PR TITLE
International migrate retweak

### DIFF
--- a/docroot/sites/international.uiowa.edu/modules/international_migrate/config/split/migrate_plus.migration.international_article_redirects.yml
+++ b/docroot/sites/international.uiowa.edu/modules/international_migrate/config/split/migrate_plus.migration.international_article_redirects.yml
@@ -34,4 +34,6 @@ process:
   status_code: constants/status_code
 destination:
   plugin: 'entity:redirect'
-migration_dependencies: { }
+migration_dependencies:
+  required:
+    - international_articles

--- a/docroot/sites/international.uiowa.edu/modules/international_migrate/config/split/migrate_plus.migration.international_article_redirects.yml
+++ b/docroot/sites/international.uiowa.edu/modules/international_migrate/config/split/migrate_plus.migration.international_article_redirects.yml
@@ -34,6 +34,4 @@ process:
   status_code: constants/status_code
 destination:
   plugin: 'entity:redirect'
-migration_dependencies:
-  required:
-    - international_articles
+migration_dependencies: { }

--- a/docroot/sites/international.uiowa.edu/modules/international_migrate/src/Plugin/migrate/source/Articles.php
+++ b/docroot/sites/international.uiowa.edu/modules/international_migrate/src/Plugin/migrate/source/Articles.php
@@ -32,6 +32,8 @@ class Articles extends BaseNodeSource {
    */
   public function query() {
     $query = parent::query();
+    // Only import news newer than January 2015.
+    $query->condition('created', strtotime('2015-01-01'), '>=');
     $query->leftJoin('url_alias', 'alias', "alias.source = CONCAT('node/', n.nid)");
     $query->fields('alias', ['alias']);
     // Make sure our nodes are retrieved in order,
@@ -58,13 +60,6 @@ class Articles extends BaseNodeSource {
       return FALSE;
     }
     parent::prepareRow($row);
-
-    // Only import news newer than January 2015.
-    $created_year = date('Y', $row->getSourceProperty('created'));
-    if ($created_year < 2015) {
-      $this->logger->notice('Older than 2015. Skipping.');
-      return FALSE;
-    }
 
     // Get the author tags to build into our mapped
     // field_news_authors value.


### PR DESCRIPTION
Rethought @richardbporter's comment on the previous PR (#4766):
> Gotcha. This all sounded familiar so I just double checked old PRs and found [29ac0d7](https://github.com/uiowa/uiowa/commit/29ac0d7acd87187d2ad3733285c8018d3f7c205d) which got around it slightly differently. Seems like both ways work. 👍🏻

Still won't be able to use the `mim --all` with this, but making this change allows the redirects to still be dependent, and gives accurate counts when using `drush ms`, which is a nice bonus when running in batches.

Note: the query condition (and previous `prepareRow` check) comes from a request to not migrate articles prior to 2015, so this change should preserve that request.

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

Code review, or follow the steps in #3716 to run a test migration.