### PR TITLE
hotfix: add sitenow_pages.schema.yml

### DIFF
--- a/docroot/modules/custom/sitenow_pages/config/schema/sitenow_pages.schema.yml
+++ b/docroot/modules/custom/sitenow_pages/config/schema/sitenow_pages.schema.yml
@@ -1,6 +1,6 @@
-sitenow_people.settings:
+sitenow_pages.settings:
   type: config_object
-  label: 'SiteNow People settings'
+  label: 'SiteNow Pages settings'
   mapping:
     featured_image_display_default:
       type: string


### PR DESCRIPTION
There was a [misnamed file](https://github.com/uiowa/uiowa/blob/main/docroot/modules/custom/sitenow_pages/config/schema/sitenow_people.schema.yml) in sitenow_pages' module folder with incorrect yml keys/values, this should be fixed with this PR.