### PR TITLE
Hotfix: partial split logger channel config and disable errors and warnings in local env.

### DIFF
--- a/config/default/config_split.config_split.local.yml
+++ b/config/default/config_split.config_split.local.yml
@@ -19,4 +19,5 @@ module:
 theme: {  }
 complete_list:
   - stage_file_proxy.settings
-partial_list: {  }
+partial_list:
+  - purge.logger_channels

--- a/config/envs/local/config_split.patch.purge.logger_channels.yml
+++ b/config/envs/local/config_split.patch.purge.logger_channels.yml
@@ -1,0 +1,18 @@
+adding:
+  channels:
+    -
+      id: diagnostics
+      grants:
+        - 0
+        - 1
+        - 2
+removing:
+  channels:
+    -
+      id: diagnostics
+      grants:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4


### PR DESCRIPTION
Seems like after #4942, errors and warnings started printing on the CLI when running any Drush commands locally. This is because we don't have any purge integration locally (yet). This makes it hard to parse console output. 

This PR disables logging diagnostic errors and warnings in the local environment split.

# How to test

- On `main`, run `ddev drush status`.
- See purge errors.
- Check out this branch.
- Import config with `ddev drush cim`.
- Clear cache with `ddev drush cr`
- Run `ddev drush status` again.
- See no purge errors.
