### PR TITLE
Re-add drush cc plugin

### DIFF
--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -24,6 +24,7 @@ class ReplaceCommands extends BltTasks {
     $this->config->set('drush.alias', '');
 
     $app = EnvironmentDetector::getAhGroup() ?: 'local';
+    $env = EnvironmentDetector::getAhEnv() ?: 'local';
     $multisite_exception = FALSE;
 
     // Unshift sites to the beginning to run first.
@@ -69,6 +70,12 @@ class ReplaceCommands extends BltTasks {
           }
 
           try {
+            // Clear the plugin cache for discovery and potential layout issue.
+            // @see: https://github.com/uiowa/uiowa/issues/3585.
+            $this->taskDrush()
+              ->drush('cc plugin')
+              ->run();
+
             $this->invokeCommand('drupal:update');
             $this->logger->info("Finished deploying updates to <comment>{$multisite}</comment>.");
           }


### PR DESCRIPTION
Relates to https://github.com/uiowa/uiowa/issues/3585

Following the git history of this file, I think the work originally done in #4167 can be simplified to what it is in this PR because we upgraded to Drush 11 and this work: https://github.com/uiowa/uiowa/issues/4839

# To Test
- `ddev blt auda`
- Should see something like the below for each site:
```
[Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/vendor/bin/drush @self cc plugin --uri=admissions.uiowa.edu --no-interaction --ansi in /var/www/html/docroot
 [success] 'plugin' cache was cleared.
``` 