### PR TITLE
Feature: border regression fixes

### DIFF
--- a/docroot/themes/custom/uids_base/package.json
+++ b/docroot/themes/custom/uids_base/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "ISC",
   "dependencies": {
-    "@uiowa/uids": "https://github.com/uiowa/uids.git#v3.6.7",
+    "@uiowa/uids": "https://github.com/uiowa/uids.git#v3.6.8",
     "autoprefixer": "^9.8.8",
     "breakpoint-sass": "^2.7.1",
     "cssnano": "^4.1.11",

--- a/docroot/themes/custom/uids_base/scss/components/banner.scss
+++ b/docroot/themes/custom/uids_base/scss/components/banner.scss
@@ -267,17 +267,3 @@
     position: relative;
   }
 }
-
-.banner {
-  &.banner--gradient-light:not([class*="bg-"]) {
-    .banner__action {
-      .bttn--tertiary {
-        [class*=bg--black] & {
-          @include breakpoint(sm) {
-            color: $secondary;
-          }
-        }
-      }
-    }
-  }
-}

--- a/docroot/themes/custom/uids_base/scss/components/card.scss
+++ b/docroot/themes/custom/uids_base/scss/components/card.scss
@@ -195,36 +195,6 @@
   }
 }
 
-.card[class*="bg--gold"],
-.card[class*="bg--gray"] {
-  .bttn--sans-serif {
-    border-color: rgba(0,0,0,.225);
-  }
-}
-
-// Border color adjustment for cards not using a bg color
-.card:not([class*="bg-"]) {
-  border-color: rgba(0,0,0,.125);
-  .bg-pattern--brain-black &,
-  [class*="bg--black"] & {
-    border-color: rgba(255,255,255,.325);
-    .bttn--sans-serif {
-      border-color: rgba(255,255,255,.325);
-    }
-  }
-  .bttn--sans-serif {
-    border-color: rgba(0,0,0,.225);
-  }
-}
-
-.card:not([class*="bg-"]) {
-  .layout__container:not([class*="bg-"]) & {
-    .bttn--sans-serif {
-      border-color: rgba(0,0,0,.125);
-    }
-  }
-}
-
 // Set background for all v2 cards
 .paragraph--type--section {
   &[class*=bg-] {
@@ -374,5 +344,15 @@
     display: flex;
     justify-content: center;
     padding-top: .135rem;
+  }
+}
+
+// Border color adjustments
+.card:not([class*="bg-"]) {
+  .bttn--sans-serif {
+    border-color: rgba(0, 0, 0, .425);
+    [class*="bg--black"] & {
+      border-color: rgba(255,255,255,.425);
+    }
   }
 }

--- a/docroot/themes/custom/uids_base/scss/components/media.scss
+++ b/docroot/themes/custom/uids_base/scss/components/media.scss
@@ -15,3 +15,9 @@
       }
   }
 }
+
+.media--border img {
+  [class*="bg--black"] & {
+    border-color: rgba(255,255,255,.425);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1177,9 +1177,9 @@
   dependencies:
     "@types/node" "*"
 
-"@uiowa/uids@https://github.com/uiowa/uids.git#v3.6.7":
-  version "3.6.7"
-  resolved "https://github.com/uiowa/uids.git#96317895fe77cbff0c9630585d7e8c0a81dafa25"
+"@uiowa/uids@https://github.com/uiowa/uids.git#v3.6.8":
+  version "3.6.8"
+  resolved "https://github.com/uiowa/uids.git#452d08feeb14f8e011af2a81b158dfe59e6c6993"
   dependencies:
     autoprefixer "^9.8.6"
     cssnano "^4.1.11"


### PR DESCRIPTION
This pr attaches an updated UIDS version to fix a few border color regression issues caused by the banner button work that was released yesterday. 

# How to test
`blt frontend`
`ddev blt ds --site=sandbox.uiowa.edu"
Go to https://sandbox.uiowa.ddev.site/cards and compare against https://sandbox.prod.drupal.uiowa.edu/cards

This row:

<img width="1497" alt="Screen Shot 2022-04-28 at 10 22 27 AM" src="https://user-images.githubusercontent.com/1036433/165787392-3ef91660-3fa4-4e70-925d-ba575f15b3b1.png">

Should look like this:

<img width="1400" alt="Screen Shot 2022-04-28 at 10 22 34 AM" src="https://user-images.githubusercontent.com/1036433/165787437-22a385c6-9477-45e6-809d-f0e40634a0cd.png">

