### PR TITLE
SiteNow v2 - re-export page display settings based on failed deploy

### DIFF
--- a/config/features/sitenow_v2/config_split.patch.core.entity_form_display.node.page.default.yml
+++ b/config/features/sitenow_v2/config_split.patch.core.entity_form_display.node.page.default.yml
@@ -2,7 +2,6 @@ adding:
   dependencies:
     config:
       - field.field.node.page.field_page_content_block
-      - field.field.node.page.layout_builder__layout
     module:
       - paragraphs
   content:

--- a/config/features/sitenow_v2/config_split.patch.core.entity_view_display.node.page.banner.yml
+++ b/config/features/sitenow_v2/config_split.patch.core.entity_view_display.node.page.banner.yml
@@ -2,7 +2,6 @@ adding:
   dependencies:
     config:
       - field.field.node.page.field_page_content_block
-      - field.field.node.page.layout_builder__layout
   hidden:
     field_page_content_block: true
 removing: {  }

--- a/config/features/sitenow_v2/config_split.patch.core.entity_view_display.node.page.teaser.yml
+++ b/config/features/sitenow_v2/config_split.patch.core.entity_view_display.node.page.teaser.yml
@@ -4,9 +4,4 @@ adding:
       - field.field.node.page.field_page_content_block
   hidden:
     field_page_content_block: true
-removing:
-  dependencies:
-    config:
-      - field.field.node.page.layout_builder__layout
-  hidden:
-    layout_builder__layout: true
+removing: {  }

--- a/config/features/sitenow_v2/config_split.patch.core.entity_view_display.node.page.token.yml
+++ b/config/features/sitenow_v2/config_split.patch.core.entity_view_display.node.page.token.yml
@@ -12,13 +12,8 @@ adding:
   hidden:
     field_page_content_block: true
 removing:
-  dependencies:
-    config:
-      - field.field.node.page.layout_builder__layout
   content:
     body:
       type: text_default
       label: hidden
       weight: 2
-  hidden:
-    layout_builder__layout: true


### PR DESCRIPTION
# To Test

- checkout main, pull, `ddev composer install` (`ddev restart` if you have been dabblin' in php 8)
- `ddev blt ds --site=law.uiowa.edu` -  see config import errors
- checkout `config-fix-v2`, pull
- `ddev blt ds --site=law.uiowa.edu` -  see no import errors