### PR TITLE
Feature: Added heading styles to labels for 2plus2 majors

### DIFF
--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
@@ -339,9 +339,22 @@ function admissions_core_preprocess_field(&$variables) {
       $term = $variables['element']['#object'];
       $name = $term->field_major_community_college->entity->name->value;
       $variables['label'] = t('@name checkpoints', ['@name' => $name]);
+
+      if (!isset($variables['title_attributes']['class'])) {
+        $variables['title_attributes']['class'] = '';
+      }
+      $variables['title_attributes']['class'] .= 'h4 headline headline--serif';
       break;
 
+    case 'field_major_responsibilities':
+    case 'field_major_uiowa_checkpoints':
+      if (!isset($variables['title_attributes']['class'])) {
+        $variables['title_attributes']['class'] = '';
+      }
+      $variables['title_attributes']['class'] .= 'h4 headline headline--serif';
+      break;
   }
+
 }
 
 /**

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/field--node--field-major-area-of-study--major.html.twig
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/field--node--field-major-area-of-study--major.html.twig
@@ -42,3 +42,4 @@
   <a href="{{ items.0.content['#url'] }}" class="bttn bttn--transparent bttn--light-font">Studying {{ items.0.content['#title'] }} at Iowa<i class="fas fa-arrow-right"></i>
   </a>
 </p>
+<hr class="element--spacer-separator" />


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/5528. 

# How to test

- `ddev blt ds --site=admissions.uiowa.edu`
- Go to https://admissions.uiowa.ddev.site/academics/2plus2/anthropology-des-moines-area-community-college and verify that it looks like the screenshot below. 

Looks like:
<img width="1495" alt="Screen Shot 2022-08-12 at 4 02 22 PM" src="https://user-images.githubusercontent.com/1036433/184444650-3b54a507-a9ac-436f-8966-41518991b983.png">

