### PR TITLE
remove other non-existent options

### DIFF
--- a/scripts/deploy_branch
+++ b/scripts/deploy_branch
@@ -2,6 +2,6 @@
 
 set -ev
 
-blt artifact:deploy:check-dirty --ansi --branch "${TRAVIS_BRANCH}-build" --no-interaction --verbose
+blt artifact:deploy:check-dirty --ansi --verbose
 
 set +v


### PR DESCRIPTION
```
blt artifact:deploy:check-dirty --ansi --branch "${TRAVIS_BRANCH}-build" --no-interaction --verbose
In ArgvInput.php line 201:
                                                          
  [Symfony\Component\Console\Exception\RuntimeException]  
  The "--branch" option does not exist. 
```