### PR TITLE
Fix path for uiowa_articles

### DIFF
--- a/config/default/views.view.article_list_block.yml
+++ b/config/default/views.view.article_list_block.yml
@@ -847,7 +847,7 @@ display:
         configure_sorts: configure_sorts
         configure_filters: configure_filters
         use_more: use_more
-      more_link_help_text: 'Check to include a ''display more'' link. To use the default <a href="/admin/config/sitenow/sitenow-articles">articles path set within SiteNow Articles</a>, make sure the ‘Enable articles listing’ box is checked. Alternatively, a custom URL path can be provided in the ‘Path’ text box below.'
+      more_link_help_text: 'Check to include a ''display more'' link. To use the default <a href="/admin/config/sitenow/uiowa-articles">articles path set within SiteNow Articles</a>, make sure the ‘Enable articles listing’ box is checked. Alternatively, a custom URL path can be provided in the ‘Path’ text box below.'
       restrict_fields:
         title: title
         nid: nid


### PR DESCRIPTION
tracks and fixes https://github.com/uiowa/uiowa/issues/5473


# How to test

sync default, ensure config imports.
check the link on the articles block and ensure it now points to the correct URL.
