### PR TITLE
Update acquia_connector module to 4.x version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "bower-asset/photoswipe": "^4.1",
         "cweagans/composer-patches": "^1.7",
         "dompdf/dompdf": "1.2.1",
-        "drupal/acquia_connector": "^3.0@RC",
+        "drupal/acquia_connector": "^4.0",
         "drupal/acquia_purge": "^1.0",
         "drupal/address": "^1.8",
         "drupal/administerusersbyrole": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "42a0257e962c012318b7703e16a1d8a6",
+    "content-hash": "cf44e547aa2387da12cee522c5e50f6c",
     "packages": [
         {
             "name": "acquia/blt",
@@ -3314,17 +3314,17 @@
         },
         {
             "name": "drupal/acquia_connector",
-            "version": "3.0.4",
+            "version": "4.0.0-beta3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/acquia_connector.git",
-                "reference": "3.0.4"
+                "reference": "4.0.0-beta3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/acquia_connector-3.0.4.zip",
-                "reference": "3.0.4",
-                "shasum": "318f9a85c9e24565d9a347d467d53d99644d7bc3"
+                "url": "https://ftp.drupal.org/files/projects/acquia_connector-4.0.0-beta3.zip",
+                "reference": "4.0.0-beta3",
+                "shasum": "089696bb05b9479ef6f6f246502e731b4727f21a"
             },
             "require": {
                 "drupal/core": "^8.9 || ^9",
@@ -3333,19 +3333,19 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.0.4",
-                    "datestamp": "1632414112",
+                    "version": "4.0.0-beta3",
+                    "datestamp": "1653456895",
                     "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
                     }
                 },
                 "branch-alias": {
-                    "dev-3.x": "3.x-dev"
+                    "dev-4.x": "4.x-dev"
                 },
                 "drush": {
                     "services": {
-                        "drush.services.yml": "^9 || ^10"
+                        "drush.services.yml": ">=9"
                     }
                 }
             },
@@ -21805,7 +21805,6 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "acquia/blt-multisite": 20,
-        "drupal/acquia_connector": 5,
         "drupal/better_exposed_filters": 10,
         "drupal/better_normalizers": 10,
         "drupal/config_split": 10,
@@ -21847,5 +21846,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
Per conversation in an issue that @richardbporter created, it seems like the 4.x branch of the `acquia_connector` module fixes the issue that has been plaguing our `#drupal-status` channel in slack recently: https://www.drupal.org/project/acquia_connector/issues/3273706

The code changes from the 3.x to 4.x version are significant: https://git.drupalcode.org/project/acquia_connector/-/compare/3.0.4...4.0.0-beta3?from_project_id=55302. I don't see any changes to config and when I attempted to re-export config, there were no changes.

# How to test

I'm not sure how to test this. I'm not sure how we will know that this is working or not other than that we might be able to see a status for it in Acquia Cloud. The status report on a local site shows that the subscription is active.

I'm inclined to put this out there and see if it fixes our issue and whether we can determine any issues stemming from the change.
