### PR TITLE
Hotfix: Updated UIDS4 version with updated md breakpoint

### DIFF
--- a/docroot/themes/custom/uids_base/package.json
+++ b/docroot/themes/custom/uids_base/package.json
@@ -4,7 +4,7 @@
   "license": "ISC",
   "dependencies": {
     "@uiowa/uids": "https://github.com/uiowa/uids.git#581a215",
-    "@uiowa/uids4": "https://github.com/uiowa/uids.git#2a20b04",
+    "@uiowa/uids4": "https://github.com/uiowa/uids.git#4f6a3af",
     "autoprefixer": "^9.8.8",
     "breakpoint-sass": "^3.0.0",
     "cssnano": "^4.1.11",

--- a/docroot/themes/custom/uids_base/scss/components/banner.scss
+++ b/docroot/themes/custom/uids_base/scss/components/banner.scss
@@ -58,21 +58,18 @@
     .headline--large.headline--serif:not([class*="banner__pre-title"]),
     .headline--large:not([class*="banner__pre-title"]) {
       font-size: 2.6rem;
-      font-size: containerClamp(2.6rem, 2.6rem);
     }
 
     // Set medium heading size
     .headline--medium.headline--serif:not([class*="banner__pre-title"]),
     .headline--medium:not([class*="banner__pre-title"]) {
       font-size: 2.2rem;
-      font-size: containerClamp(2.1rem, 2.1rem);
     }
 
     // Set small heading size
     .headline--small.headline--serif:not([class*="banner__pre-title"]),
     .headline--small:not([class*="banner__pre-title"]) {
       font-size: 1.8rem;
-      font-size: containerClamp(1.6rem, 1.6rem);
     }
   }
 
@@ -183,7 +180,8 @@
 .layout--title.banner .bold-headline,
 .layout--title.banner .headline.page-title {
   font-size: 4.7rem;
-  font-size: containerClamp(2.5rem, 4.7rem);
+  // https://garyridgway.github.io/clampCalculator/?minWidth=600&maxWidth=1310&minFontSize=2.5&maxFontSize=4.7&auto
+  font-size: clamp(2.5rem, calc(4.9577vw + 0.6408rem), 4.7rem);
 }
 
 .banner__image {

--- a/docroot/themes/custom/uids_base/scss/content/person.scss
+++ b/docroot/themes/custom/uids_base/scss/content/person.scss
@@ -40,7 +40,8 @@
   .field--name-field-person-position {
     margin-top: .6rem;
     .field__item {
-      font-size: containerClamp(1.8rem, 2.3rem);
+      // https://garyridgway.github.io/clampCalculator/?minWidth=600&maxWidth=1310&minFontSize=1.8&maxFontSize=2.3&auto
+      font-size: clamp(1.8rem, calc(1.1268vw + 1.3775rem), 2.3rem);
       line-height: 1.1;
       font-weight: 300;
       margin-bottom: .5rem;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1213,9 +1213,9 @@
   dependencies:
     "@types/node" "*"
 
-"@uiowa/uids4@https://github.com/uiowa/uids.git#2a20b04":
+"@uiowa/uids4@https://github.com/uiowa/uids.git#4f6a3af":
   version "4.0.0-alpha1"
-  resolved "https://github.com/uiowa/uids.git#2a20b04ba7d1f3fbbc0c4f792015be856cbe5ae0"
+  resolved "https://github.com/uiowa/uids.git#4f6a3af99257f7c29e3ad9426028200c893dde02"
   dependencies:
     vue "^3.2.31"
 


### PR DESCRIPTION
Noticed this while testing https://github.com/uiowa/uiowa/pull/6135.  We made an update to the `md` breakpoint back in November but did not update it in 4.x UIDS.  This pr makes that update to UIDS4. 

# How to test
- `ddev blt frontend`
- `ddev blt ds --site=csd.uiowa.edu`
- Collapse https://csd.uiowa.ddev.site/research down and the blocks should appear like this screenshot below. 
<img width="916" alt="Screen Shot 2023-01-27 at 12 42 45 PM" src="https://user-images.githubusercontent.com/1036433/215168832-23429385-37a6-40d2-af49-57a4f6e7d8f1.png">
