### PR TITLE
Update Admissions kiosk print button text

### DIFF
--- a/config/sites/admissions.uiowa.edu/views.view.areas_of_study_kiosk.yml
+++ b/config/sites/admissions.uiowa.edu/views.view.areas_of_study_kiosk.yml
@@ -1205,7 +1205,7 @@ display:
           plugin_id: text
           empty: false
           content:
-            value: "<p class=\"element--light-intro\">Iowa offers over 200 majors, minors, and certificates.</p>\r\n<p>Students are encouraged to work across disciplines to find their passion. If you are unsure of what you’d like to study at Iowa, look at an&nbsp; open major, or take our MyMajors assessment to explore possible majors based on your interests and strengths.</p>\r\n<p>Use our program search to explore all of our areas of study and find what is right for you.&nbsp;</p>\r\n<hr class=\"element--spacer-separator\" />\r\n<div class=\"aos-cta\">\r\n<button id=\"aos-cta__button\" class=\"bttn bttn--primary bttn--caps\" type=\"button\">\r\n    Print PDF <i class=\"fas fa-print\"></i>\r\n </button>\r\n</div>"
+            value: "<p class=\"element--light-intro\">Iowa offers over 200 majors, minors, and certificates.</p>\r\n<p>Students are encouraged to work across disciplines to find their passion. If you are unsure of what you’d like to study at Iowa, look at an&nbsp; open major, or take our MyMajors assessment to explore possible majors based on your interests and strengths.</p>\r\n<p>Use our program search to explore all of our areas of study and find what is right for you.&nbsp;</p>\r\n<hr class=\"element--spacer-separator\" />\r\n<div class=\"aos-cta\">\r\n<button id=\"aos-cta__button\" class=\"bttn bttn--primary bttn--caps\" type=\"button\">\r\n    Print <i class=\"fas fa-print\"></i>\r\n </button>\r\n</div>"
             format: full_html
           tokenize: false
       exposed_block: false


### PR DESCRIPTION
Closes #5065 

# How to test

1. `git checkout print_kiosk_update`
2. If syncing from prod is still broken, `ddev blt sync --site admissions.uiowa.edu --define drush.aliases.remote=admissions.test`. Otherwise `blt ds --site=admissions.uiowa.edu` as normal.
4. `ddev drush @admissions.local uli`
5. Go to [https://admissions.uiowa.ddev.site/kiosk](https://admissions.uiowa.ddev.site/kiosk)
6. Select one or many majors! 
7. Check that the button at the bottom now only says Print, instead of Print PDF. Also check that it still brings up the print dialogue as expected.

Note: if the font looks different from the one on [https://admissions.uiowa.edu/kiosk](https://admissions.uiowa.edu/kiosk) and/or you have console errors related to fonts a `ddev blt frontend` should fix it. 