### PR TITLE
z-index fix for the sticky header for uiowa.edu

### DIFF
--- a/docroot/themes/custom/uids_base/package.json
+++ b/docroot/themes/custom/uids_base/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "ISC",
   "dependencies": {
-    "@uiowa/uids": "https://github.com/uiowa/uids.git#v3.6.17",
+    "@uiowa/uids": "https://github.com/uiowa/uids.git#2d4b661",
     "@uiowa/uids4": "https://github.com/uiowa/uids.git#40cb3cb",
     "autoprefixer": "^9.8.8",
     "breakpoint-sass": "^2.7.1",

--- a/docroot/themes/custom/uids_base/package.json
+++ b/docroot/themes/custom/uids_base/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "ISC",
   "dependencies": {
-    "@uiowa/uids": "https://github.com/uiowa/uids.git#2d4b661",
+    "@uiowa/uids": "https://github.com/uiowa/uids.git#v3.6.18",
     "@uiowa/uids4": "https://github.com/uiowa/uids.git#40cb3cb",
     "autoprefixer": "^9.8.8",
     "breakpoint-sass": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,9 +1173,9 @@
   dependencies:
     vue "^3.2.31"
 
-"@uiowa/uids@https://github.com/uiowa/uids.git#2d4b661":
-  version "3.6.17"
-  resolved "https://github.com/uiowa/uids.git#2d4b6618665f1fdbcd181b7756a28284b750991c"
+"@uiowa/uids@https://github.com/uiowa/uids.git#v3.6.18":
+  version "3.6.18"
+  resolved "https://github.com/uiowa/uids.git#f8c9a65bdba81dccccfc5b19cef9a9f7fa90538d"
   dependencies:
     autoprefixer "^9.8.6"
     cssnano "^4.1.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,9 +1173,9 @@
   dependencies:
     vue "^3.2.31"
 
-"@uiowa/uids@https://github.com/uiowa/uids.git#v3.6.17":
+"@uiowa/uids@https://github.com/uiowa/uids.git#2d4b661":
   version "3.6.17"
-  resolved "https://github.com/uiowa/uids.git#c8dab1fdbb760a39ddf78702f0b1836df6a8d4c1"
+  resolved "https://github.com/uiowa/uids.git#2d4b6618665f1fdbcd181b7756a28284b750991c"
   dependencies:
     autoprefixer "^9.8.6"
     cssnano "^4.1.11"


### PR DESCRIPTION
This pr moves the sticky header to `z-index: 3` so that it sits above the banner play button. 

# How to test

- `blt frontend`
- `ddev blt ds --site=uiowa.edu`
- Scroll down/scroll up on the home page until the banner play button overlaps with the sticky header. 

**Before**

<img width="735" alt="Screen Shot 2022-09-16 at 3 17 01 PM" src="https://user-images.githubusercontent.com/1036433/190726131-04ee48ab-15d9-40fd-8efc-296e0ff0341d.png">


**After**

<img width="866" alt="Screen Shot 2022-09-16 at 3 18 58 PM" src="https://user-images.githubusercontent.com/1036433/190726138-6d8120ae-29c9-47ff-9b12-90ef6edf8f47.png">
