### PR TITLE
Admissions button hotfix

### DIFF
--- a/config/sites/admissions.uiowa.edu/core.entity_view_display.paragraph.admissions_card.default.yml
+++ b/config/sites/admissions.uiowa.edu/core.entity_view_display.paragraph.admissions_card.default.yml
@@ -25,7 +25,7 @@ content:
     weight: 3
     region: content
   field_admissions_card_link:
-    type: link
+    type: link_separate
     label: hidden
     settings:
       trim_length: 80
@@ -62,4 +62,7 @@ content:
     weight: 0
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   search_api_excerpt: true

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/field--node--field-transfer-tips-aos--transfer-tips.html.twig
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/field--node--field-transfer-tips-aos--transfer-tips.html.twig
@@ -37,21 +37,8 @@
  * @see template_preprocess_field()
  */
 #}
-
-{%
-  set classes = [
-  'card--list',
-  'bg--white',
-  'card--alignment-left',
-  'card--media-left',
-  'card',
-]
-%}
-
-{{ attach_library('uids_base/card') }}
-
-<h1 {{ attributes.addClass(classes) }}>
+<p>
   {%- for item in items -%}
     <a href="{{ item.content['#url'] }}" class="bttn bttn--transparent bttn--light-font">{{ item.content['#title']|render }}<i role="presentation" class="fas fa-arrow-right"></i></a>
   {%- endfor -%}
-</h1>
+</p>

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/node--transfer-tips--full.html.twig
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/node--transfer-tips--full.html.twig
@@ -111,9 +111,9 @@
 
     {{ attach_library('uids_base/card') }}
 
-    <h1 {{ attributes.addClass(classes) }}>
+    <div {{ attributes.addClass(classes) }}>
         <a href="{{ two_plus_two.url }}" class="bttn bttn--transparent bttn--light-font">{{ two_plus_two.title }}<i role="presentation" class="fas fa-arrow-right"></i></a>
-    </h1>
+    </div>
   {% endif %}
 
 </div>

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/node--transfer-tips--full.html.twig
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/node--transfer-tips--full.html.twig
@@ -99,21 +99,9 @@
   </div>
 
   {% if two_plus_two %}
-    {%
-      set classes = [
-      'card--list',
-      'bg--white',
-      'card--alignment-left',
-      'card--media-left',
-      'card',
-    ]
-    %}
-
-    {{ attach_library('uids_base/card') }}
-
-    <div {{ attributes.addClass(classes) }}>
+    <p>
         <a href="{{ two_plus_two.url }}" class="bttn bttn--transparent bttn--light-font">{{ two_plus_two.title }}<i role="presentation" class="fas fa-arrow-right"></i></a>
-    </div>
+    </p>
   {% endif %}
 
 </div>

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/paragraph--admissions-card--default.html.twig
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/paragraph--admissions-card--default.html.twig
@@ -69,6 +69,7 @@
   'card_image': content.field_admissions_card_media|render,
   'media_sizes': 'card__media--large',
   'headline_level': 'h2',
+  'visible_button': true,
 } %}
 
 {% embed '@uids_base/uids/card.html.twig' with admissions_card only %}{% endembed %}


### PR DESCRIPTION
# How to test

- `ddev blt ds --site=admissions.uiowa.edu`
- Go to https://admissions.uiowa.edu/academics/biomedical-engineering and verify that buttons are appearing on the story cards. 
  -  Verify that circle button displays if there is a link and no link text
- Compare https://admissions.uiowa.edu/academics/international-studies/transfer-tips against https://admissions.uiowa.ddev.site/academics/international-studies/transfer-tips and verify that the 2plus2 button isn't being rendered in a `<h1>` tag. 


