### PR TITLE
Profiles meta

### DIFF
--- a/docroot/modules/custom/uiowa_profiles/js/uiowa-profiles.js
+++ b/docroot/modules/custom/uiowa_profiles/js/uiowa-profiles.js
@@ -11,7 +11,8 @@ uiProfiles = { basePath: drupalSettings.uiowaProfiles.basePath };
 
   Drupal.uiowaProfiles = {};
 
-  Drupal.uiowaProfiles.updateCanonical = function (settings, url) {
+  // Updates the canonical link for a person and the metadata descriptions for profiles.
+  Drupal.uiowaProfiles.updateSEOData = function (settings, url) {
     url = new URL(url);
     let path = url.pathname;
 
@@ -20,13 +21,16 @@ uiProfiles = { basePath: drupalSettings.uiowaProfiles.basePath };
       path = path.substr(0, path.length - 1);
     }
 
+    // Grab the canonical link element.
     let link = document.head.querySelector('link[rel="canonical"]');
+
+    // Grab the meta description element.
     let meta_description = document.head.querySelector('meta[name="description"]');
 
     // We only need to set the canonical link on individual profile pages.
     if (path !== settings.uiowaProfiles.basePath) {
-      meta_description = document.head.querySelector('meta[name="description"]');
 
+      // Split in to an array the pieces of the path that are not empty.
       let parts = path.split('/').filter(function (el) {
         return el !== '';
       });
@@ -36,33 +40,46 @@ uiProfiles = { basePath: drupalSettings.uiowaProfiles.basePath };
 
       // Get the environment from the settings.
       let environment = drupalSettings.uiowaProfiles.environment;
+
       // Set the endpoint to either the test or prod versions of the api based on environment.
       let endpoint = 'https://profiles' + (environment === 'test' ? '-test' : '') + '.uiowa.edu/api/people/';
+
       // Set query parameters, in this case the api key gotten from settings.
       let params = 'api-key=' + drupalSettings.uiowaProfiles.api_key;
+
       // Concatenate all relevant pieces together to create an api call url.
       let url = endpoint + person + '/metadata?' + params;
 
       // Create a new XMLHttpRequest() with our api call url.
       const request = new XMLHttpRequest();
       request.open("GET", url);
+
       // On loading of the request...
       request.onload = ()=>{
+
         // If the request is a success...
         if (request.status === 200) {
+
           // Parse the response in to readable JSON.
           let response = JSON.parse(request.response);
+
           // Grab the canonical URL from the response.
           let canonical = response.canonical_url;
-          // console.log(response);
 
           // Construct the `meta_description_markup` using the response data.
           let meta_description_markup = this.personMetaElement(response.name, response.directoryTitle);
 
+          // If the meta description exists...
           if (meta_description !== null) {
+
+            // Replace it with the newly constructed `meta_description_markup`.
             meta_description.parentNode.replaceChild(meta_description_markup, meta_description);
           }
+
+          // Else if the meta description does not exist...
           else {
+
+            // Append the `meta_description_markup` at the end of the `head` element.
             document.querySelector('head').appendChild(meta_description_markup);
           }
 
@@ -71,6 +88,7 @@ uiProfiles = { basePath: drupalSettings.uiowaProfiles.basePath };
         }
         // If the request fails...
         else {
+
           // Log the error code.
           console.log(`error ${request.status}`);
         }
@@ -80,31 +98,41 @@ uiProfiles = { basePath: drupalSettings.uiowaProfiles.basePath };
 
     // Else if this is not an individual profile page...
     else {
-      meta_description = document.head.querySelector('meta[name="description"]');
-      let directory_title = drupalSettings.uiowaProfiles.directoryTitle;
+
+      // Grab some data from `drupalSettings` and make the `directory_meta_description` from it,
       let site_name = drupalSettings.uiowaProfiles.siteName;
+      let directory_title = drupalSettings.uiowaProfiles.directoryTitle;
       let directory_meta_description = this.directoryMetaElement(site_name, directory_title);
 
       // Get the original url for the directory.
       let original = url.toString();
 
-      // Strip any queries.
+      // Strip any queries or hash parameters.
       if (url.search) {
-        original = original.toString().split('?')[0];
+        original = original.split('?')[0].split('#')[0];
       }
 
       // And reset the canonical back to it.
       link.setAttribute('href', original);
 
+      // If the meta description exists...
       if (meta_description !== null) {
+
+        // Replace it with the newly constructed `directory_meta_description`.
         meta_description.parentNode.replaceChild(directory_meta_description, meta_description);
       }
+
+      // Else if the meta description does not exist...
       else {
+
+        // Append the `directory_meta_description` at the end of the `head` element.
         document.querySelector('head').appendChild(directory_meta_description);
       }
     }
   }
 
+  // This function creates a meta element for an individual person.
+  // It takes two strings, `name` and `directoryTitle` and returns a fully constructed meta element.
   Drupal.uiowaProfiles.personMetaElement = function (name, directoryTitle) {
     let element = document.createElement('meta');
     element.name = 'description';
@@ -112,6 +140,8 @@ uiProfiles = { basePath: drupalSettings.uiowaProfiles.basePath };
     return element;
   }
 
+  // This function creates a meta element for a directory listing.
+  // It takes two strings, `siteName` and `directoryTitle` and returns a fully constructed meta element.
   Drupal.uiowaProfiles.directoryMetaElement = function (siteName, directoryTitle) {
     let element = document.createElement('meta');
     element.name = 'description';
@@ -125,11 +155,11 @@ uiProfiles = { basePath: drupalSettings.uiowaProfiles.basePath };
   Drupal.behaviors.uiowaProfiles = {
     attach: function (context, settings) {
       $(document, context).once('uiowaProfiles').each(function() {
-        Drupal.uiowaProfiles.updateCanonical(settings, document.URL);
+        Drupal.uiowaProfiles.updateSEOData(settings, document.URL);
 
         const root = document.getElementById('profiles-root');
         const observer = new MutationObserver(function() {
-          Drupal.uiowaProfiles.updateCanonical(settings, document.URL);
+          Drupal.uiowaProfiles.updateSEOData(settings, document.URL);
         });
 
         observer.observe(root, {

--- a/docroot/modules/custom/uiowa_profiles/js/uiowa-profiles.js
+++ b/docroot/modules/custom/uiowa_profiles/js/uiowa-profiles.js
@@ -21,9 +21,12 @@ uiProfiles = { basePath: drupalSettings.uiowaProfiles.basePath };
     }
 
     let link = document.head.querySelector('link[rel="canonical"]');
+    let meta_description = document.head.querySelector('meta[name="description"]');
 
     // We only need to set the canonical link on individual profile pages.
     if (path !== settings.uiowaProfiles.basePath) {
+      meta_description = document.head.querySelector('meta[name="description"]');
+
       let parts = path.split('/').filter(function (el) {
         return el !== '';
       });
@@ -51,6 +54,18 @@ uiProfiles = { basePath: drupalSettings.uiowaProfiles.basePath };
           let response = JSON.parse(request.response);
           // Grab the canonical URL from the response.
           let canonical = response.canonical_url;
+          // console.log(response);
+
+          // Construct the `meta_description_markup` using the response data.
+          let meta_description_markup = this.personMetaElement(response.name, response.directoryTitle);
+
+          if (meta_description !== null) {
+            meta_description.parentNode.replaceChild(meta_description_markup, meta_description);
+          }
+          else {
+            document.querySelector('head').appendChild(meta_description_markup);
+          }
+
           // And set the canonical URL in the head.
           link.setAttribute('href', canonical);
         }
@@ -62,8 +77,13 @@ uiProfiles = { basePath: drupalSettings.uiowaProfiles.basePath };
       }
       request.send();
     }
+
     // Else if this is not an individual profile page...
     else {
+      meta_description = document.head.querySelector('meta[name="description"]');
+      let directory_title = drupalSettings.uiowaProfiles.directoryTitle;
+      let site_name = drupalSettings.uiowaProfiles.siteName;
+      let directory_meta_description = this.directoryMetaElement(site_name, directory_title);
 
       // Get the original url for the directory.
       let original = url.toString();
@@ -75,7 +95,28 @@ uiProfiles = { basePath: drupalSettings.uiowaProfiles.basePath };
 
       // And reset the canonical back to it.
       link.setAttribute('href', original);
+
+      if (meta_description !== null) {
+        meta_description.parentNode.replaceChild(directory_meta_description, meta_description);
+      }
+      else {
+        document.querySelector('head').appendChild(directory_meta_description);
+      }
     }
+  }
+
+  Drupal.uiowaProfiles.personMetaElement = function (name, directoryTitle) {
+    let element = document.createElement('meta');
+    element.name = 'description';
+    element.content = name + ' - ' + directoryTitle + ' - The University of Iowa';
+    return element;
+  }
+
+  Drupal.uiowaProfiles.directoryMetaElement = function (siteName, directoryTitle) {
+    let element = document.createElement('meta');
+    element.name = 'description';
+    element.content = siteName + ' - ' + directoryTitle;
+    return element;
   }
 
   /**

--- a/docroot/modules/custom/uiowa_profiles/js/uiowa-profiles.js
+++ b/docroot/modules/custom/uiowa_profiles/js/uiowa-profiles.js
@@ -24,9 +24,6 @@ uiProfiles = { basePath: drupalSettings.uiowaProfiles.basePath };
     // Grab the canonical link element.
     let link = document.head.querySelector('link[rel="canonical"]');
 
-    // Grab the meta description element.
-    let meta_description = document.head.querySelector('meta[name="description"]');
-
     // We only need to set the canonical link on individual profile pages.
     if (path !== settings.uiowaProfiles.basePath) {
 
@@ -68,6 +65,9 @@ uiProfiles = { basePath: drupalSettings.uiowaProfiles.basePath };
 
           // Construct the `meta_description_markup` using the response data.
           let meta_description_markup = this.personMetaElement(response.name, response.directoryTitle);
+
+          // Grab the meta description element.
+          let meta_description = document.head.querySelector('meta[name="description"]');
 
           // If the meta description exists...
           if (meta_description !== null) {
@@ -114,6 +114,9 @@ uiProfiles = { basePath: drupalSettings.uiowaProfiles.basePath };
 
       // And reset the canonical back to it.
       link.setAttribute('href', original);
+
+      // Grab the meta description element.
+      let meta_description = document.head.querySelector('meta[name="description"]');
 
       // If the meta description exists...
       if (meta_description !== null) {

--- a/docroot/modules/custom/uiowa_profiles/src/Controller/DirectoryController.php
+++ b/docroot/modules/custom/uiowa_profiles/src/Controller/DirectoryController.php
@@ -112,6 +112,8 @@ class DirectoryController extends ControllerBase {
             'basePath' => Html::escape($directory['path']),
             'api_key' => Html::escape($directory['api_key']),
             'environment' => $this->profiles->environment,
+            'siteName' => \Drupal::config('system.site')->get('name'),
+            'directoryTitle' => Html::escape($directory['title']),
           ],
         ],
       ],


### PR DESCRIPTION
tracks https://github.com/uiowa/uiowa/issues/4889

## To test
- Pull down education.uiowa.edu.
- Go to the profiles directory config page.
- [Change the API key to this one.](https://iowaweb.slack.com/archives/C0164FNN1PV/p1647377146635319?thread_ts=1647377129.307609&cid=C0164FNN1PV)
- navigate to `/directory`.
- Check that there is a `meta` element in the `head` element that has `name="description"` that describes the directory.
  - It should look something like `<meta name="description" content="College of Education - People.">`.
- Click on an individual person.
- Check that there is a `meta` element in the `head` element that has `name="description"` that describes that person.
  - It should look something like `<meta name="description" content="John G. Achrazoglou - Clinical Associate Professor - The University of Iowa" />`.
- Try and break things!
- Report breakages here!