### PR TITLE
Update residence halls count from 10 to 11.

### DIFF
--- a/config/sites/housing.uiowa.edu/views.view.residence_halls.yml
+++ b/config/sites/housing.uiowa.edu/views.view.residence_halls.yml
@@ -601,7 +601,7 @@ display:
           plugin_id: text
           empty: true
           content:
-            value: "<div class=\"block--edge-to-edge bg--white--pattern--community block-margin__bottom--extra\">\r\n<div class=\"page__container block-padding__top block-padding__bottom\">\r\n<div class=\"page__container\">\r\n<h2 class=\"h3 headline headline--serif headline--underline\">Our residence halls</h2>\r\n<p>At the University of Iowa, we offer 10 different residence halls located on both the east and west sides of campus. All halls come with furnished spaces, information desks, study lounges, high speed internet, laundry facilities and more. Find your right fit using the filter below.</p>\r\n</div>\r\n</div>\r\n</div>"
+            value: "<div class=\"block--edge-to-edge bg--white--pattern--community block-margin__bottom--extra\">\r\n<div class=\"page__container block-padding__top block-padding__bottom\">\r\n<div class=\"page__container\">\r\n<h2 class=\"h3 headline headline--serif headline--underline\">Our residence halls</h2>\r\n<p>At the University of Iowa, we offer 11 different residence halls located on both the east and west sides of campus. All halls come with furnished spaces, information desks, study lounges, high speed internet, laundry facilities and more. Find your right fit using the filter below.</p>\r\n</div>\r\n</div>\r\n</div>"
             format: filtered_html
           tokenize: false
       footer: {  }


### PR DESCRIPTION
Quick update to change the residence halls count from 10 to 11 on /residence-halls.

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
Code review, or check out and `blt ds --site=housing.uiowa.edu`, check that https://housing.uiowa.ddev.site/residence-halls includes "...offer 11 different residence halls..." instead of 10, like it is on https://housing.prod.drupal.uiowa.edu/residence-halls