### PR TITLE
Hotfix: Fix for nav color within white or gray backgrounds

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/menus/main-menu.scss
+++ b/docroot/themes/custom/uids_base/scss/components/menus/main-menu.scss
@@ -9,6 +9,19 @@
   }
 }
 
+[class*="bg--white"],
+[class*="bg--gray"] {
+  .menu-wrapper--horizontal {
+    .menu {
+      li {
+        a {
+          color: $secondary;
+        }
+      }
+    }
+  }
+}
+
 
 // set horizontal only if used in layout--onecol section.
 // @todo remove once https://github.com/GoogleChromeLabs/container-query-polyfill/issues/23 is resolved.

--- a/docroot/themes/custom/uids_base/scss/components/menus/main-menu.scss
+++ b/docroot/themes/custom/uids_base/scss/components/menus/main-menu.scss
@@ -9,6 +9,7 @@
   }
 }
 
+// @todo move back to UIDS. 
 [class*="bg--white"],
 [class*="bg--gray"] {
   .menu-wrapper--horizontal {


### PR DESCRIPTION
`blt frontend`
`blt ds --site=uiowa.edu`
Go to https://uiowa.edu/academics and verify that link color is black and not blue. 