### PR TITLE
Temp minimal plus format

### DIFF
--- a/config/default/editor.editor.minimal_plus.yml
+++ b/config/default/editor.editor.minimal_plus.yml
@@ -1,0 +1,64 @@
+uuid: 0fef852a-3ae6-491d-b83a-327ee0ea7155
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.minimal_plus
+  module:
+    - ckeditor
+format: minimal_plus
+editor: ckeditor
+settings:
+  toolbar:
+    rows:
+      -
+        -
+          name: Formatting
+          items:
+            - Bold
+            - Underline
+            - Italic
+            - Strike
+            - JustifyLeft
+            - JustifyRight
+            - JustifyCenter
+            - JustifyBlock
+            - Superscript
+            - Subscript
+            - SpecialChar
+        -
+          name: Lists
+          items:
+            - BulletedList
+            - NumberedList
+        -
+          name: Links
+          items:
+            - DrupalLink
+            - DrupalUnlink
+        -
+          name: Media
+          items:
+            - Blockquote
+        -
+          name: Tools
+          items:
+            - Source
+            - Undo
+            - Redo
+        -
+          name: Format
+          items:
+            - Format
+  plugins:
+    drupallink:
+      linkit_enabled: true
+      linkit_profile: default
+image_upload:
+  status: false
+  scheme: public
+  directory: inline-images
+  max_size: ''
+  max_dimensions:
+    width: null
+    height: null

--- a/config/default/field.field.block_content.uiowa_card.field_uiowa_card_excerpt.yml
+++ b/config/default/field.field.block_content.uiowa_card.field_uiowa_card_excerpt.yml
@@ -11,7 +11,7 @@ dependencies:
 third_party_settings:
   allowed_formats:
     allowed_formats:
-      - minimal
+      - minimal_plus
       - plain_text
 _core:
   default_config_hash: d7-oWkJwADXKLY9QldFK28pif5n_srH-0UsqsZrZFrA

--- a/config/default/filter.format.minimal.yml
+++ b/config/default/filter.format.minimal.yml
@@ -6,7 +6,6 @@ dependencies:
     - editor
     - entity_embed
     - linkit
-    - media
     - uiowa_core
 name: 'Minimal HTML'
 format: minimal

--- a/config/default/filter.format.minimal_plus.yml
+++ b/config/default/filter.format.minimal_plus.yml
@@ -1,0 +1,97 @@
+uuid: e146ef17-33bc-45cc-a2eb-50c765311477
+langcode: en
+status: true
+dependencies:
+  module:
+    - editor
+    - entity_embed
+    - linkit
+    - uiowa_core
+name: 'Minimal HTML +'
+format: minimal_plus
+weight: -9
+filters:
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: false
+    weight: -47
+    settings: {  }
+  entity_embed:
+    id: entity_embed
+    provider: entity_embed
+    status: false
+    weight: -40
+    settings: {  }
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: false
+    weight: -46
+    settings: {  }
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: false
+    weight: -45
+    settings: {  }
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: false
+    weight: -44
+    settings: {  }
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -49
+    settings:
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title id target aria-label rel data-*> <u> <s> <sup> <sub> <div class="lead alert alert-success alert-info alert-warning alert-danger"> <p> <span role class="fa*"> <hr class=""> <br> <small class=""> <ul> <li> <ol>'
+      filter_html_help: true
+      filter_html_nofollow: false
+  filter_html_escape:
+    id: filter_html_escape
+    provider: filter
+    status: false
+    weight: -48
+    settings: {  }
+  filter_html_image_secure:
+    id: filter_html_image_secure
+    provider: filter
+    status: false
+    weight: -42
+    settings: {  }
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: -41
+    settings: {  }
+  filter_icon:
+    id: filter_icon
+    provider: uiowa_core
+    status: true
+    weight: -30
+    settings: {  }
+  filter_iframe:
+    id: filter_iframe
+    provider: uiowa_core
+    status: false
+    weight: -40
+    settings:
+      allowed_sources: ''
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: true
+    weight: -43
+    settings:
+      filter_url_length: 72
+  linkit:
+    id: linkit
+    provider: linkit
+    status: true
+    weight: -50
+    settings:
+      title: true

--- a/config/default/user.role.editor.yml
+++ b/config/default/user.role.editor.yml
@@ -9,6 +9,7 @@ dependencies:
     - filter.format.basic
     - filter.format.filtered_html
     - filter.format.minimal
+    - filter.format.minimal_plus
     - media.type.audio
     - media.type.facebook
     - media.type.file
@@ -239,6 +240,7 @@ permissions:
   - 'use text format basic'
   - 'use text format filtered_html'
   - 'use text format minimal'
+  - 'use text format minimal_plus'
   - 'view any unpublished content'
   - 'view article revisions'
   - 'view latest version'

--- a/config/default/user.role.publisher.yml
+++ b/config/default/user.role.publisher.yml
@@ -6,6 +6,7 @@ dependencies:
     - filter.format.basic
     - filter.format.filtered_html
     - filter.format.minimal
+    - filter.format.minimal_plus
     - media.type.audio
     - media.type.facebook
     - media.type.file
@@ -200,6 +201,7 @@ permissions:
   - 'use text format basic'
   - 'use text format filtered_html'
   - 'use text format minimal'
+  - 'use text format minimal_plus'
   - 'view any unpublished content'
   - 'view article revisions'
   - 'view latest version'

--- a/config/default/user.role.webmaster.yml
+++ b/config/default/user.role.webmaster.yml
@@ -8,6 +8,7 @@ dependencies:
     - filter.format.basic
     - filter.format.filtered_html
     - filter.format.minimal
+    - filter.format.minimal_plus
     - media.type.audio
     - media.type.facebook
     - media.type.file
@@ -348,6 +349,7 @@ permissions:
   - 'use text format basic'
   - 'use text format filtered_html'
   - 'use text format minimal'
+  - 'use text format minimal_plus'
   - 'view any unpublished content'
   - 'view any webform submission'
   - 'view article revisions'

--- a/config/sites/facilities.uiowa.edu/field.field.node.named_building.body.yml
+++ b/config/sites/facilities.uiowa.edu/field.field.node.named_building.body.yml
@@ -11,7 +11,7 @@ dependencies:
 third_party_settings:
   allowed_formats:
     allowed_formats:
-      - basic
+      - minimal_plus
 id: node.named_building.body
 field_name: body
 entity_type: node

--- a/config/sites/facilities.uiowa.edu/field.field.node.named_building.field_building_honoree_achieve.yml
+++ b/config/sites/facilities.uiowa.edu/field.field.node.named_building.field_building_honoree_achieve.yml
@@ -11,7 +11,7 @@ dependencies:
 third_party_settings:
   allowed_formats:
     allowed_formats:
-      - minimal
+      - minimal_plus
 id: node.named_building.field_building_honoree_achieve
 field_name: field_building_honoree_achieve
 entity_type: node

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -1900,3 +1900,22 @@ function sitenow_update_9049() {
 function sitenow_update_9050() {
   drupal_flush_all_caches();
 }
+
+/**
+ * Set existing banner blocks with a default button style value.
+ */
+function sitenow_update_9051() {
+  // Loop through our newly updated banner blocks.
+  foreach ([
+             'inline_block:uiowa_card',
+           ] as $block_plugin_id) {
+    _update_all_blocks_by_plugin_id($block_plugin_id, function (&$component, $block) {
+
+      // Change the format for the card excerpt.
+      if (!is_null($block)) {
+        $block->field_uiowa_card_excerpt->format = 'minimal_plus';
+        $block->save();
+      }
+    });
+  }
+}

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -1902,20 +1902,15 @@ function sitenow_update_9050() {
 }
 
 /**
- * Set existing banner blocks with a default button style value.
+ * Update card excerpt field format to the new minimal_plus format.
  */
 function sitenow_update_9051() {
-  // Loop through our newly updated banner blocks.
-  foreach ([
-             'inline_block:uiowa_card',
-           ] as $block_plugin_id) {
-    _update_all_blocks_by_plugin_id($block_plugin_id, function (&$component, $block) {
+  _update_all_blocks_by_plugin_id('inline_block:uiowa_card', function (&$component, $block) {
 
-      // Change the format for the card excerpt.
-      if (!is_null($block)) {
-        $block->field_uiowa_card_excerpt->format = 'minimal_plus';
-        $block->save();
-      }
-    });
-  }
+    // Change the format for the card excerpt.
+    if (!is_null($block)) {
+      $block->field_uiowa_card_excerpt->format = 'minimal_plus';
+      $block->save();
+    }
+  });
 }


### PR DESCRIPTION
Resolves #5472 
Resolves #6023 

# How to test

Quick setup:
```
ddev blt ds && ddev blt ds --site facilities.uiowa.edu && ddev drush @facilities.local cim --source ../config/sites/facilities.uiowa.edu --partial -y && ddev drush @default.local uli layout_builder/update/block/overrides/node.1/5/first/a5a7967b-da1a-495a-9a7f-ff6c67929abe && ddev drush @facilities.local uli node/add/named_building
```

- `ddev blt ds`
- `ddev blt ds --site facilities.uiowa.edu`
- `ddev drush @facilities.local cim --source ../config/sites/facilities.uiowa.edu --partial -y`
- `ddev drush @default.local uli layout_builder/update/block/overrides/node.1/5/first/a5a7967b-da1a-495a-9a7f-ff6c67929abe`
- `ddev drush @facilities.local uli node/add/named_building`
- Observe that update hook runs in both cases without errors.
- Click the first link to the default site and confirm that the Minimal + format is selected in the Card Excerpt field. You should not be able to choose the Minimal format.
- Click the second link to the facilities site and validate that you can use the new Minimal + format on the Description of Facilities and Achievements fields. You should not see an option to choose a text format.
- Compare the `editor.editor.minimal` and `editor.editor.minimal_plus` config files and confirm that the only changes are related to a new UUID, the name change, and the addition of the list options in a lists group.
- Compare the `filter.format.minimal` and `filter.format.minimal_plus` config files and confirm that the only changes are related to a new UUID, the name change, and the addition of the `ol`, `ul`, and `li` elements as allowed HTML.
- There is a change to the minimal format removing the media dependency. I did this because the minimal_plus format exported that way and reviewing the format it appears to not allow media.