### PR TITLE
Config updates for now.uiowa

### DIFF
--- a/config/sites/now.uiowa.edu/config_split.patch.core.entity_form_display.node.article.default.yml
+++ b/config/sites/now.uiowa.edu/config_split.patch.core.entity_form_display.node.article.default.yml
@@ -7,6 +7,8 @@ adding:
     module:
       - smart_date
   content:
+    body:
+      weight: 2
     field_article_type:
       type: options_select
       weight: 1
@@ -37,8 +39,6 @@ adding:
         show_extra: false
         hide_date: true
       third_party_settings: {  }
-    body:
-      weight: 2
 removing:
   content:
     body:

--- a/config/sites/now.uiowa.edu/config_split.patch.core.entity_view_display.node.article.default.yml
+++ b/config/sites/now.uiowa.edu/config_split.patch.core.entity_view_display.node.article.default.yml
@@ -1,0 +1,6 @@
+adding:
+  hidden:
+    field_article_type: true
+    field_embargo_information: true
+    field_original_publication_date: true
+removing: {  }

--- a/config/sites/now.uiowa.edu/config_split.patch.core.entity_view_display.node.article.teaser.yml
+++ b/config/sites/now.uiowa.edu/config_split.patch.core.entity_view_display.node.article.teaser.yml
@@ -1,0 +1,6 @@
+adding:
+  hidden:
+    field_article_type: true
+    field_embargo_information: true
+    field_original_publication_date: true
+removing: {  }

--- a/config/sites/now.uiowa.edu/config_split.patch.core.entity_view_display.node.article.token.yml
+++ b/config/sites/now.uiowa.edu/config_split.patch.core.entity_view_display.node.article.token.yml
@@ -1,0 +1,6 @@
+adding:
+  hidden:
+    field_article_type: true
+    field_embargo_information: true
+    field_original_publication_date: true
+removing: {  }


### PR DESCRIPTION
Deployment failed on some config diffs. Updating config split to fix.

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

`git checkout now-config-hotfix && git pull`
`blt ds --site=now.uiowa.edu`
Site should sync and update correctly
`drush @now.local uli`
Add an article, check that Article Type field is available
If you select "News Feature" the embargo field appears just below
If you select "In the News" the Original Publication Date field appears below the article source fields