### PR TITLE
Adjusted 'Browse all' view display on Topic Collection to respect content's sticky status

### DIFF
--- a/config/features/topic_page/views.view.topic_page_browse_by_tag.yml
+++ b/config/features/topic_page/views.view.topic_page_browse_by_tag.yml
@@ -298,6 +298,19 @@ display:
           separator: ', '
           field_api_classes: false
       sorts:
+        sticky:
+          id: sticky
+          table: taxonomy_index
+          field: sticky
+          relationship: reverse__node__field_tags
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
         name:
           id: name
           table: taxonomy_term_field_data


### PR DESCRIPTION
Resolves #5616

This PR adjusts the "Browse all" view display to respect a piece of content's sticky status.

# How to test

1. Stay on the `main` branch
2. Pull down mentalhealth.uiowa.edu locally: `blt ds --site=mentalhealth.uiowa.edu`
3. Edit the  "University Counseling Services" page and attempt to sticky it with the promotion options: https://mentalhealth.uiowa.ddev.site/node/196/edit
4. Go to the "Find Help" page (https://mentalhealth.uiowa.ddev.site/help), scroll to the "Browse by tag" heading and note that "University Counseling Service" is at the bottom of many of the bulleted lists due to its name being near the end alphabetically
5. Check out this branch: `git checkout topic-page-sticky-fix`
6. Import the config split updates: `drush @mentalhealth.local cim`
7. Return to the "Find Help" page and note that University Counseling Service is now stickied at the top of each tag's heading
