### PR TITLE
Added map field to residence halls content type.

### DIFF
--- a/config/sites/housing.uiowa.edu/core.entity_form_display.node.residence_hall.default.yml
+++ b/config/sites/housing.uiowa.edu/core.entity_form_display.node.residence_hall.default.yml
@@ -21,6 +21,7 @@ dependencies:
     - field.field.node.residence_hall.field_residence_hall_getting
     - field.field.node.residence_hall.field_residence_hall_images
     - field.field.node.residence_hall.field_residence_hall_llc
+    - field.field.node.residence_hall.field_residence_hall_map
     - field.field.node.residence_hall.field_residence_hall_meet_us
     - field.field.node.residence_hall.field_residence_hall_neighborhd
     - field.field.node.residence_hall.field_residence_hall_population
@@ -54,7 +55,7 @@ third_party_settings:
       label: 'Contact Information'
       region: content
       parent_name: ''
-      weight: 4
+      weight: 5
       format_type: details
       format_settings:
         classes: ''
@@ -70,7 +71,7 @@ third_party_settings:
       label: Media
       region: content
       parent_name: ''
-      weight: 3
+      weight: 4
       format_type: details
       format_settings:
         classes: ''
@@ -89,7 +90,7 @@ third_party_settings:
       label: 'Room Details'
       region: content
       parent_name: ''
-      weight: 16
+      weight: 17
       format_type: details
       format_settings:
         classes: ''
@@ -105,7 +106,7 @@ third_party_settings:
       label: 'Getting around'
       region: content
       parent_name: ''
-      weight: 19
+      weight: 20
       format_type: details
       format_settings:
         classes: ''
@@ -121,6 +122,7 @@ third_party_settings:
         - field_residence_hall_year_built
         - field_residence_hall_who_lives
         - field_residence_hall_population
+        - field_residence_hall_map
       label: 'Building details'
       region: content
       parent_name: ''
@@ -139,7 +141,7 @@ third_party_settings:
       label: 'Bathroom details'
       region: content
       parent_name: ''
-      weight: 17
+      weight: 18
       format_type: details
       format_settings:
         classes: ''
@@ -155,7 +157,7 @@ third_party_settings:
       label: 'Custom links'
       region: content
       parent_name: ''
-      weight: 20
+      weight: 21
       format_type: details
       format_settings:
         classes: ''
@@ -172,7 +174,7 @@ third_party_settings:
       label: 'Emergency Policies'
       region: content
       parent_name: ''
-      weight: 23
+      weight: 24
       format_type: details
       format_settings:
         classes: ''
@@ -187,7 +189,7 @@ third_party_settings:
       label: 'Meet us'
       region: content
       parent_name: ''
-      weight: 22
+      weight: 23
       format_type: details
       format_settings:
         classes: ''
@@ -206,7 +208,7 @@ third_party_settings:
       label: 'Restroom Gallery'
       region: content
       parent_name: ''
-      weight: 18
+      weight: 19
       format_type: details
       format_settings:
         classes: ''
@@ -232,20 +234,20 @@ content:
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   field_image:
     type: media_library_widget
-    weight: 14
+    weight: 15
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
   field_meta_tags:
     type: metatag_firehose
-    weight: 15
+    weight: 16
     region: content
     settings:
       sidebar: true
@@ -388,13 +390,20 @@ content:
     third_party_settings: {  }
   field_residence_hall_llc:
     type: entity_reference_autocomplete
-    weight: 21
+    weight: 22
     region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  field_residence_hall_map:
+    type: media_library_widget
+    weight: 8
+    region: content
+    settings:
+      media_types: {  }
     third_party_settings: {  }
   field_residence_hall_meet_us:
     type: entity_reference_autocomplete
@@ -414,7 +423,7 @@ content:
     third_party_settings: {  }
   field_residence_hall_population:
     type: number
-    weight: 28
+    weight: 7
     region: content
     settings:
       placeholder: ''
@@ -454,7 +463,7 @@ content:
     third_party_settings: {  }
   field_residence_hall_rr_private:
     type: media_library_widget
-    weight: 28
+    weight: 29
     region: content
     settings:
       media_types: {  }
@@ -482,7 +491,7 @@ content:
     third_party_settings: {  }
   field_residence_hall_who_lives:
     type: entity_reference_autocomplete
-    weight: 7
+    weight: 6
     region: content
     settings:
       match_operator: CONTAINS
@@ -500,7 +509,7 @@ content:
     third_party_settings: {  }
   field_teaser:
     type: string_textarea
-    weight: 13
+    weight: 14
     region: content
     settings:
       rows: 5
@@ -508,33 +517,33 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 8
+    weight: 9
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 12
+    weight: 13
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 9
+    weight: 10
     region: content
     settings:
       display_label: true
@@ -549,7 +558,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 6
     region: content
     settings:
       match_operator: CONTAINS
@@ -558,7 +567,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sites/housing.uiowa.edu/core.entity_view_display.node.residence_hall.default.yml
+++ b/config/sites/housing.uiowa.edu/core.entity_view_display.node.residence_hall.default.yml
@@ -21,6 +21,7 @@ dependencies:
     - field.field.node.residence_hall.field_residence_hall_getting
     - field.field.node.residence_hall.field_residence_hall_images
     - field.field.node.residence_hall.field_residence_hall_llc
+    - field.field.node.residence_hall.field_residence_hall_map
     - field.field.node.residence_hall.field_residence_hall_meet_us
     - field.field.node.residence_hall.field_residence_hall_neighborhd
     - field.field.node.residence_hall.field_residence_hall_population
@@ -428,6 +429,26 @@ third_party_settings:
                 type: text_default
                 label: above
                 settings: {  }
+                third_party_settings: {  }
+            weight: 0
+            additional: {  }
+            third_party_settings: {  }
+          cc6d0a2b-e20f-40c5-b736-c6ddda2220ca:
+            uuid: cc6d0a2b-e20f-40c5-b736-c6ddda2220ca
+            region: second
+            configuration:
+              id: 'field_block:node:residence_hall:field_residence_hall_map'
+              label: null
+              label_display: null
+              provider: layout_builder
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+              formatter:
+                type: entity_reference_entity_view
+                label: hidden
+                settings:
+                  view_mode: large__square
                 third_party_settings: {  }
             weight: 0
             additional: {  }
@@ -1025,6 +1046,7 @@ hidden:
   field_residence_hall_furnishings: true
   field_residence_hall_images: true
   field_residence_hall_llc: true
+  field_residence_hall_map: true
   field_residence_hall_rates: true
   field_residence_hall_room_type: true
   field_residence_hall_video: true

--- a/config/sites/housing.uiowa.edu/core.entity_view_display.node.residence_hall.teaser.yml
+++ b/config/sites/housing.uiowa.edu/core.entity_view_display.node.residence_hall.teaser.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.residence_hall.field_residence_hall_getting
     - field.field.node.residence_hall.field_residence_hall_images
     - field.field.node.residence_hall.field_residence_hall_llc
+    - field.field.node.residence_hall.field_residence_hall_map
     - field.field.node.residence_hall.field_residence_hall_meet_us
     - field.field.node.residence_hall.field_residence_hall_neighborhd
     - field.field.node.residence_hall.field_residence_hall_population
@@ -89,6 +90,7 @@ hidden:
   field_residence_hall_getting: true
   field_residence_hall_images: true
   field_residence_hall_llc: true
+  field_residence_hall_map: true
   field_residence_hall_meet_us: true
   field_residence_hall_neighborhd: true
   field_residence_hall_population: true

--- a/config/sites/housing.uiowa.edu/field.field.node.residence_hall.field_residence_hall_map.yml
+++ b/config/sites/housing.uiowa.edu/field.field.node.residence_hall.field_residence_hall_map.yml
@@ -1,0 +1,29 @@
+uuid: c39df27e-b926-48be-ba08-0bba32b151c1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_residence_hall_map
+    - media.type.static_map
+    - node.type.residence_hall
+id: node.residence_hall.field_residence_hall_map
+field_name: field_residence_hall_map
+entity_type: node
+bundle: residence_hall
+label: Map
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      static_map: static_map
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sites/housing.uiowa.edu/field.storage.node.field_residence_hall_map.yml
+++ b/config/sites/housing.uiowa.edu/field.storage.node.field_residence_hall_map.yml
@@ -1,0 +1,20 @@
+uuid: 56553a5d-7287-4995-860f-91962a835dd5
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_residence_hall_map
+field_name: field_residence_hall_map
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sites/housing.uiowa.edu/views.view.residence_halls.yml
+++ b/config/sites/housing.uiowa.edu/views.view.residence_halls.yml
@@ -384,7 +384,7 @@ display:
             remember: false
             default_group: All
             default_group_multiple: {  }
-            group_items: { }
+            group_items: {  }
           reduce_duplicates: true
           vid: room_type
           type: select


### PR DESCRIPTION
Resolves #5476 

# How to test

- `ddev blt ds --site housing.uiowa.edu`
- `ddev drush @housing.local uli node/466/edit`
- Add a map to Daum Hall using https://maps.uiowa.edu/?id=1890#!m/591094 and save the node
- Confirm that map placement shows up and looks correct, according to the mockup: https://sandbox.prod.drupal.uiowa.edu/catlett-hall
