### PR TITLE
exclude Topic Collection content type from related views

### DIFF
--- a/config/features/topic_page/config_split.patch.views.view.related_content.yml
+++ b/config/features/topic_page/config_split.patch.views.view.related_content.yml
@@ -1,0 +1,51 @@
+adding:
+  dependencies:
+    config:
+      - node.type.topic_collection
+  display:
+    block_related_headings_lists:
+      display_options:
+        filters:
+          type:
+            id: type
+            table: node_field_data
+            field: type
+            relationship: nid
+            group_type: group
+            admin_label: ''
+            entity_type: node
+            entity_field: type
+            plugin_id: bundle
+            operator: 'not in'
+            value:
+              topic_collection: topic_collection
+            group: 1
+            exposed: false
+            expose:
+              operator_id: ''
+              label: ''
+              description: ''
+              use_operator: false
+              operator: ''
+              operator_limit_selection: false
+              operator_list: {  }
+              identifier: ''
+              required: false
+              remember: false
+              multiple: false
+              remember_roles:
+                authenticated: authenticated
+              reduce: false
+            is_grouped: false
+            group_info:
+              label: ''
+              description: ''
+              identifier: ''
+              optional: true
+              widget: select
+              multiple: false
+              remember: false
+              default_group: All
+              default_group_multiple: {  }
+              group_items: {  }
+removing: {  }


### PR DESCRIPTION
See: https://github.com/uiowa/uiowa/issues/4932

# How to test

1. Check out this branch
2. `blt ds --site=basicneeds.uiowa.edu`
3. Click into an individual page from the homepage (Topic Collection)
4. Check for "Find Resources" in related content
5. If there's no "Find Resources" page in related content, then this worked. 

