### PR TITLE
Facilities views updates

### DIFF
--- a/config/sites/facilities.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/facilities.uiowa.edu/config_split.config_split.site.yml
@@ -19,8 +19,8 @@ complete_list:
   - pathauto.pattern.named_building
   - schemadotorg.schemadotorg_mapping.node.named_building
   - simple_sitemap.bundle_settings.default.node.named_building
-  - views.view.building_list
-  - views.view.named_buildings
+  - views.view.named_building_list
+  - views.view.named_building_details
   - 'field.storage.node.field_building_*'
 partial_list:
   - metatag.settings

--- a/config/sites/facilities.uiowa.edu/core.entity_view_display.node.named_building.default.yml
+++ b/config/sites/facilities.uiowa.edu/core.entity_view_display.node.named_building.default.yml
@@ -17,7 +17,7 @@ dependencies:
     - field.field.node.named_building.field_image
     - field.field.node.named_building.field_meta_tags
     - node.type.named_building
-    - views.view.named_buildings
+    - views.view.named_building_details
   module:
     - layout_builder
     - layout_builder_restrictions
@@ -181,7 +181,7 @@ third_party_settings:
             uuid: 39c2ce84-7276-44fc-852c-d0049eef9117
             region: first
             configuration:
-              id: 'views_block:named_buildings-block_honoree'
+              id: 'views_block:named_building_details-block_honoree'
               label: null
               label_display: null
               provider: views
@@ -225,7 +225,7 @@ third_party_settings:
             uuid: 577f857f-8063-47e5-95c1-2dd12a4d3d64
             region: content
             configuration:
-              id: 'views_block:named_buildings-block_building'
+              id: 'views_block:named_building_details-block_building'
               label: null
               label_display: null
               provider: views

--- a/config/sites/facilities.uiowa.edu/views.view.named_building_details.yml
+++ b/config/sites/facilities.uiowa.edu/views.view.named_building_details.yml
@@ -17,7 +17,7 @@ dependencies:
     - node
     - text
     - user
-id: named_buildings
+id: named_building_details
 label: 'Named Buildings'
 module: views
 description: ''

--- a/config/sites/facilities.uiowa.edu/views.view.named_building_list.yml
+++ b/config/sites/facilities.uiowa.edu/views.view.named_building_list.yml
@@ -9,8 +9,8 @@ dependencies:
   module:
     - node
     - user
-id: building_list
-label: 'Building list'
+id: named_building_list
+label: 'Named building list'
 module: views
 description: ''
 tag: ''
@@ -23,7 +23,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: 'Building list'
+      title: 'Named building list'
       fields:
         field_building_honoree_name:
           id: field_building_honoree_name

--- a/docroot/sites/facilities.uiowa.edu/modules/facilities_core/facilities_core.module
+++ b/docroot/sites/facilities.uiowa.edu/modules/facilities_core/facilities_core.module
@@ -91,14 +91,14 @@ function facilities_core_preprocess_layout(&$variables) {
  */
 function facilities_core_preprocess_block(&$variables) {
   switch ($variables['plugin_id']) {
-    case 'views_block:named_buildings-block_honoree':
+    case 'views_block:named_building_details-block_honoree':
       if (!isset($variables['attributes']['class'])) {
         $variables['attributes']['class'] = [''];
       }
       $variables['attributes']['class'][] .= 'bg--gray block-padding__all block-margin__default--removed';
       break;
 
-    case 'views_block:named_buildings-block_building':
+    case 'views_block:named_building_details-block_building':
       if (!isset($variables['attributes']['class'])) {
         $variables['attributes']['class'] = [''];
       }


### PR DESCRIPTION
- Updated label of block displaying named buildings list from "Building list" to "Named building list".
- Renamed views machine names to be less ambiguous so that our future selves might be less confused.

# How to test

```
ddev blt ds --site facilities.uiowa.edu && ddev drush @facilities.local uli node/1/layout
```
- Click an "Add component" button, click "More..." in the drop-down.
- Verify that the block show up under site custom as "Named building list"
- https://facilities.uiowa.ddev.site/admin/content
- Check that named building pages are still showing up correctly with their honoree info and building info sections showing correctly.