### PR TITLE
Hotfix: Added missing class to topics_page view

### DIFF
--- a/config/features/topic_page/views.view.topic_page_browse_by_tag.yml
+++ b/config/features/topic_page/views.view.topic_page_browse_by_tag.yml
@@ -418,7 +418,7 @@ display:
           entity_type: taxonomy_term
           plugin_id: entity_reverse
           required: true
-      css_class: 'tags-list__related col--threecol--33'
+      css_class: 'related col--threecol--33'
       group_by: false
       display_description: ''
       display_extenders:


### PR DESCRIPTION
This is a hotfix for the recent tags deployment. 

# How to test

- Code review or `blt ds --site=basicneeds.uiowa.edu` and go to home page and verify that "Browse by tag" section appears in a three column grid.  Compare against https://basicneeds.uiowa.edu/. 