### PR TITLE
Feature: Added fix for grad admissions tvi

### DIFF
--- a/config/sites/grad.admissions.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/grad.admissions.uiowa.edu/config_split.config_split.site.yml
@@ -49,6 +49,7 @@ complete_list:
   - 'core.entity_view_display.node.costs_estimate.*'
   - 'core.entity_view_display.node.area_of_study.*'
   - 'core.entity_form_display.node.area_of_study.*'
+  - 'core.entity_form_display.taxonomy_term.tags.*'
   - 'field.field.node.costs_estimate.*'
   - 'field.storage.node.field_costs_estimate_*'
   - 'field.storage.node.field_area_of_study*'

--- a/config/sites/grad.admissions.uiowa.edu/config_split.patch.core.entity_form_display.taxonomy_term.tags.default.yml
+++ b/config/sites/grad.admissions.uiowa.edu/config_split.patch.core.entity_form_display.taxonomy_term.tags.default.yml
@@ -1,0 +1,8 @@
+adding:
+  content:
+    tvi:
+      weight: 5
+      region: content
+      settings: {  }
+      third_party_settings: {  }
+removing: {  }


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/5487. 

# To Test

- Checkout this branch.
- `ddev composer install && ddev blt frontend && ddev drush @admissionsgrad.local sql-drop && ddev drush @admissionsgrad.local cr && ddev blt ds --site=grad.admissions.uiowa.edu`
- There should be no config import issues.
- `ddev drush @admissionsgrad.local uli` go to https://grad.admissions.uiowa.ddev.site/admin/structure/taxonomy/manage/tags/overview/form-display and see that both image and tvi are represented.