### PR TITLE
remove non-existent option

### DIFF
--- a/scripts/deploy_branch
+++ b/scripts/deploy_branch
@@ -2,6 +2,6 @@
 
 set -ev
 
-blt artifact:deploy:check-dirty --ansi --commit-msg "Automated commit by Travis CI for Build ${TRAVIS_BUILD_ID}" --branch "${TRAVIS_BRANCH}-build" --no-interaction --verbose
+blt artifact:deploy:check-dirty --ansi --branch "${TRAVIS_BRANCH}-build" --no-interaction --verbose
 
 set +v


### PR DESCRIPTION
```
blt artifact:deploy:check-dirty --ansi --commit-msg "Automated commit by Travis CI for Build ${TRAVIS_BUILD_ID}" --branch "${TRAVIS_BRANCH}-build" --no-interaction --verbose
In ArgvInput.php line 201:
                                                          
  [Symfony\Component\Console\Exception\RuntimeException]  
  The "--commit-msg" option does not exist. 
```

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
