### PR TITLE
Careers split for aggregator expire setting

### DIFF
--- a/config/sites/careers.uiowa.edu/.htaccess
+++ b/config/sites/careers.uiowa.edu/.htaccess
@@ -1,0 +1,27 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>
+<IfModule mod_php.c>
+  php_flag engine off
+</IfModule>

--- a/config/sites/careers.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/careers.uiowa.edu/config_split.config_split.site.yml
@@ -1,0 +1,17 @@
+uuid: 0ddb86d7-1520-4b09-9755-04f497f33932
+langcode: en
+status: true
+dependencies: {  }
+id: site
+label: Site
+description: ''
+weight: 70
+stackable: true
+storage: folder
+folder: ../config/sites/careers.uiowa.edu
+module: {  }
+theme: {  }
+complete_list:
+  - config_split.config_split.site
+partial_list:
+  - aggregator.settings

--- a/config/sites/careers.uiowa.edu/config_split.patch.aggregator.settings.yml
+++ b/config/sites/careers.uiowa.edu/config_split.patch.aggregator.settings.yml
@@ -1,0 +1,6 @@
+adding:
+  items:
+    expire: 2419200
+removing:
+  items:
+    expire: 31557600


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/5614

# To Test

- Checkout `careers_split`
- `ddev drush @careers.local uli admin/config/services/aggregator`
- See lots of items.
- `ddev drush @careers.local config:import --source ../config/sites/careers.uiowa.edu --partial && ddev drush @careers.local cim && ddev drush @careers.local cron`
- See less items after refresh. https://careers.uiowa.ddev.site/admin/config/services/aggregator