### PR TITLE
Feature: quick menu item divider lines fix for gold background for horizontal menus

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/menus/main-menu.scss
+++ b/docroot/themes/custom/uids_base/scss/components/menus/main-menu.scss
@@ -78,7 +78,6 @@
             > span {
               background-color: $light;
               margin: 0;
-              //padding-left: 1.875rem;
               padding-bottom: 1.475rem;
 
               &:before {
@@ -301,6 +300,15 @@
 
     &[class*="bg--gold"] {
       .menu-wrapper--horizontal {
+        > .menu > {
+          li:before {
+            background: #fff;
+            width: 2px;
+          }
+          li:last-child:before {
+            background: transparent;
+          }
+        }
         > .menu {
           > li > a,
           > li > span {
@@ -447,6 +455,7 @@
         height: 100%;
         top: 5px;
         width: auto;
+        margin: 0 auto;
       }
       position: absolute;
       right: 0;


### PR DESCRIPTION
A fix to add divider lines for horizontal menus on gold backgrounds and centering the toggle button for second level menu items. 

<img width="793" alt="Screen Shot 2022-04-27 at 8 43 42 AM" src="https://user-images.githubusercontent.com/1036433/165532841-c54706a7-dcb9-427e-acff-b0e4ed76a276.png">


# How to test
- Code review is fine. 