### PR TITLE
Disable auto rebasing for dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     time: "14:00"
     timezone: America/Chicago
   open-pull-requests-limit: 10
+  rebase-strategy: "disabled"
   ignore:
   - dependency-name: drupal/core-composer-scaffold
     versions:


### PR DESCRIPTION
Related to #4550 

Snapshots reset Sunday. Wanted to get this in beforehand. This change will requiring using comment commands to tell dependabot to rebase when ready to review/merge a dependabot PR.
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/managing-pull-requests-for-dependency-updates#managing-dependabot-pull-requests-with-comment-commands

### How to test
- Code review