### PR TITLE
update metatag to 1.19.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8382,21 +8382,22 @@
         },
         {
             "name": "drupal/metatag",
-            "version": "1.16.0",
+            "version": "1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/metatag.git",
-                "reference": "8.x-1.16"
+                "reference": "8.x-1.19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/metatag-8.x-1.16.zip",
-                "reference": "8.x-1.16",
-                "shasum": "1c0028f4ff4583dc6601035657dd631c351b290c"
+                "url": "https://ftp.drupal.org/files/projects/metatag-8.x-1.19.zip",
+                "reference": "8.x-1.19",
+                "shasum": "d70f59c034e971885ed4969a11bb392f6ab447ee"
             },
             "require": {
-                "drupal/core": "^8 || ^9",
-                "drupal/token": "^1.0"
+                "drupal/core": "^9",
+                "drupal/token": "^1.0",
+                "php": ">=7.0"
             },
             "require-dev": {
                 "drupal/devel": "^4.0",
@@ -8404,13 +8405,14 @@
                 "drupal/metatag_open_graph": "*",
                 "drupal/page_manager": "4.x-dev",
                 "drupal/panelizer": "4.x-dev",
-                "drupal/redirect": "1.x-dev"
+                "drupal/redirect": "1.x-dev",
+                "mpyw/phpunit-patch-serializable-comparison": "*"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.16",
-                    "datestamp": "1615820867",
+                    "version": "8.x-1.19",
+                    "datestamp": "1641496014",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/config/default/metatag.metatag_defaults.global.yml
+++ b/config/default/metatag.metatag_defaults.global.yml
@@ -20,7 +20,6 @@ tags:
   shortcut_icon: /profiles/custom/sitenow/assets/favicon.ico
   icon_96x96: /profiles/custom/sitenow/assets/favicon-96x96.png
   apple_touch_icon_152x152: /profiles/custom/sitenow/assets/apple-touch-icon-152x152.png
-  mask-icon: /profiles/custom/sitenow/assets/safari-pinned-tab.svg
   apple_touch_icon_72x72: /profiles/custom/sitenow/assets/apple-touch-icon-72x72.png
   apple_touch_icon_180x180: /profiles/custom/sitenow/assets/apple-touch-icon-180x180.png
   icon_32x32: /profiles/custom/sitenow/assets/favicon-32x32.png
@@ -34,3 +33,5 @@ tags:
   x_ua_compatible: IE=edge
   msapplication_tilecolor: '#000000'
   msapplication_square150x150logo: /profiles/custom/sitenow/assets/mstile-150x150.png
+  mask_icon:
+    href: /profiles/custom/sitenow/assets/safari-pinned-tab.svg


### PR DESCRIPTION
i think it worked for my local:

<img width="877" alt="Screen Shot 2022-02-17 at 10 47 55 AM" src="https://user-images.githubusercontent.com/4663676/154529880-902c493e-ee0b-4da5-a48b-00eff302ff92.png">

also, i no longer see the microsoft one added later in the head