### PR TITLE
adding date updated to PDFs

### DIFF
--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/pdf.scss
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/pdf.scss
@@ -263,6 +263,16 @@ h6 {
   }
 }
 
+.print__contact--last-updated {
+  position: absolute;
+  right: 0;
+  bottom: -5px;
+  font-size: 8px;
+  font-family: $font-family-caps;
+  text-transform: uppercase;
+  letter-spacing: .3px;
+}
+
 .view-areas-of-study-kiosk .views-row {
   page-break-before: always;
 }

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/node--area-of-study--pdf.html.twig
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/node--area-of-study--pdf.html.twig
@@ -149,7 +149,7 @@
         <span class="print__contact--web"><img src="/sites/admissions.uiowa.edu/modules/admissions_core/assets/images/arrow-gray.png" width="11" height="10" /> admissions.uiowa.edu{{ url }}</span>
         <span class="print__contact--phone"><img src="/sites/admissions.uiowa.edu/modules/admissions_core/assets/images/phone-gray.png" width="11" height="10" /> 319-335-3847</span>
         <span class="print__contact--email"><img src="/sites/admissions.uiowa.edu/modules/admissions_core/assets/images/envelope-gray.png" width="11" height="10" /> admissions@uiowa.edu</span>
-        <span class="print__contact--last-updated"> updated {{ node.getChangedTime()|date('d/m/Y') }}</span>
+        <span class="print__contact--last-updated"> updated {{ node.getChangedTime()|date('m/d/Y') }}</span>
     </p>
     </div>
 

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/node--area-of-study--pdf.html.twig
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/node--area-of-study--pdf.html.twig
@@ -149,13 +149,13 @@
         <span class="print__contact--web"><img src="/sites/admissions.uiowa.edu/modules/admissions_core/assets/images/arrow-gray.png" width="11" height="10" /> admissions.uiowa.edu{{ url }}</span>
         <span class="print__contact--phone"><img src="/sites/admissions.uiowa.edu/modules/admissions_core/assets/images/phone-gray.png" width="11" height="10" /> 319-335-3847</span>
         <span class="print__contact--email"><img src="/sites/admissions.uiowa.edu/modules/admissions_core/assets/images/envelope-gray.png" width="11" height="10" /> admissions@uiowa.edu</span>
-        <span class="print__contact--last-updated"> updated {{ node.getChangedTime()|date('m/d/Y') }}</span>
     </p>
     </div>
 
     <div class="print__contact--statement">
       <p><small>The University of Iowa prohibits discrimination in employment, educational programs, and activities on the basis of race, creed, color, religion, national origin, age, sex, pregnancy, disability, genetic information, status as a U.S. veteran, service in the U.S. military, sexual orientation, gender identity, associational preferences, or any other classification that deprives the person of consideration as an individual. The university also affirms its commitment to providing equal opportunities and equal access to university facilities. For additional information on nondiscrimination policies, contact the Director, Office of Equal Opportunity and Diversity, the University of Iowa, 202 Jessup Hall, Iowa City, IA, 52242-1316, 319-335-0705 (voice), 319-335-0697 (TDD), diversity@uiowa.edu.</small></p>
     </div>
+   <span class="print__contact--last-updated"> updated {{ node.getChangedTime()|date('m/d/Y') }}</span>
 
    {# PDF Second Page #}
 

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/node--area-of-study--pdf.html.twig
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/node--area-of-study--pdf.html.twig
@@ -149,6 +149,7 @@
         <span class="print__contact--web"><img src="/sites/admissions.uiowa.edu/modules/admissions_core/assets/images/arrow-gray.png" width="11" height="10" /> admissions.uiowa.edu{{ url }}</span>
         <span class="print__contact--phone"><img src="/sites/admissions.uiowa.edu/modules/admissions_core/assets/images/phone-gray.png" width="11" height="10" /> 319-335-3847</span>
         <span class="print__contact--email"><img src="/sites/admissions.uiowa.edu/modules/admissions_core/assets/images/envelope-gray.png" width="11" height="10" /> admissions@uiowa.edu</span>
+        <span class="print__contact--last-updated"> updated {{ node.getChangedTime()|date('d/m/Y') }}</span>
     </p>
     </div>
 


### PR DESCRIPTION
Adding date updated to the PDFs of areas of study
closes #4990 

## To test

sync down admissions
go to /kiosk
print a pdf page
check if it has a last updated at the bottom
make sure that is that same date as it is on the edit page for that area of study