### PR TITLE
exclude topic collection from the count in browse by tag

### DIFF
--- a/config/features/topic_page/views.view.topic_page_browse_by_tag.yml
+++ b/config/features/topic_page/views.view.topic_page_browse_by_tag.yml
@@ -2,6 +2,8 @@ uuid: c778cc6e-65f7-4c01-94c1-b203b2114730
 langcode: en
 status: true
 dependencies:
+  config:
+    - node.type.topic_collection
   module:
     - node
     - taxonomy
@@ -675,6 +677,66 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
+      filters:
+        status:
+          id: status
+          table: taxonomy_term_field_data
+          field: status
+          entity_type: taxonomy_term
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: nid
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: 'not in'
+          value:
+            topic_collection: topic_collection
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: default
         options:
@@ -698,6 +760,8 @@ display:
         relationships: false
         fields: false
         arguments: false
+        filters: false
+        filter_groups: false
       relationships:
         nid:
           id: nid


### PR DESCRIPTION
Resolves: #4997 

# How to test

1. Check out this branch
2. Pull down basicneeds.uiowa.edu via `blt ds`
3. Check the homepage to see if the counts in parenthesis are accurate when you click into a taxonomy term. 

What should happen:

Example: This count is (1) and you should only see one result when clicking in:

<img width="354" alt="Screen Shot 2022-03-22 at 4 11 49 PM" src="https://user-images.githubusercontent.com/472923/159576787-ee0aae94-1fd7-4ac2-b4ea-4648ba43756e.png">

Currently on the live site, Education has (2) next to it when it should be one:

https://basicneeds.uiowa.edu


