### PR TITLE
Feature: Updated banner pre-title font weight

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/banner.scss
+++ b/docroot/themes/custom/uids_base/scss/components/banner.scss
@@ -243,3 +243,6 @@
   }
 }
 
+.banner__pre-title {
+  font-weight: 500;
+}


### PR DESCRIPTION
This is a quick fix to update the banner pre-title font weight to 500 instead of 700. 

# How to test

Code review is fine. 