### PR TITLE
RSS - GUID fix

### DIFF
--- a/config/default/views.view.articles.yml
+++ b/config/default/views.view.articles.yml
@@ -394,7 +394,7 @@ display:
           date_field: created
           guid_field_options:
             guid_field: nid
-            guid_field_is_permalink: true
+            guid_field_is_permalink: false
       path: news/feed
       title: News
       enabled: true

--- a/config/default/views.view.taxonomy_term.yml
+++ b/config/default/views.view.taxonomy_term.yml
@@ -669,7 +669,7 @@ display:
           date_field: created
           guid_field_options:
             guid_field: nid
-            guid_field_is_permalink: true
+            guid_field_is_permalink: false
       query:
         type: views_query
         options: {  }

--- a/docroot/modules/custom/sitenow_articles/sitenow_articles.install
+++ b/docroot/modules/custom/sitenow_articles/sitenow_articles.install
@@ -55,3 +55,15 @@ function sitenow_articles_update_9302() {
 
   $config->save();
 }
+
+/**
+ * Update articles feed guid permalink to false.
+ */
+function sitenow_articles_update_9303() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('views.view.articles');
+
+  $config
+    ->set('display.feed_articles.display_options.row.options.guid_field_options.guid_field_is_permalink', FALSE)
+    ->save();
+}


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->
Resolves https://github.com/uiowa/uiowa/issues/5378
<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

- After pulling this branch, run a fresh site install `ddev blt drupal:install --site default`
- Go to https://default.uiowa.ddev.site/news/feed and check to guid see instances are like `<guid isPermaLink="false">` instead of true.
- Sync down a site using SiteNow Articles with the feed enabled (e.g. tippie.uiowa.edu). The update hook should fire and update the articles view page feed (https://tippie.uiowa.ddev.site/news/feed) to be the same `false` as above. Compare with PROD.
- Go to https://tippie.uiowa.ddev.site/taxonomy/term/2826/feed and see that for taxonomy term feeds, it is also set to `false`