### PR TITLE
Hotfix: Patch `smart_date` module to fix issues with end date not being set correctly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -276,6 +276,9 @@
             "drupal/restrict_ip": {
                 "Parameter must be an array or an object that implements Countable": "https://www.drupal.org/files/issues/2022-01-11/2957482-11.patch"
             },
+            "drupal/smart_date": {
+                "Issues with time in Smart Date inline range widget": "https://www.drupal.org/files/issues/2022-04-06/3272338-3.patch"
+            },
             "drupal/jquery_ui_touch_punch": {
                 "JQuery UI TouchPunch for D9": "https://www.drupal.org/files/issues/2021-02-26/jquery_ui_touch_punch.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50b96b359983de4627b6bcf4420e408b",
+    "content-hash": "9df5b96998c576999c0fb482a7ae98f6",
     "packages": [
         {
             "name": "acquia/blt",
@@ -3481,7 +3481,7 @@
             "extra": {
                 "drupal": {
                     "version": "8.x-1.10",
-                    "datestamp": "1643715177",
+                    "datestamp": "1643715226",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
Resolves #5056 

# How to test
- `ddev composer install`
- `ddev blt ds --site grad.uiowa.edu --define  drush.aliases.remote=grad.test`
- `ddev drush @grad.local uli node/add/thesis_defense`
- Test the following scenarios, observe no form errors, and observe that the time displays as a point in time rather than a duration:
  - Future date, leave default time.
  - Future time, leave default date.
  - Change both date and time to future values.
  - Change both date and time to past values.
- `ddev blt ds --site admissions.uiowa.edu --define drush.aliases.remote=admissions.test`
- `ddev drush @admissions.local uli node/add/event`
- Test date functionality in local events and observe no unexpected behavior. When you change the start time, you can observe the end time update based on the duration. What displays on the page is what you selected.