### PR TITLE
Iowa Now: experts list wsod fix

### DIFF
--- a/docroot/sites/now.uiowa.edu/modules/now_core/now_core.module
+++ b/docroot/sites/now.uiowa.edu/modules/now_core/now_core.module
@@ -314,7 +314,7 @@ function now_core_preprocess_views_view_unformatted(&$variables) {
         'card_title' => $style->getField($id, 'title'),
         'card_link_url' => $link,
         'card_subtitle' => $style->getField($id, 'field_person_position'),
-        'card_meta' => $meta,
+        'card_meta' => \Drupal::service('renderer')->render($meta),
         'card_text' => $style->getField($id, 'field_person_research_areas'),
       ];
     }


### PR DESCRIPTION
Another episode of https://github.com/uiowa/uiowa/pull/6029.   

# How to test
`ddev blt ds --site=now.uiowa.edu`
Go to /experts-list and verify that the page loads and works. 