### PR TITLE
International Migration Hotfix 2

### DIFF
--- a/docroot/sites/international.uiowa.edu/modules/international_migrate/src/Plugin/migrate/source/Articles.php
+++ b/docroot/sites/international.uiowa.edu/modules/international_migrate/src/Plugin/migrate/source/Articles.php
@@ -216,9 +216,11 @@ class Articles extends BaseNodeSource {
           if ($term->save()) {
             $this->tagMapping[$tag_name] = $term->id();
           }
-          // Add the mapped TID to match our tag name.
-          $tags[] = $this->tagMapping[$tag_name];
         }
+
+        // Add the mapped TID to match our tag name.
+        $tags[] = $this->tagMapping[$tag_name];
+
       }
       $row->setSourceProperty('tags', $tags);
     }


### PR DESCRIPTION
# How to test
Sync latest source database on uiowa703 DD. Restore user-created backup locally for D9 IP site. Download it to the tmp directory within the application.

ddev drush @international.local sql:drop -y && ddev drush @international.local cr
ddev drush @international.local sqlc < tmp/backup-2022-04-05-20-08-international_uiowa_edu-205858668.sql
ddev blt drupal:update --site international.uiowa.edu
ddev drush rsync @international.prod:%files @international.local:%files -v --yes
ddev drush @international.local pmu stage_file_proxy
ddev drush @international.local en international_migrate --yes
ddev drush @international.local uli /admin/config/sitenow/sitenow-migrate
Configure the form for DD.

ddev drush @international.local ms
ddev drush @international.local mim --all (don't do this for the PROD run)

Spot check links in any of nodes 1376, 1391, 1396, 1411; each link on a person's name, if there is one, should go to the article about their receiving the award

https://international.uiowa.ddev.site/tags/worldcanvass should have more than one article tagged.

Article Critical Language Scholarship winner Marissa Schooley to study Mandarin this summer should have more than one tag added.

For prod, we will want to disable production mode, restore the db, clear caches and run similar steps but by batching `drush @international.prod mim international_articles --limit 50` and removing the limit once it is about to run the last one. Then run drush @international.prod mim international_article_redirects afterward specifically to prevent articles from running again.