### PR TITLE
Feature: container query polyfill

### DIFF
--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -748,3 +748,21 @@ body:not(.page-node-type-article, .page-node-type-page).layout-builder-disabled 
 .screen-reader-text {
   @include element-invisible;
 }
+
+
+// Container queries example.
+.layout--fourcol .layout__region {
+  /* Add inline container to parent */
+  container-type: inline-size;
+
+}
+
+@container (max-width: 268px) {
+  .card {
+    flex-direction: column!important;
+  }
+  .card.card--media-right .card__media--large {
+    width: 100%!important;
+    margin-bottom: 2rem;
+  }
+}

--- a/docroot/themes/custom/uids_base/templates/layout/html.html.twig
+++ b/docroot/themes/custom/uids_base/templates/layout/html.html.twig
@@ -40,6 +40,11 @@
     <title>{{ head_title|safe_join(' | ') }}</title>
     <css-placeholder token="{{ placeholder_token }}">
     <js-placeholder token="{{ placeholder_token }}">
+    <script type="module">
+      if (!("container" in document.documentElement.style)) {
+        import("https://unpkg.com/container-query-polyfill@^0.2.0");
+      }
+    </script>
   </head>
   <body{{ attributes.addClass(body_classes) }}>
 


### PR DESCRIPTION
A quick experiment using the updated container query poyfill.  

# How to test

- `blt frontend`
- `ddev blt ds --site=sandbox.uiowa.edu`
- Go to https://sandbox.uiowa.ddev.site/four-column-card-list and collapse the browser and the card lists should display as stacked when you get below 1230px. 
