### PR TITLE
Hotfix for views exposed form reset link

### DIFF
--- a/docroot/themes/custom/uids_base/scss/views/views.scss
+++ b/docroot/themes/custom/uids_base/scss/views/views.scss
@@ -8,6 +8,7 @@
   min-height: 20px;
   padding: 19px;
   margin-bottom: 2rem;
+  position: relative;
 
   [type=checkbox], [type=radio] {
     height: 1.2rem;


### PR DESCRIPTION
Test the reset button https://iowasummerwritingfestival.prod.drupal.uiowa.edu/events. 

`ddev blt frontend`
`ddev blt ds --site=iowasummerwritingfestival.uiowa.edu`
Test https://iowasummerwritingfestival.uiowa.ddev.site/events in a private window.  Reset button should be placed under search and not above. 