### PR TITLE
Hotfix for BLT inspector change and refactor UME to only notify on error.

### DIFF
--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -21,12 +21,15 @@ use GuzzleHttp\Exception\ClientException;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Yaml\Yaml;
+use Uiowa\InspectorTrait;
 use Uiowa\Multisite;
 
 /**
  * Global multisite commands.
  */
 class MultisiteCommands extends BltTasks {
+
+  use InspectorTrait;
 
   /**
    * A no-op command.
@@ -161,7 +164,7 @@ class MultisiteCommands extends BltTasks {
         continue;
       }
 
-      if (!$this->getInspector()->isDrupalInstalled()) {
+      if (!$this->isDrupalInstalled($multisite)) {
         $uninstalled[] = $multisite;
       }
     }

--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -1032,19 +1032,20 @@ EOD;
     $webhook_url = getenv('SLACK_WEBHOOK_URL');
 
     if ($webhook_url && $env == 'prod' || $env == 'local') {
-      $payload = [
+      $data = [
         'username' => 'Acquia Cloud',
         'text' => $message,
-        'icon_emoji' => ':acquia:',
       ];
 
-      $data = "payload=" . json_encode($payload);
-      $ch = curl_init($webhook_url);
-      curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
-      curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
-      curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
-      curl_exec($ch);
-      curl_close($ch);
+      $client = new GuzzleClient();
+
+      try {
+        $client->post($webhook_url, [
+          'body' => json_encode($data),
+        ]);
+      } catch (ClientException $e) {
+        $this->logger->warning('Error attempting to send Slack notification: ' . $e->getMessage());
+      }
     }
     else {
       $this->logger->warning("Slack webhook URL not configured. Cannot send message: {$message}");

--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -1046,7 +1046,8 @@ EOD;
         $client->post($webhook_url, [
           'body' => json_encode($data),
         ]);
-      } catch (ClientException $e) {
+      }
+      catch (ClientException $e) {
         $this->logger->warning('Error attempting to send Slack notification: ' . $e->getMessage());
       }
     }

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -42,7 +42,7 @@ class ReplaceCommands extends BltTasks {
         continue;
       }
       else {
-        if ($this->getInspector()->isDrupalInstalled()) {
+        if ($this->isDrupalInstalled($multisite)) {
           $this->logger->info("Deploying updates to <comment>{$multisite}</comment>...");
 
           // Invalidate the Twig cache if on AH env. This happens automatically
@@ -284,6 +284,18 @@ EOD;
       $chromeDriverPort = $this->getConfigValue('tests.chromedriver.port');
       $this->getContainer()->get('executor')->killProcessByPort($chromeDriverPort);
     }
+  }
+
+  /**
+   * Determine if Drupal is installed via a SQL query.
+   *
+   * @return bool
+   *   Whether drupal is installed.
+   */
+  protected function isDrupalInstalled($uri): bool {
+    $result = $this->getContainer()->get('executor')->drush("sqlq --uri=$uri \"SHOW TABLES LIKE 'config'\"")->run();
+    $output = trim($result->getMessage());
+    return $result->wasSuccessful() && $output == 'config';
   }
 
 }

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -289,6 +289,12 @@ EOD;
   /**
    * Determine if Drupal is installed via a SQL query.
    *
+   * We were relying on BLT Inspector::isDrupalInstalled() but a change in
+   * that method started relying on Drush status to determine this. This
+   * is problematic because errors can prevent Drush status from completing.
+   *
+   * @see https://github.com/acquia/blt/pull/4049
+   *
    * @return bool
    *   Whether drupal is installed.
    */

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -6,11 +6,13 @@ use Acquia\Blt\Robo\BltTasks;
 use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Acquia\Blt\Robo\Common\YamlMunge;
 use Acquia\Blt\Robo\Exceptions\BltException;
+use Uiowa\InspectorTrait;
 
 /**
  * BLT override commands.
  */
 class ReplaceCommands extends BltTasks {
+  use InspectorTrait;
 
   /**
    * Replace the artifact:update:drupal:all-sites BLT command.
@@ -284,24 +286,6 @@ EOD;
       $chromeDriverPort = $this->getConfigValue('tests.chromedriver.port');
       $this->getContainer()->get('executor')->killProcessByPort($chromeDriverPort);
     }
-  }
-
-  /**
-   * Determine if Drupal is installed via a SQL query.
-   *
-   * We were relying on BLT Inspector::isDrupalInstalled() but a change in
-   * that method started relying on Drush status to determine this. This
-   * is problematic because errors can prevent Drush status from completing.
-   *
-   * @see https://github.com/acquia/blt/pull/4049
-   *
-   * @return bool
-   *   Whether drupal is installed.
-   */
-  protected function isDrupalInstalled($uri): bool {
-    $result = $this->getContainer()->get('executor')->drush("sqlq --uri=$uri \"SHOW TABLES LIKE 'config'\"")->run();
-    $output = trim($result->getMessage());
-    return $result->wasSuccessful() && $output == 'config';
   }
 
 }

--- a/blt/src/InspectorTrait.php
+++ b/blt/src/InspectorTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Uiowa;
+
+trait InspectorTrait {
+  /**
+   * Determine if Drupal is installed via a SQL query.
+   *
+   * We were relying on BLT Inspector::isDrupalInstalled() but a change in
+   * that method started relying on Drush status to determine this. This
+   * is problematic because errors can prevent Drush status from completing.
+   *
+   * @see https://github.com/acquia/blt/pull/4049
+   *
+   * @return bool
+   *   Whether drupal is installed.
+   */
+  protected function isDrupalInstalled($uri): bool {
+    $result = $this->getContainer()->get('executor')->drush("sqlq --uri=$uri \"SHOW TABLES LIKE 'config'\"")->run();
+    $output = trim($result->getMessage());
+    return $result->wasSuccessful() && $output == 'config';
+  }
+}

--- a/blt/src/InspectorTrait.php
+++ b/blt/src/InspectorTrait.php
@@ -2,7 +2,11 @@
 
 namespace Uiowa;
 
+/**
+ * Temporary trait to roll our own inspector methods.
+ */
 trait InspectorTrait {
+
   /**
    * Determine if Drupal is installed via a SQL query.
    *
@@ -20,4 +24,5 @@ trait InspectorTrait {
     $output = trim($result->getMessage());
     return $result->wasSuccessful() && $output == 'config';
   }
+
 }


### PR DESCRIPTION
Resolves #4930 
Resolves #4929 

# How to test

On main, sync these sites:
```
multisites:
  - default
  - admissions.uiowa.edu
  - brand.uiowa.edu
```

Drop admissions, i.e. replicate a uninstalled site:
`ddev drush @admissions.local sql:drop`

Create an error in brand - add a bogus `$foo` argument to `brand.uiowa.edu/modules/brand_core/src/Commands/BrandCoreCommands` constructor:
```
  public function __construct(AccountSwitcherInterface $accountSwitcher, DateFormatterInterface $dateFormatter, MailManagerInterface $mailManager, ConfigFactoryInterface $configFactory, $foo) {
...
```

Run `ddev blt umi` and see that `brand.uiowa.edu` is reported as being uninstalled when actually an error is preventing BLT inspector from running Drush status.

Check out this branch and run `ddev blt umi` again. See that brand.uiowa.edu is not reported since our method uses a SQL query.

Checkout main again and run `ddev blt auda -v`. See that the `drupal:update` process is only triggered on the default site even though `brand.uiowa.edu` is installed. Check out this branch and re-run. The `drupal:update` process should be triggered on default and brand.uiowa.edu, not admissions, and the error regading `$foo` is thrown. We want this to happen so sites throwing errors in AC get an update hook to run.


#### Cron
From the previous steps, i.e. on this branch with the `$foo` error:

- DM me for a Slack webhook URL.
- ddev ssh
- export SLACK_WEBHOOK_URL=xxx
- blt ume status

See that no start/stop messages are posted to Slack but rather an error message is posted for brand site. Fix `$foo` error and re-run in same terminal session. See that no Slack messages are posted.

## Post-deploy tasks
- [x] Update [AC variable](https://docs.acquia.com/cloud-platform/manage/variables/) to new webhook URL