### PR TITLE
Hotfix - Hours - Account for resourceAlias

### DIFF
--- a/docroot/modules/custom/uiowa_hours/src/HoursApi.php
+++ b/docroot/modules/custom/uiowa_hours/src/HoursApi.php
@@ -183,6 +183,7 @@ class HoursApi {
 
     // This isn't used and borks the foreach loop. Unset it.
     unset($data['$id']);
+    unset($data['resourceAlias']);
 
     return [
       'data' => $data,


### PR DESCRIPTION
Regression from #5415

# To Test

See https://recserv.uiowa.edu/ and notice the extra items dating back to 1969.
Pull this branch and sync `ddev blt ds --site=recserv.uiowa.edu`
See that those extra 1969 items are gone and current date results are correct.