### PR TITLE
Grad Admissions - added title search to aos view

### DIFF
--- a/config/sites/grad.admissions.uiowa.edu/views.view.areas_of_study.yml
+++ b/config/sites/grad.admissions.uiowa.edu/views.view.areas_of_study.yml
@@ -268,6 +268,53 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: reverse__node__field_area_of_study_area
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Search
+            description: ''
+            use_operator: false
+            operator: title_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              viewer: '0'
+              editor: '0'
+              publisher: '0'
+              webmaster: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         field_area_of_study_degree_types_target_id:
           id: field_area_of_study_degree_types_target_id
           table: node__field_area_of_study_degree_types


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/4926
## To Test

- Sync grad.admissions
- Try the following search boxes: 
  - https://admissionsgrad.uiowa.ddev.site
  - https://admissionsgrad.uiowa.ddev.site/academics
  - https://admissionsgrad.uiowa.ddev.site/new-students
- They should all take you to /areas-of-study and fill in the search filter with your value. That value should then provide results based on your query.
- Searching for `bio` should return results for both `Biochemical Engineering` and `Chemical & Biochemical Engineering`