### PR TITLE
Tippie Migrate - adjust array for fetchAdditionalFields change

### DIFF
--- a/docroot/modules/custom/sitenow_migrate/src/Plugin/migrate/source/BaseNodeSource.php
+++ b/docroot/modules/custom/sitenow_migrate/src/Plugin/migrate/source/BaseNodeSource.php
@@ -127,7 +127,13 @@ abstract class BaseNodeSource extends Node implements ImportAwareInterface {
       }
       $table_name = $field_name;
       if (substr($table_name, 0, 11) !== 'field_data_') {
+        // If the table name doesn't already have the 'field_data_' prefix,
+        // add it.
         $table_name = 'field_data_' . $table_name;
+      }
+      else {
+        // Our field name needs to have 'field_data_' removed from it.
+        $field_name = str_replace('field_data_', '', $field_name);
       }
       foreach ($fields as $column_name) {
         if (substr($column_name, 0, strlen($field_name)) !== $field_name) {

--- a/docroot/sites/tippie.uiowa.edu/modules/tippie_migrate/src/Plugin/migrate/source/Articles.php
+++ b/docroot/sites/tippie.uiowa.edu/modules/tippie_migrate/src/Plugin/migrate/source/Articles.php
@@ -22,6 +22,14 @@ class Articles extends BaseNodeSource {
   use LinkReplaceTrait;
 
   /**
+   * {@inheritdoc}
+   */
+  protected $multiValueFields = [
+    'field_tags' => 'tid',
+    'field_news_departments' => 'target_id',
+  ];
+
+  /**
    * Term-to-name mapping for authors.
    *
    * @var array
@@ -91,13 +99,6 @@ class Articles extends BaseNodeSource {
 
     // Establish an array to eventually map to field_tags.
     $tids = [];
-
-    // Load additional database table information to get entity label data.
-    $tables = [
-      'field_tags' => ['tid'],
-      'field_news_departments' => ['target_id'],
-    ];
-    $this->fetchAdditionalFields($row, $tables);
 
     // Set our tagMapping if it's not already.
     if (empty($this->tagMapping)) {

--- a/docroot/sites/tippie.uiowa.edu/modules/tippie_migrate/src/Plugin/migrate/source/Articles.php
+++ b/docroot/sites/tippie.uiowa.edu/modules/tippie_migrate/src/Plugin/migrate/source/Articles.php
@@ -94,8 +94,8 @@ class Articles extends BaseNodeSource {
 
     // Load additional database table information to get entity label data.
     $tables = [
-      'field_data_field_tags' => ['field_tags_tid'],
-      'field_data_field_news_departments' => ['field_news_departments_target_id'],
+      'field_tags' => ['tid'],
+      'field_news_departments' => ['target_id'],
     ];
     $this->fetchAdditionalFields($row, $tables);
 


### PR DESCRIPTION
Test to your heart's content, but hoping to get this out to PROD by AM.

# To Test

Right now if you run the migration using `main` then you will encounter this error:
```
[error]  Migration failed with source plugin exception: SQLSTATE[42S22]: Column not found: 1054 Unknown column &#039;t.field_data_field_tags_field_tags_tid
```
Check this branch out and the migration should run. See https://github.com/uiowa/uiowa/pull/5243 for original testing instructions