### PR TITLE
Removed unused code in text area template.

### DIFF
--- a/docroot/themes/custom/uids_base/templates/block/block--inline-block--uiowa-text-area.html.twig
+++ b/docroot/themes/custom/uids_base/templates/block/block--inline-block--uiowa-text-area.html.twig
@@ -27,11 +27,11 @@
 #}
 {%
   set classes = [
-    'block',
-    'block-' ~ configuration.provider|clean_class,
-    'block-' ~ plugin_id|clean_class,
-    'uids-content',
-  ]
+  'block',
+  'block-' ~ configuration.provider|clean_class,
+  'block-' ~ plugin_id|clean_class,
+  'uids-content',
+]
 %}
 
 {% set rendered_content = content|render %}
@@ -40,18 +40,6 @@
 <div{{ attributes.addClass(classes) }}>
   {{ title_prefix }}
   {{ title_suffix }}
-
-  {% block heading %}
-  {% if content.field_uiowa_text_area_title[0]['#text'] is not empty %}
-    <div class="cta__title">
-    {% include '@uids_base/uids/headline.html.twig' with {
-      "headline_level" : content.field_uiowa_text_area_title[0]['#size'],
-      "headline_class" : 'headline headline--upppercase',
-      "headline_text" : content.field_uiowa_text_area_title[0]['#text']
-    } %}
-    </div>
-  {% endif %}
-{% endblock %}
 
   {% block content %}
     {{ content }}


### PR DESCRIPTION
I noticed while looking into how headlines are themed that this section of code was not being used in the text area block template. It was referencing a field name that is not in use on that block type.

# How to test

Code review or other testing to confirm the headline still shows.
