### PR TITLE
Removed words from pathauto's ignore_words setting

### DIFF
--- a/config/default/pathauto.settings.yml
+++ b/config/default/pathauto.settings.yml
@@ -42,7 +42,7 @@ max_component_length: 100
 transliterate: true
 reduce_ascii: false
 case: true
-ignore_words: 'a, an, as, at, before, but, by, for, from, is, in, into, like, of, off, on, onto, per, since, than, the, this, that, to, up, via, with'
+ignore_words: ''
 update_action: 2
 safe_tokens:
   - alias


### PR DESCRIPTION
This PR removes the following words from the `ignore_words` setting in pathauto:
`a, an, as, at, before, but, by, for, from, is, in, into, like, of, off, on, onto, per, since, than, the, this, that, to, up, via, with`

# Reasoning
According to [this documentation page on Drupal's site](https://www.drupal.org/node/847370):

> Pathauto has a feature to remove less important words from rewritten URLs in order to save space without compromising semantical meaning, or potentially, usefulness in search engine optimization (SEO).

[A person in the comments section of an issue](https://www.drupal.org/project/pathauto/issues/3298897) found [the original source of this list](https://www.drupal.org/project/pathauto/issues/84553), which dates back to **September 2006** and makes me question its relevance to modern SEO practices and general best practices.

I've had to constantly re-add words to URLs manually (and consequently this removes the benefits of something like `pathauto` automatically generating the URL) when the semantical meaning of the URL has actually been changed by the removal of these words. I don't really understand why these words need to be removed when you can end up with strange URLs that need to be promoted.

A few examples I've found of this going wrong:

- On the Mental Health at Iowa website, I've had to adjust URLs for various posts including "Social Media: What's the Right Fit For You" to put words back in them. For example: `social-media-whats-right-fit-you` had to be manually adjusted to `social-media-whats-the-right-fit-for-you`
- [Someone trying to have a URL containing `internet-of-things` with `of` being stripped out](https://www.drupal.org/project/pathauto/issues/3061797)
- [Someone trying to have a URL containing `talk-with-your-child-about-their-illness` with `with` being stripped out, making it look strange](https://stackoverflow.com/questions/23136495/drupal-automatic-url-alias-removing-words)
- [Someone questioning why `before` is on this list when a word like that could change the semantic definition of the URL, e.g. `what-to-do-before-climbing-a-mountain`](https://www.drupal.org/project/pathauto/issues/3298897).

# How to test

1. Check out this branch
2. Run `drush @sandbox.local cex`
3. Create a new page with one or more of the values in the `ignore_words` list in the title 
4. Note that this word is still in the url upon saving the page.
