### PR TITLE
fix default content card blocks

### DIFF
--- a/docroot/profiles/custom/sitenow/content/block_content/3e775397-cb1e-40de-9c53-f00e328edc2d.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/3e775397-cb1e-40de-9c53-f00e328edc2d.yml
@@ -19,7 +19,7 @@ default:
   field_uiowa_card_excerpt:
     -
       value: "<p>Browse the service site or contact us with any questions you have about the SiteNow service.</p>\r\n"
-      format: minimal
+      format: minimal_plus
   field_uiowa_card_image:
     -
       entity: fc23ffc0-95e1-45ff-ab07-b92464068d66

--- a/docroot/profiles/custom/sitenow/content/block_content/41c43a1b-0473-45b1-b799-2b235c3904fb.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/41c43a1b-0473-45b1-b799-2b235c3904fb.yml
@@ -19,7 +19,7 @@ default:
   field_uiowa_card_excerpt:
     -
       value: "<p>Reach out directly to the team building the SiteNow service.</p>\r\n"
-      format: minimal
+      format: minimal_plus
   field_uiowa_card_image:
     -
       entity: be324113-25ee-43e3-b6f2-26ce619ce852

--- a/docroot/profiles/custom/sitenow/content/block_content/5026fa65-d6f5-464b-820b-e1cca3ff6be3.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/5026fa65-d6f5-464b-820b-e1cca3ff6be3.yml
@@ -17,7 +17,7 @@ default:
   field_uiowa_card_excerpt:
     -
       value: "<p>Site support, feature questions, and general requests.</p>\r\n"
-      format: minimal
+      format: minimal_plus
   field_uiowa_card_link:
     -
       uri: 'https://sitenow.uiowa.edu/contact-us'

--- a/docroot/profiles/custom/sitenow/content/block_content/5294fe6f-aad8-46ab-8b48-f98d11e41818.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/5294fe6f-aad8-46ab-8b48-f98d11e41818.yml
@@ -17,7 +17,7 @@ default:
   field_uiowa_card_excerpt:
     -
       value: "<p>Consultations on site content, web strategy, and what to put on your website.&nbsp;</p>\r\n"
-      format: minimal
+      format: minimal_plus
   field_uiowa_card_link:
     -
       uri: 'mailto:UI-web-strategy@uiowa.edu'

--- a/docroot/profiles/custom/sitenow/content/block_content/631979b9-cf39-46d2-a357-e8857487fccd.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/631979b9-cf39-46d2-a357-e8857487fccd.yml
@@ -19,7 +19,7 @@ default:
   field_uiowa_card_excerpt:
     -
       value: "<p>Attend or watch a recorded SiteNow/Layout Builder training session offered by the web team.</p>\r\n"
-      format: minimal
+      format: minimal_plus
   field_uiowa_card_image:
     -
       entity: c064e28e-aae9-42f5-bb15-f40fa1d8a3d7

--- a/docroot/profiles/custom/sitenow/content/block_content/81baa7ae-8510-4cec-ad00-c29e95098229.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/81baa7ae-8510-4cec-ad00-c29e95098229.yml
@@ -17,7 +17,7 @@ default:
   field_uiowa_card_excerpt:
     -
       value: "<p>Updates, feature info, and Help documents for the SiteNow service.</p>\r\n"
-      format: minimal
+      format: minimal_plus
   field_uiowa_card_link:
     -
       uri: 'https://sitenow.uiowa.edu/'

--- a/docroot/profiles/custom/sitenow/content/block_content/e8a1a5d7-a7c6-4b59-a13d-ee498ec7232c.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/e8a1a5d7-a7c6-4b59-a13d-ee498ec7232c.yml
@@ -19,7 +19,7 @@ default:
   field_uiowa_card_excerpt:
     -
       value: "<p>Stay up-to-date on upcoming features and the web team's current priorities.&nbsp;</p>\r\n"
-      format: minimal
+      format: minimal_plus
   field_uiowa_card_image:
     -
       entity: d872b41f-45af-4c94-9054-56d249130203

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -1924,3 +1924,18 @@ function sitenow_update_9052() {
   $config_storage = \Drupal::service('config.storage');
   $config_storage->write('config_ignore.settings', $source->read('config_ignore.settings'));
 }
+
+/**
+ * Re-run of 9051 to pick up newly provisioned sites
+ * that didn't have the correct format.
+ */
+function sitenow_update_9053() {
+  _update_all_blocks_by_plugin_id('inline_block:uiowa_card', function (&$component, $block) {
+
+    // Change the format for the card excerpt.
+    if (!is_null($block)) {
+      $block->field_uiowa_card_excerpt->format = 'minimal_plus';
+      $block->save();
+    }
+  });
+}

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -1933,8 +1933,10 @@ function sitenow_update_9053() {
 
     // Change the format for the card excerpt.
     if (!is_null($block)) {
-      $block->field_uiowa_card_excerpt->format = 'minimal_plus';
-      $block->save();
+      if ($block->get('field_uiowa_card_excerpt')->format !== 'minimal_plus') {
+        $block->field_uiowa_card_excerpt->format = 'minimal_plus';
+        $block->save();
+      }
     }
   });
 }

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -1926,8 +1926,7 @@ function sitenow_update_9052() {
 }
 
 /**
- * Re-run of 9051 to pick up newly provisioned sites
- * that didn't have the correct format.
+ * Re-run of 9051 to fix recently provisioned sites.
  */
 function sitenow_update_9053() {
   _update_all_blocks_by_plugin_id('inline_block:uiowa_card', function (&$component, $block) {


### PR DESCRIPTION
# How to test

```
ddev blt di --site=default && ddev blt ds --site=daly.lab.uiowa.edu
```

```
ddev drush @default.local uli node/2/layout
```

pick a card to inspect. should be minimal plus.

```
ddev drush @labdaly.local uli node/1/layout
```

pick a card to inspect. should be minimal plus.

might have to `blt bis` to get daly.lab to sync.