### PR TITLE
Update "hide" logic for taxonomy term view on community colleges

### DIFF
--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
@@ -42,6 +42,13 @@ function admissions_core_entity_extra_field_info() {
 }
 
 /**
+ * Implements hook_preprocess_HOOK().
+ */
+function admissions_core_preprocess_taxonomy_term(&$variables) {
+  $foo = $variables;
+}
+
+/**
  * Implements hook_ENTITY_TYPE_view().
  */
 function admissions_core_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
@@ -763,6 +770,7 @@ function admissions_core_views_pre_render(ViewExecutable $view) {
         foreach ($view->result as $key => $value) {
           unset($view->result[$key]);
         }
+        unset($view->pager);
       }
     }
   }

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
@@ -42,13 +42,6 @@ function admissions_core_entity_extra_field_info() {
 }
 
 /**
- * Implements hook_preprocess_HOOK().
- */
-function admissions_core_preprocess_taxonomy_term(&$variables) {
-  $foo = $variables;
-}
-
-/**
  * Implements hook_ENTITY_TYPE_view().
  */
 function admissions_core_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
@@ -729,6 +729,28 @@ function admissions_core_theme_suggestions_field_alter(array &$suggestions, arra
 }
 
 /**
+ * Implements hook_views_pre_view().
+ */
+function admissions_core_views_pre_view(ViewExecutable $view, $display_id, array &$args) {
+  // Prevent taxonomy term view from executing on community colleges vocabulary.
+  // Results are instead rendered in an extra field in
+  // admissions_core_taxonomy_term_view().
+  if ($view->id() === 'taxonomy_term') {
+    if (\Drupal::routeMatch()
+      ->getRouteName() === 'entity.taxonomy_term.canonical' &&
+      $page_term_id = \Drupal::routeMatch()->getRawParameter('taxonomy_term')) {
+      $term = \Drupal::entityTypeManager()
+        ->getStorage('taxonomy_term')
+        ->load($page_term_id);
+      if ($term->bundle() === 'community_colleges') {
+        // Trick Views into not executing the view.
+        $view->executed = TRUE;
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_views_pre_render().
  */
 function admissions_core_views_pre_render(ViewExecutable $view) {
@@ -752,20 +774,6 @@ function admissions_core_views_pre_render(ViewExecutable $view) {
   if ($view->id() === 'areas_of_study') {
     $view->element['#attached']['library'][] = 'uids_base/stat';
     $view->element['#attached']['library'][] = 'uids_base/twocol';
-  }
-
-  // Ugly way to hide related node content but not taxonomy fields.
-  if ($view->id() === 'taxonomy_term') {
-    if (\Drupal::routeMatch()->getRouteName() === 'entity.taxonomy_term.canonical' &&
-      $page_term_id = \Drupal::routeMatch()->getRawParameter('taxonomy_term')) {
-      $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($page_term_id);
-      if ($term->bundle() === 'community_colleges') {
-        foreach ($view->result as $key => $value) {
-          unset($view->result[$key]);
-        }
-        unset($view->pager);
-      }
-    }
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/5894

# To Test

Pull branch and sync admissions.
Go to https://admissions.uiowa.edu/academics/2plus2/des-moines-area-community-college and see the pager.
Go to https://admissions.uiowa.ddev.site/academics/2plus2/des-moines-area-community-college and see *no* pager.