### PR TITLE
admissions - re-export with person status field placed

### DIFF
--- a/config/sites/admissions.uiowa.edu/config_split.patch.core.entity_form_display.node.person.default.yml
+++ b/config/sites/admissions.uiowa.edu/config_split.patch.core.entity_form_display.node.person.default.yml
@@ -4,80 +4,69 @@ adding:
       - field.field.node.person.field_person_territory
   content:
     created:
-      weight: 15
-    field_image:
-      weight: 4
+      weight: 16
     field_meta_tags:
-      weight: 24
+      weight: 26
+      settings:
+        use_details: true
     field_person_bio:
-      weight: 10
-    field_person_contact_information:
-      weight: 25
-    field_person_credential:
-      weight: 3
-    field_person_education:
       weight: 11
+    field_person_contact_information:
+      weight: 27
+    field_person_education:
+      weight: 12
     field_person_email:
-      weight: 8
+      weight: 9
     field_person_hide:
-      weight: 24
+      weight: 25
     field_person_hometown:
       type: string_textfield
-      weight: 6
+      weight: 7
       region: content
       settings:
         size: 60
         placeholder: ''
       third_party_settings: {  }
     field_person_phone:
-      weight: 9
-    field_person_position:
-      weight: 5
+      weight: 10
     field_person_research_areas:
-      weight: 12
+      weight: 13
     field_person_territory:
       type: options_select
-      weight: 7
+      weight: 8
       region: content
       settings: {  }
       third_party_settings: {  }
     field_person_website:
-      weight: 13
-    field_tags:
-      weight: 16
-    field_teaser:
-      weight: 23
-    moderation_state:
-      weight: 22
-    path:
-      weight: 19
-    promote:
-      weight: 17
-    status:
-      weight: 21
-    sticky:
-      weight: 18
-    uid:
       weight: 14
-    url_redirects:
+    field_tags:
+      weight: 17
+    field_teaser:
+      weight: 24
+    moderation_state:
+      weight: 23
+    path:
       weight: 20
+    promote:
+      weight: 18
+    status:
+      weight: 22
+    sticky:
+      weight: 19
+    uid:
+      weight: 15
+    url_redirects:
+      weight: 21
 removing:
-  dependencies:
-    config:
-      - field.field.node.person.field_person_type_status
   content:
     created:
       weight: 14
-    field_image:
-      weight: 5
     field_meta_tags:
       weight: 25
     field_person_bio:
       weight: 9
     field_person_contact_information:
       weight: 24
-    field_person_credential:
-      weight: 4
     field_person_education:
       weight: 10
     field_person_email:
@@ -86,16 +75,8 @@ removing:
       weight: 23
     field_person_phone:
       weight: 8
-    field_person_position:
-      weight: 6
     field_person_research_areas:
       weight: 11
-    field_person_type_status:
-      type: options_buttons
-      weight: 3
-      region: content
-      settings: {  }
-      third_party_settings: {  }
     field_person_website:
       weight: 12
     field_tags:


### PR DESCRIPTION
Admissions never got the person status field and it is now having issues since the field_tags change on the form.

# To Test
Sync admissions.uiowa.edu, no errors