### PR TITLE
Webform/Honeypot Updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -113,7 +113,7 @@
         "drupal/google_analytics": "^4.0",
         "drupal/google_tag": "^1.3",
         "drupal/heading": "^1.4",
-        "drupal/honeypot": "^2.0",
+        "drupal/honeypot": "^2.1",
         "drupal/iframe_title_filter": "^1.1",
         "drupal/imagecache_external": "^3.0",
         "drupal/imagemagick": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -176,7 +176,7 @@
         "drupal/tvi": "^1.0@RC",
         "drupal/views_ical": "^1.0@alpha",
         "drupal/views_tree": "^2.0@alpha",
-        "drupal/webform": "^6.0",
+        "drupal/webform": "^6.1",
         "drupal/weight": "^3.2",
         "drupal/workbench_email": "^2.2",
         "drush/drush": "^11.0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf44e547aa2387da12cee522c5e50f6c",
+    "content-hash": "9e6042ac66071cf851c1b8ad8e3fa4e4",
     "packages": [
         {
             "name": "acquia/blt",
@@ -10878,17 +10878,17 @@
         },
         {
             "name": "drupal/webform",
-            "version": "6.1.2",
+            "version": "6.1.3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/webform.git",
-                "reference": "6.1.2"
+                "reference": "6.1.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/webform-6.1.2.zip",
-                "reference": "6.1.2",
-                "shasum": "3afb96566f5d31474483e163b4e0138d43cffdcd"
+                "url": "https://ftp.drupal.org/files/projects/webform-6.1.3.zip",
+                "reference": "6.1.3",
+                "shasum": "efd032eadc10a4752b9b0203152a5d20eefac175"
             },
             "require": {
                 "drupal/core": "^8.8 || ^9"
@@ -10898,15 +10898,15 @@
                 "drupal/bootstrap": "~3.0",
                 "drupal/captcha": "~1.0",
                 "drupal/chosen": "~3.0",
-                "drupal/clientside_validation": "*",
+                "drupal/clientside_validation": "~3.0",
                 "drupal/clientside_validation_jquery": "*",
-                "drupal/devel": "*",
+                "drupal/devel": "~3.0",
                 "drupal/entity": "~1.0",
-                "drupal/entity_print": "*",
+                "drupal/entity_print": "~2.0",
                 "drupal/gnode": "*",
-                "drupal/group": "*",
+                "drupal/group": "1.0",
                 "drupal/jquery_ui": "~1.0",
-                "drupal/jquery_ui_checkboxradio": "*",
+                "drupal/jquery_ui_checkboxradio": "~1.0",
                 "drupal/jquery_ui_datepicker": "~1.0",
                 "drupal/lingotek": "~3.0",
                 "drupal/mailsystem": "~4.0",
@@ -10915,7 +10915,7 @@
                 "drupal/smtp": "~1.0",
                 "drupal/styleguide": "~1.0",
                 "drupal/telephone_validation": "~2.0",
-                "drupal/token": "*",
+                "drupal/token": "~1.0",
                 "drupal/variationcache": "~1.0",
                 "drupal/webform_access": "*",
                 "drupal/webform_attachment": "*",
@@ -10936,8 +10936,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "6.1.2",
-                    "datestamp": "1644940638",
+                    "version": "6.1.3",
+                    "datestamp": "1644940723",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -21846,5 +21846,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc761b80d829d151e1e0ad2de9cb017c",
+    "content-hash": "b84e1638f8da01d8753a44e1e01bda31",
     "packages": [
         {
             "name": "acquia/blt",
@@ -6416,26 +6416,29 @@
         },
         {
             "name": "drupal/honeypot",
-            "version": "2.0.1",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/honeypot.git",
-                "reference": "2.0.1"
+                "reference": "2.1.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/honeypot-2.0.1.zip",
-                "reference": "2.0.1",
-                "shasum": "c29d248c0fdcdf733a31b9214355acfa73716632"
+                "url": "https://ftp.drupal.org/files/projects/honeypot-2.1.1.zip",
+                "reference": "2.1.1",
+                "shasum": "2f01297c8c6d1bdb2e5f4c3b2c8c7e8be521191c"
             },
             "require": {
-                "drupal/core": "^8.0 || ^9.0"
+                "drupal/core": "^9.2 || ^10"
+            },
+            "require-dev": {
+                "drupal/rules": "^3.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.1",
-                    "datestamp": "1597855128",
+                    "version": "2.1.1",
+                    "datestamp": "1654198290",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c84a86a61bef0a83eca34bc20f23d198",
+    "content-hash": "bc761b80d829d151e1e0ad2de9cb017c",
     "packages": [
         {
             "name": "acquia/blt",
@@ -658,7 +658,7 @@
             "version": "v4.1.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/dimsemenov/PhotoSwipe.git",
+                "url": "git@github.com:dimsemenov/PhotoSwipe.git",
                 "reference": "80607e12542a1a54ecefa837649e862b35dffd25"
             },
             "dist": {

--- a/config/default/webform.settings.yml
+++ b/config/default/webform.settings.yml
@@ -206,9 +206,15 @@ export:
   header_prefix: true
   header_prefix_key_delimiter: __
   header_prefix_label_delimiter: ': '
+  entity_reference_items:
+    - id
+    - title
+    - url
   options_single_format: compact
   options_multiple_format: compact
   options_item_format: label
+  likert_answers_format: label
+  signature_format: status
   composite_element_item_format: label
   excluded_exporters:
     yaml: yaml

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -570,12 +570,12 @@ function _sitenow_webform_validate(array &$form, FormStateInterface $form_state)
     // Prevent non-default extensions from being added.
     $default_extensions = \Drupal::configFactory()->getEditable('webform.settings')->get('file.default_managed_file_extensions');
     $default_extensions_array = explode(' ', $default_extensions);
-    $current_extensions = explode(' ', $form_state->getValue(
+    $current_extensions = explode(' ', trim($form_state->getValue(
       [
         'properties',
         'file_extensions',
       ]
-    ));
+    )));
     foreach ($current_extensions as $extension) {
       if (!in_array($extension, $default_extensions_array)) {
         $form_state->setErrorByName('properties[file_extensions]',

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -524,12 +524,10 @@ function sitenow_form_alter(&$form, FormStateInterface $form_state, $form_id) {
         $form['properties']['markup']['message_close_effect']['#access'] = FALSE;
         $form['properties']['markup']['message_storage']['#access'] = FALSE;
         $form['properties']['markup']['message_id']['#access'] = FALSE;
-
-        // Remove access to change allowed file upload extensions.
-        if (isset($form['properties']['file'])) {
-          $form['properties']['file']['file_extensions']['#access'] = FALSE;
-        }
       }
+
+      // Custom validation for webform components.
+      $form['#validate'][] = '_sitenow_webform_validate';
       break;
 
     // Remove access to headline field in footer contact block.
@@ -555,6 +553,41 @@ function sitenow_form_alter(&$form, FormStateInterface $form_state, $form_id) {
       }
       break;
 
+  }
+}
+
+/**
+ * Custom validation for webform_ui_element_form.
+ *
+ * @param array $form
+ *   The form element.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ */
+function _sitenow_webform_validate(array &$form, FormStateInterface $form_state) {
+  // Validate the managed_file webform component.
+  if ($form_state->getValue(['properties', 'type']) == 'managed_file') {
+    // Prevent non-default extensions from being added.
+    $default_extensions = \Drupal::configFactory()->getEditable('webform.settings')->get('file.default_managed_file_extensions');
+    $default_extensions_array = explode(' ', $default_extensions);
+    $current_extensions = explode(' ', $form_state->getValue(
+      [
+        'properties',
+        'file_extensions',
+      ]
+    ));
+    foreach ($current_extensions as $extension) {
+      if (!in_array($extension, $default_extensions_array)) {
+        $form_state->setErrorByName('properties[file_extensions]',
+          t('File extension, <em>@extension</em>, is not allowed. <em>Allowed extensions (@default_extensions)</em>',
+            [
+              '@extension' => $extension,
+              '@default_extensions' => $default_extensions,
+            ]
+          )
+        );
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Webform [6.1.2 to 6.1.3](https://git.drupalcode.org/project/webform/-/compare/6.1.2...6.1.3?from_project_id=59750)

Honeypot [2.01 to 2.1.1](https://git.drupalcode.org/project/honeypot/-/compare/2.0.1...2.1.1?from_project_id=53761)

Fixes #4028

## To Test
- For the general module update, there were some configurations to repair, but just poke around normal webform config for issues. This stable release has been out since February.
- As a webmaster, I can add a file component to my webform limit the list of allowed file extensions without developer interaction, however if I try to add a non-allowed extension like exe, makerbot, billmurray, I won't be able to save the component and will get a message as to why. The component's help text provides the original list of allowed extensions should the editor wish to revert back.
- Limiting the list of allowed extensions, try the form as a user and try uploading a file that is not allowed. The error message should pop up and be limited to your limited list.
- To test honeypot, just confirm honeypot and antibot are being loaded for anonymous users on a webform. You can do this by inspecting the page looking for `honeypot` and `antibot` bits