### PR TITLE
Added more padding for banner videos

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/banner.scss
+++ b/docroot/themes/custom/uids_base/scss/components/banner.scss
@@ -144,6 +144,19 @@
   }
 }
 
+// Add more padding for play/pause button for banners with video.
+.banner.banner--video,
+.layout--onecol[class*=page__container--edge] .banner.banner--video {
+  .banner__content {
+    padding-bottom: 4rem;
+    padding-top: 4rem;
+    @include breakpoint(page-container) {
+      padding-bottom: 6rem;
+      padding-top: 6rem;
+    }
+  }
+}
+
   // Remove left/right padding if edge-to-edge is selected
   .layout--onecol[class*=page__container--edge] {
     .banner__content {


### PR DESCRIPTION
This turned out to be easier than I had thought because of the class that we added recently: https://github.com/uiowa/uiowa/blob/main/docroot/themes/custom/uids_base/uids_base.theme#L679.    

Resolves https://github.com/uiowa/uiowa/issues/5585.

# How to test

- `blt frontend`
- `ddev blt ds --site=sandbox.uiowa.edu`
- Test all the videos on https://sandbox.prod.drupal.uiowa.edu/banner-videos at all breakpoints and verify that the play button doesn't overlap. 
- Adjust container size to "Normal" and check all of the breakpoints again. 
- Test video on https://imu.uiowa.edu/student-involvement. 