### PR TITLE
Feature: local tabs/tasks fix

### DIFF
--- a/docroot/themes/custom/uids_base/scss/admin.scss
+++ b/docroot/themes/custom/uids_base/scss/admin.scss
@@ -12,6 +12,7 @@ $imgpath: '../../uids/assets/images';
 @import "admin/_grid.scss";
 @import "admin/_paragraphs.scss";
 @import "admin/_claro.scss";
+@import "admin/_local-tasks.scss";
 
 .uiowa-headline--container {
   border: 1px solid #999;

--- a/docroot/themes/custom/uids_base/scss/admin/_local-tasks.scss
+++ b/docroot/themes/custom/uids_base/scss/admin/_local-tasks.scss
@@ -1,12 +1,63 @@
-@import "assets/scss/_variables.scss";
-@import "assets/scss/_utilities.scss";
-@import "assets/scss/_local-fonts.scss";
-$imgpath: '../../uids/assets/images';
+// Tasks
 
 .block-local-tasks-block {
+  .tabs {
+    margin: 0;
+    list-style-type: none;
+    background: $white;
+    @extend %no-ul-list;
+  }
+
+  .tabs::after,
+  .tabs::before {
+    display: table;
+    content: ' ';
+    @include flex($fb: 0);
+    @include order($int: 1);
+  }
+
+  .tabs::after {
+    clear: both;
+  }
+
+  .tabs.vertical > li {
+    display: block;
+    float: none;
+    width: auto;
+  }
+
+  .tab > a.is-active,
+  .tab > a:focus,
+  .tab a[aria-selected=true],
+  .tabs li > a.is-active,
+  .tabs li > a:focus,
+  .tabs li a[aria-selected=true] {
+    color: $blk;
+    background: $primary;
+  }
+
+  .tabs > li > a:hover {
+    background: $grey-light;
+  }
+
+  .tab,
+  .tabs li {
+    float: left;
+  }
+
+  .tab > a,
+  .tabs li > a {
+    display: block;
+    text-decoration: none;
+    color: $blk;
+    line-height: 1;
+    @include padding($top: $md, $right: $lg, $bottom: $md, $left:$lg);
+  }
+
   nav.tabs {
     li {
       border-bottom: 1px solid rgba(0,0,0,.125);
+
       .layout-builder-disabled & {
         @include breakpoint(sm) {
           margin-bottom: $md;
@@ -17,15 +68,17 @@ $imgpath: '../../uids/assets/images';
   }
 }
 
-.tabs>li>a.local-task-icon {
-  &:hover,
-  &:focus {
+.tabs > li > a.local-task-icon {
+  &:focus,
+  &:hover {
     background: #f3f3f3;
     text-decoration: underline;
   }
+
   &.is-active {
     background: none;
     position: relative;
+
     &:after {
       position: absolute;
       bottom: 0;
@@ -42,42 +95,49 @@ $imgpath: '../../uids/assets/images';
   &.local-task-icon--delete {
     color: $danger;
   }
-  &:hover:before,
-  &:focus:before {
+
+  &:focus:before,
+  &:hover:before {
     color: $secondary;
   }
+
   &:before {
     @include fas();
     margin-right: 15px;
     color: $grey;
     font-size: 13px;
   }
+
   &.local-task-icon--view::before {
     content: "\f06e";
   }
+
   &.local-task-icon--edit::before {
     content: "\f044";
   }
+
   &.local-task-icon--delete::before {
     content: "\f2ed";
     color: $danger;
   }
+
   &.local-task-icon--layout::before {
     content: "\f009";
   }
+
   &.local-task-icon--history::before {
     content: "\f1da";
   }
+
   &.local-task-icon--usage::before {
     content: "\f0c1";
   }
+
   &.local-task-icon--devel::before {
     content: "\f121";
   }
+
   &.local-task-icon--replicate::before {
     content: "\f24d";
   }
 }
-
-
-

--- a/docroot/themes/custom/uids_base/scss/admin/_local-tasks.scss
+++ b/docroot/themes/custom/uids_base/scss/admin/_local-tasks.scss
@@ -20,26 +20,6 @@
     clear: both;
   }
 
-  .tabs.vertical > li {
-    display: block;
-    float: none;
-    width: auto;
-  }
-
-  .tab > a.is-active,
-  .tab > a:focus,
-  .tab a[aria-selected=true],
-  .tabs li > a.is-active,
-  .tabs li > a:focus,
-  .tabs li a[aria-selected=true] {
-    color: $blk;
-    background: $primary;
-  }
-
-  .tabs > li > a:hover {
-    background: $grey-light;
-  }
-
   .tab,
   .tabs li {
     float: left;

--- a/docroot/themes/custom/uids_base/scss/components/tabs.scss
+++ b/docroot/themes/custom/uids_base/scss/components/tabs.scss
@@ -1,9 +1,3 @@
 @import "assets/scss/_variables.scss";
 @import "assets/scss/_utilities.scss";
 @import "components/tabs/tabs.scss";
-
-nav.tabs,
-.tabs.primary {
-  //@include margin($lg, 0, $lg, 0);
-  border: none;
-}

--- a/docroot/themes/custom/uids_base/uids_base.libraries.yml
+++ b/docroot/themes/custom/uids_base/uids_base.libraries.yml
@@ -20,7 +20,6 @@ global-styling:
       assets/css/components/pagination.css: {}
       assets/css/components/typography/paragraph.css: {}
       assets/css/components/tables.css: {}
-      assets/css/components/tabs.css: {}
       assets/css/components/form/search.css: {}
       assets/css/components/iowa-bar.css: {}
       assets/css/components/footer.css: {}
@@ -345,7 +344,6 @@ admin:
   css:
     component:
       assets/css/admin.css: { weight: 200 }
-      assets/css/local-tasks.css: {}
       assets/css/components/badge.css: {}
 sftouchscreen:
   js:


### PR DESCRIPTION
In order to proceed with https://github.com/uiowa/uiowa/issues/4759 or even a new UIDS release, we need to move the old `tabs.scss` styling into the `local-tasks.scss` file in `uids_base`.  Without this CSS our local tasks tabs are not styled.  This pr moves the deleted `tabs.scss` styles from UIDS into the local tasks admin file. 

# How to test

`blt frontend` and `drush cr` a site and look at the local edit tabs on a site and verify that they are still styled like the screenshot below.


<img width="1345" alt="Screen Shot 2022-03-02 at 2 19 43 PM" src="https://user-images.githubusercontent.com/1036433/156443130-cfbb2b93-5085-44b9-95bd-2cbe1ef39716.png">

