### PR TITLE
Image block updates for UI Press

### DIFF
--- a/config/default/layout_builder_styles.style.banner_centered.yml
+++ b/config/default/layout_builder_styles.style.banner_centered.yml
@@ -10,4 +10,4 @@ group: banner_type
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: 31
+weight: 37

--- a/config/default/layout_builder_styles.style.banner_centered_left.yml
+++ b/config/default/layout_builder_styles.style.banner_centered_left.yml
@@ -10,4 +10,4 @@ group: banner_type
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: 26
+weight: 32

--- a/config/default/layout_builder_styles.style.banner_gradient_dark.yml
+++ b/config/default/layout_builder_styles.style.banner_gradient_dark.yml
@@ -10,4 +10,4 @@ group: banner_gradient
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: -6
+weight: -12

--- a/config/default/layout_builder_styles.style.banner_gradient_light.yml
+++ b/config/default/layout_builder_styles.style.banner_gradient_light.yml
@@ -10,4 +10,4 @@ group: banner_gradient
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: 28
+weight: 34

--- a/config/default/layout_builder_styles.style.banner_large.yml
+++ b/config/default/layout_builder_styles.style.banner_large.yml
@@ -10,4 +10,4 @@ group: banner_height
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: 34
+weight: 40

--- a/config/default/layout_builder_styles.style.banner_lower_centered.yml
+++ b/config/default/layout_builder_styles.style.banner_lower_centered.yml
@@ -10,4 +10,4 @@ group: banner_type
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: -11
+weight: -17

--- a/config/default/layout_builder_styles.style.banner_lower_left.yml
+++ b/config/default/layout_builder_styles.style.banner_lower_left.yml
@@ -10,4 +10,4 @@ group: banner_type
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: 27
+weight: 33

--- a/config/default/layout_builder_styles.style.banner_medium.yml
+++ b/config/default/layout_builder_styles.style.banner_medium.yml
@@ -10,4 +10,4 @@ group: banner_height
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: 33
+weight: 39

--- a/config/default/layout_builder_styles.style.banner_overlay.yml
+++ b/config/default/layout_builder_styles.style.banner_overlay.yml
@@ -10,4 +10,4 @@ group: default
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: 0
+weight: 5

--- a/config/default/layout_builder_styles.style.banner_small.yml
+++ b/config/default/layout_builder_styles.style.banner_small.yml
@@ -10,4 +10,4 @@ group: banner_height
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: 29
+weight: 35

--- a/config/default/layout_builder_styles.style.block_alignment_center.yml
+++ b/config/default/layout_builder_styles.style.block_alignment_center.yml
@@ -13,4 +13,4 @@ block_restrictions:
   - 'inline_block:uiowa_button'
   - 'inline_block:uiowa_spacer_separator'
 layout_restrictions: {  }
-weight: -51
+weight: -57

--- a/config/default/layout_builder_styles.style.block_alignment_flex_row_center.yml
+++ b/config/default/layout_builder_styles.style.block_alignment_flex_row_center.yml
@@ -13,4 +13,4 @@ block_restrictions:
   - 'inline_block:uiowa_cta'
   - 'inline_block:uiowa_statistic'
 layout_restrictions: {  }
-weight: -50
+weight: -56

--- a/config/default/layout_builder_styles.style.block_alignment_flex_row_left.yml
+++ b/config/default/layout_builder_styles.style.block_alignment_flex_row_left.yml
@@ -12,4 +12,4 @@ group: alignment
 block_restrictions:
   - 'inline_block:uiowa_statistic'
 layout_restrictions: {  }
-weight: -49
+weight: -55

--- a/config/default/layout_builder_styles.style.block_alignment_left.yml
+++ b/config/default/layout_builder_styles.style.block_alignment_left.yml
@@ -12,4 +12,4 @@ group: alignment
 block_restrictions:
   - 'inline_block:uiowa_cta'
 layout_restrictions: {  }
-weight: -48
+weight: -54

--- a/config/default/layout_builder_styles.style.block_background_style_black.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_black.yml
@@ -18,4 +18,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: -47
+weight: -53

--- a/config/default/layout_builder_styles.style.block_background_style_brain_pattern.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_brain_pattern.yml
@@ -12,4 +12,4 @@ group: background
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: -45
+weight: -51

--- a/config/default/layout_builder_styles.style.block_background_style_brain_pattern_black.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_brain_pattern_black.yml
@@ -11,4 +11,4 @@ block_restrictions:
   - 'inline_block:uiowa_banner'
   - 'inline_block:uiowa_cta'
 layout_restrictions: {  }
-weight: -44
+weight: -50

--- a/config/default/layout_builder_styles.style.block_background_style_brain_pattern_reversed.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_brain_pattern_reversed.yml
@@ -12,4 +12,4 @@ group: background
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: -43
+weight: -49

--- a/config/default/layout_builder_styles.style.block_background_style_gold.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_gold.yml
@@ -18,4 +18,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: -42
+weight: -48

--- a/config/default/layout_builder_styles.style.block_background_style_gray.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_gray.yml
@@ -20,4 +20,4 @@ block_restrictions:
   - 'views_block:people_list_block-list_card'
   - webform_block
 layout_restrictions: {  }
-weight: -41
+weight: -47

--- a/config/default/layout_builder_styles.style.block_background_style_light.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_light.yml
@@ -17,4 +17,4 @@ block_restrictions:
   - 'views_block:people_list_block-list_card'
   - webform_block
 layout_restrictions: {  }
-weight: -46
+weight: -52

--- a/config/default/layout_builder_styles.style.block_card_style_border.yml
+++ b/config/default/layout_builder_styles.style.block_card_style_border.yml
@@ -16,4 +16,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: -40
+weight: -46

--- a/config/default/layout_builder_styles.style.block_grid_threecol_33_34_33.yml
+++ b/config/default/layout_builder_styles.style.block_grid_threecol_33_34_33.yml
@@ -15,4 +15,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: -13
+weight: -19

--- a/config/default/layout_builder_styles.style.block_grid_twocol_50_50.yml
+++ b/config/default/layout_builder_styles.style.block_grid_twocol_50_50.yml
@@ -15,4 +15,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: -10
+weight: -16

--- a/config/default/layout_builder_styles.style.block_heading_bold_headline.yml
+++ b/config/default/layout_builder_styles.style.block_heading_bold_headline.yml
@@ -12,4 +12,4 @@ group: default
 block_restrictions:
   - 'inline_block:uiowa_heading'
 layout_restrictions: {  }
-weight: -31
+weight: -37

--- a/config/default/layout_builder_styles.style.block_hide_descriptions.yml
+++ b/config/default/layout_builder_styles.style.block_hide_descriptions.yml
@@ -13,4 +13,4 @@ block_restrictions:
   - 'inline_block:uiowa_people'
   - 'inline_block:uiowa_aggregator'
 layout_restrictions: {  }
-weight: -18
+weight: -24

--- a/config/default/layout_builder_styles.style.block_hide_details.yml
+++ b/config/default/layout_builder_styles.style.block_hide_details.yml
@@ -13,4 +13,4 @@ block_restrictions:
   - 'inline_block:uiowa_people'
   - 'inline_block:uiowa_aggregator'
 layout_restrictions: {  }
-weight: -17
+weight: -23

--- a/config/default/layout_builder_styles.style.block_hide_images.yml
+++ b/config/default/layout_builder_styles.style.block_hide_images.yml
@@ -13,4 +13,4 @@ block_restrictions:
   - 'inline_block:uiowa_people'
   - 'inline_block:uiowa_aggregator'
 layout_restrictions: {  }
-weight: 25
+weight: 31

--- a/config/default/layout_builder_styles.style.block_image_gallery_style_masonry.yml
+++ b/config/default/layout_builder_styles.style.block_image_gallery_style_masonry.yml
@@ -10,4 +10,4 @@ group: default
 block_restrictions:
   - 'inline_block:uiowa_image_gallery'
 layout_restrictions: {  }
-weight: -30
+weight: -36

--- a/config/default/layout_builder_styles.style.block_margin_bottom.yml
+++ b/config/default/layout_builder_styles.style.block_margin_bottom.yml
@@ -15,4 +15,4 @@ block_restrictions:
   - 'inline_block:uiowa_text_area'
   - webform_block
 layout_restrictions: {  }
-weight: -29
+weight: -35

--- a/config/default/layout_builder_styles.style.block_margin_bottom_extra.yml
+++ b/config/default/layout_builder_styles.style.block_margin_bottom_extra.yml
@@ -11,4 +11,4 @@ block_restrictions:
   - 'inline_block:uiowa_collection'
   - 'inline_block:uiowa_text_area'
 layout_restrictions: {  }
-weight: -28
+weight: -34

--- a/config/default/layout_builder_styles.style.block_margin_default_removed.yml
+++ b/config/default/layout_builder_styles.style.block_margin_default_removed.yml
@@ -34,4 +34,4 @@ block_restrictions:
   - sitenow_dispatch_thankyou_form
   - webform_block
 layout_restrictions: {  }
-weight: 0
+weight: 2

--- a/config/default/layout_builder_styles.style.block_margin_left.yml
+++ b/config/default/layout_builder_styles.style.block_margin_left.yml
@@ -14,4 +14,4 @@ block_restrictions:
   - 'inline_block:uiowa_text_area'
   - webform_block
 layout_restrictions: {  }
-weight: -27
+weight: -33

--- a/config/default/layout_builder_styles.style.block_margin_right.yml
+++ b/config/default/layout_builder_styles.style.block_margin_right.yml
@@ -14,4 +14,4 @@ block_restrictions:
   - 'inline_block:uiowa_text_area'
   - webform_block
 layout_restrictions: {  }
-weight: -26
+weight: -32

--- a/config/default/layout_builder_styles.style.block_margin_top.yml
+++ b/config/default/layout_builder_styles.style.block_margin_top.yml
@@ -15,4 +15,4 @@ block_restrictions:
   - 'inline_block:uiowa_text_area'
   - webform_block
 layout_restrictions: {  }
-weight: -25
+weight: -31

--- a/config/default/layout_builder_styles.style.block_margin_top_extra.yml
+++ b/config/default/layout_builder_styles.style.block_margin_top_extra.yml
@@ -11,4 +11,4 @@ block_restrictions:
   - 'inline_block:uiowa_collection'
   - 'inline_block:uiowa_text_area'
 layout_restrictions: {  }
-weight: -24
+weight: -30

--- a/config/default/layout_builder_styles.style.block_maui_hide_session_badges.yml
+++ b/config/default/layout_builder_styles.style.block_maui_hide_session_badges.yml
@@ -10,4 +10,4 @@ group: default
 block_restrictions:
   - uiowa_maui_academic_dates
 layout_restrictions: {  }
-weight: 11
+weight: 16

--- a/config/default/layout_builder_styles.style.block_menu_horizontal.yml
+++ b/config/default/layout_builder_styles.style.block_menu_horizontal.yml
@@ -10,4 +10,4 @@ group: menu_orientation
 block_restrictions:
   - 'menu_block:main'
 layout_restrictions: {  }
-weight: -23
+weight: -29

--- a/config/default/layout_builder_styles.style.block_menu_vertical.yml
+++ b/config/default/layout_builder_styles.style.block_menu_vertical.yml
@@ -10,4 +10,4 @@ group: menu_orientation
 block_restrictions:
   - 'menu_block:main'
 layout_restrictions: {  }
-weight: -22
+weight: -28

--- a/config/default/layout_builder_styles.style.block_padding_all.yml
+++ b/config/default/layout_builder_styles.style.block_padding_all.yml
@@ -13,4 +13,4 @@ block_restrictions:
   - 'inline_block:uiowa_text_area'
   - webform_block
 layout_restrictions: {  }
-weight: -21
+weight: -27

--- a/config/default/layout_builder_styles.style.block_padding_all_extra.yml
+++ b/config/default/layout_builder_styles.style.block_padding_all_extra.yml
@@ -11,4 +11,4 @@ block_restrictions:
   - 'inline_block:uiowa_text_area'
   - webform_block
 layout_restrictions: {  }
-weight: -20
+weight: -26

--- a/config/default/layout_builder_styles.style.block_statistic_style_horizontal.yml
+++ b/config/default/layout_builder_styles.style.block_statistic_style_horizontal.yml
@@ -10,4 +10,4 @@ group: default
 block_restrictions:
   - 'inline_block:uiowa_statistic'
 layout_restrictions: {  }
-weight: 30
+weight: 36

--- a/config/default/layout_builder_styles.style.block_style_hero_grid.yml
+++ b/config/default/layout_builder_styles.style.block_style_hero_grid.yml
@@ -10,4 +10,4 @@ group: default
 block_restrictions:
   - 'inline_block:uiowa_hero'
 layout_restrictions: {  }
-weight: -19
+weight: -25

--- a/config/default/layout_builder_styles.style.block_style_hero_left_aligned.yml
+++ b/config/default/layout_builder_styles.style.block_style_hero_left_aligned.yml
@@ -12,4 +12,4 @@ group: default
 block_restrictions:
   - 'inline_block:uiowa_hero'
 layout_restrictions: {  }
-weight: 32
+weight: 38

--- a/config/default/layout_builder_styles.style.button_font_thin.yml
+++ b/config/default/layout_builder_styles.style.button_font_thin.yml
@@ -11,4 +11,4 @@ block_restrictions:
   - 'inline_block:uiowa_banner'
   - 'inline_block:uiowa_button'
 layout_restrictions: {  }
-weight: 0
+weight: 3

--- a/config/default/layout_builder_styles.style.button_full_width.yml
+++ b/config/default/layout_builder_styles.style.button_full_width.yml
@@ -10,4 +10,4 @@ group: button_width
 block_restrictions:
   - 'inline_block:uiowa_button'
 layout_restrictions: {  }
-weight: 0
+weight: -2

--- a/config/default/layout_builder_styles.style.button_large.yml
+++ b/config/default/layout_builder_styles.style.button_large.yml
@@ -10,4 +10,4 @@ group: button_size
 block_restrictions:
   - 'inline_block:uiowa_button'
 layout_restrictions: {  }
-weight: 0
+weight: -5

--- a/config/default/layout_builder_styles.style.button_medium.yml
+++ b/config/default/layout_builder_styles.style.button_medium.yml
@@ -10,4 +10,4 @@ group: button_size
 block_restrictions:
   - 'inline_block:uiowa_button'
 layout_restrictions: {  }
-weight: 0
+weight: -4

--- a/config/default/layout_builder_styles.style.button_primary.yml
+++ b/config/default/layout_builder_styles.style.button_primary.yml
@@ -11,4 +11,4 @@ block_restrictions:
   - 'inline_block:uiowa_banner'
   - 'inline_block:uiowa_button'
 layout_restrictions: {  }
-weight: 0
+weight: -1

--- a/config/default/layout_builder_styles.style.button_secondary.yml
+++ b/config/default/layout_builder_styles.style.button_secondary.yml
@@ -11,4 +11,4 @@ block_restrictions:
   - 'inline_block:uiowa_banner'
   - 'inline_block:uiowa_button'
 layout_restrictions: {  }
-weight: 0
+weight: -6

--- a/config/default/layout_builder_styles.style.button_small.yml
+++ b/config/default/layout_builder_styles.style.button_small.yml
@@ -10,4 +10,4 @@ group: button_size
 block_restrictions:
   - 'inline_block:uiowa_button'
 layout_restrictions: {  }
-weight: 0
+weight: -3

--- a/config/default/layout_builder_styles.style.button_tertiary.yml
+++ b/config/default/layout_builder_styles.style.button_tertiary.yml
@@ -11,4 +11,4 @@ block_restrictions:
   - 'inline_block:uiowa_banner'
   - 'inline_block:uiowa_button'
 layout_restrictions: {  }
-weight: 0
+weight: 4

--- a/config/default/layout_builder_styles.style.button_tertiary_outline.yml
+++ b/config/default/layout_builder_styles.style.button_tertiary_outline.yml
@@ -11,4 +11,4 @@ block_restrictions:
   - 'inline_block:uiowa_banner'
   - 'inline_block:uiowa_button'
 layout_restrictions: {  }
-weight: 0
+weight: 1

--- a/config/default/layout_builder_styles.style.card_image_large.yml
+++ b/config/default/layout_builder_styles.style.card_image_large.yml
@@ -14,4 +14,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: -36
+weight: -42

--- a/config/default/layout_builder_styles.style.card_image_medium.yml
+++ b/config/default/layout_builder_styles.style.card_image_medium.yml
@@ -14,4 +14,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: -35
+weight: -41

--- a/config/default/layout_builder_styles.style.card_image_small.yml
+++ b/config/default/layout_builder_styles.style.card_image_small.yml
@@ -14,4 +14,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: -34
+weight: -40

--- a/config/default/layout_builder_styles.style.card_media_position_left.yml
+++ b/config/default/layout_builder_styles.style.card_media_position_left.yml
@@ -14,4 +14,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: -38
+weight: -44

--- a/config/default/layout_builder_styles.style.card_media_position_right.yml
+++ b/config/default/layout_builder_styles.style.card_media_position_right.yml
@@ -14,4 +14,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: -37
+weight: -43

--- a/config/default/layout_builder_styles.style.card_media_position_stacked.yml
+++ b/config/default/layout_builder_styles.style.card_media_position_stacked.yml
@@ -14,4 +14,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: -39
+weight: -45

--- a/config/default/layout_builder_styles.style.card_style_button_position.yml
+++ b/config/default/layout_builder_styles.style.card_style_button_position.yml
@@ -12,4 +12,4 @@ block_restrictions:
   - 'inline_block:uiowa_events'
   - 'inline_block:uiowa_aggregator'
 layout_restrictions: {  }
-weight: -8
+weight: -14

--- a/config/default/layout_builder_styles.style.content_alignment_center.yml
+++ b/config/default/layout_builder_styles.style.content_alignment_center.yml
@@ -14,4 +14,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: -33
+weight: -39

--- a/config/default/layout_builder_styles.style.content_alignment_left.yml
+++ b/config/default/layout_builder_styles.style.content_alignment_left.yml
@@ -14,4 +14,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: -32
+weight: -38

--- a/config/default/layout_builder_styles.style.headline_all_caps.yml
+++ b/config/default/layout_builder_styles.style.headline_all_caps.yml
@@ -10,4 +10,4 @@ group: headline_type
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: -16
+weight: -22

--- a/config/default/layout_builder_styles.style.headline_all_caps_highlight.yml
+++ b/config/default/layout_builder_styles.style.headline_all_caps_highlight.yml
@@ -10,4 +10,4 @@ group: headline_type
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: -15
+weight: -21

--- a/config/default/layout_builder_styles.style.headline_bold_serif.yml
+++ b/config/default/layout_builder_styles.style.headline_bold_serif.yml
@@ -10,4 +10,4 @@ group: headline_type
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: -14
+weight: -20

--- a/config/default/layout_builder_styles.style.headline_bold_serif_highlight.yml
+++ b/config/default/layout_builder_styles.style.headline_bold_serif_highlight.yml
@@ -10,4 +10,4 @@ group: headline_type
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: -12
+weight: -18

--- a/config/default/layout_builder_styles.style.headline_large.yml
+++ b/config/default/layout_builder_styles.style.headline_large.yml
@@ -10,4 +10,4 @@ group: headline_size
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: 12
+weight: 17

--- a/config/default/layout_builder_styles.style.headline_medium.yml
+++ b/config/default/layout_builder_styles.style.headline_medium.yml
@@ -10,4 +10,4 @@ group: headline_size
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: 14
+weight: 19

--- a/config/default/layout_builder_styles.style.headline_small.yml
+++ b/config/default/layout_builder_styles.style.headline_small.yml
@@ -10,4 +10,4 @@ group: headline_size
 block_restrictions:
   - 'inline_block:uiowa_banner'
 layout_restrictions: {  }
-weight: 17
+weight: 22

--- a/config/default/layout_builder_styles.style.list_format_grid.yml
+++ b/config/default/layout_builder_styles.style.list_format_grid.yml
@@ -15,4 +15,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: 24
+weight: 30

--- a/config/default/layout_builder_styles.style.list_format_list.yml
+++ b/config/default/layout_builder_styles.style.list_format_list.yml
@@ -15,4 +15,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: 23
+weight: 29

--- a/config/default/layout_builder_styles.style.media_format_circle.yml
+++ b/config/default/layout_builder_styles.style.media_format_circle.yml
@@ -14,4 +14,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: 22
+weight: 27

--- a/config/default/layout_builder_styles.style.media_format_no_crop.yml
+++ b/config/default/layout_builder_styles.style.media_format_no_crop.yml
@@ -1,13 +1,13 @@
-uuid: e30cded2-6834-4c39-90ff-a83fef2d2068
+uuid: 4eb7e965-b55e-41d1-a37d-d72153cc3f1f
 langcode: en
 status: true
 dependencies: {  }
-id: media_format_ultrawide
-label: 'Ultrawide (21:9)'
-classes: media--ultrawide
+id: media_format_no_crop
+label: 'No crop'
+classes: media--no-crop
 type: component
 group: media_format
 block_restrictions:
   - 'inline_block:uiowa_image'
 layout_restrictions: {  }
-weight: 25
+weight: 28

--- a/config/default/layout_builder_styles.style.media_format_square.yml
+++ b/config/default/layout_builder_styles.style.media_format_square.yml
@@ -15,4 +15,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: 21
+weight: 26

--- a/config/default/layout_builder_styles.style.media_format_widescreen.yml
+++ b/config/default/layout_builder_styles.style.media_format_widescreen.yml
@@ -15,4 +15,4 @@ block_restrictions:
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
-weight: 19
+weight: 24

--- a/config/default/layout_builder_styles.style.quote_above.yml
+++ b/config/default/layout_builder_styles.style.quote_above.yml
@@ -10,4 +10,4 @@ group: card_media_position
 block_restrictions:
   - 'inline_block:uiowa_quote'
 layout_restrictions: {  }
-weight: -9
+weight: -15

--- a/config/default/layout_builder_styles.style.quote_center.yml
+++ b/config/default/layout_builder_styles.style.quote_center.yml
@@ -10,4 +10,4 @@ group: content_alignment
 block_restrictions:
   - 'inline_block:uiowa_quote'
 layout_restrictions: {  }
-weight: -7
+weight: -13

--- a/config/default/layout_builder_styles.style.quote_footer.yml
+++ b/config/default/layout_builder_styles.style.quote_footer.yml
@@ -10,4 +10,4 @@ group: card_media_position
 block_restrictions:
   - 'inline_block:uiowa_quote'
 layout_restrictions: {  }
-weight: 18
+weight: 23

--- a/config/default/layout_builder_styles.style.quote_left.yml
+++ b/config/default/layout_builder_styles.style.quote_left.yml
@@ -10,4 +10,4 @@ group: content_alignment
 block_restrictions:
   - 'inline_block:uiowa_quote'
 layout_restrictions: {  }
-weight: 13
+weight: 18

--- a/config/default/layout_builder_styles.style.quote_right.yml
+++ b/config/default/layout_builder_styles.style.quote_right.yml
@@ -10,4 +10,4 @@ group: content_alignment
 block_restrictions:
   - 'inline_block:uiowa_quote'
 layout_restrictions: {  }
-weight: 16
+weight: 21

--- a/config/default/layout_builder_styles.style.remove_default_bottom_padding.yml
+++ b/config/default/layout_builder_styles.style.remove_default_bottom_padding.yml
@@ -9,4 +9,4 @@ type: section
 group: spacing
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 49
+weight: 55

--- a/config/default/layout_builder_styles.style.remove_default_top_padding.yml
+++ b/config/default/layout_builder_styles.style.remove_default_top_padding.yml
@@ -9,4 +9,4 @@ type: section
 group: spacing
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 48
+weight: 54

--- a/config/default/layout_builder_styles.style.restore_default_spacing.yml
+++ b/config/default/layout_builder_styles.style.restore_default_spacing.yml
@@ -9,4 +9,4 @@ type: section
 group: spacing
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 50
+weight: 56

--- a/config/default/layout_builder_styles.style.section_alignment_start.yml
+++ b/config/default/layout_builder_styles.style.section_alignment_start.yml
@@ -9,4 +9,4 @@ type: section
 group: default
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 35
+weight: 41

--- a/config/default/layout_builder_styles.style.section_background_black_pattern_community.yml
+++ b/config/default/layout_builder_styles.style.section_background_black_pattern_community.yml
@@ -9,4 +9,4 @@ type: section
 group: background
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: -3
+weight: -9

--- a/config/default/layout_builder_styles.style.section_background_black_pattern_particle.yml
+++ b/config/default/layout_builder_styles.style.section_background_black_pattern_particle.yml
@@ -9,4 +9,4 @@ type: section
 group: background
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: -2
+weight: -8

--- a/config/default/layout_builder_styles.style.section_background_gold_pattern_community.yml
+++ b/config/default/layout_builder_styles.style.section_background_gold_pattern_community.yml
@@ -9,4 +9,4 @@ type: section
 group: background
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 2
+weight: 7

--- a/config/default/layout_builder_styles.style.section_background_gold_pattern_particle.yml
+++ b/config/default/layout_builder_styles.style.section_background_gold_pattern_particle.yml
@@ -9,4 +9,4 @@ type: section
 group: background
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 3
+weight: 8

--- a/config/default/layout_builder_styles.style.section_background_gray_pattern_brain.yml
+++ b/config/default/layout_builder_styles.style.section_background_gray_pattern_brain.yml
@@ -9,4 +9,4 @@ type: section
 group: background
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 5
+weight: 10

--- a/config/default/layout_builder_styles.style.section_background_gray_pattern_community.yml
+++ b/config/default/layout_builder_styles.style.section_background_gray_pattern_community.yml
@@ -9,4 +9,4 @@ type: section
 group: background
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 6
+weight: 11

--- a/config/default/layout_builder_styles.style.section_background_gray_pattern_particle.yml
+++ b/config/default/layout_builder_styles.style.section_background_gray_pattern_particle.yml
@@ -9,4 +9,4 @@ type: section
 group: background
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 7
+weight: 12

--- a/config/default/layout_builder_styles.style.section_background_style_black.yml
+++ b/config/default/layout_builder_styles.style.section_background_style_black.yml
@@ -9,4 +9,4 @@ type: section
 group: background
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: -5
+weight: -11

--- a/config/default/layout_builder_styles.style.section_background_style_brain_pattern.yml
+++ b/config/default/layout_builder_styles.style.section_background_style_brain_pattern.yml
@@ -11,4 +11,4 @@ type: section
 group: background
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 8
+weight: 13

--- a/config/default/layout_builder_styles.style.section_background_style_brain_pattern_black.yml
+++ b/config/default/layout_builder_styles.style.section_background_style_brain_pattern_black.yml
@@ -9,4 +9,4 @@ type: section
 group: background
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: -4
+weight: -10

--- a/config/default/layout_builder_styles.style.section_background_style_gold.yml
+++ b/config/default/layout_builder_styles.style.section_background_style_gold.yml
@@ -9,4 +9,4 @@ type: section
 group: background
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: -1
+weight: -7

--- a/config/default/layout_builder_styles.style.section_background_style_gray.yml
+++ b/config/default/layout_builder_styles.style.section_background_style_gray.yml
@@ -9,4 +9,4 @@ type: section
 group: background
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 4
+weight: 9

--- a/config/default/layout_builder_styles.style.section_background_white_pattern_community.yml
+++ b/config/default/layout_builder_styles.style.section_background_white_pattern_community.yml
@@ -9,4 +9,4 @@ type: section
 group: background
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 9
+weight: 14

--- a/config/default/layout_builder_styles.style.section_background_white_pattern_particle.yml
+++ b/config/default/layout_builder_styles.style.section_background_white_pattern_particle.yml
@@ -9,4 +9,4 @@ type: section
 group: background
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 10
+weight: 15

--- a/config/default/layout_builder_styles.style.section_container_narrow.yml
+++ b/config/default/layout_builder_styles.style.section_container_narrow.yml
@@ -9,4 +9,4 @@ type: section
 group: container
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 39
+weight: 45

--- a/config/default/layout_builder_styles.style.section_layout_grid_1x3.yml
+++ b/config/default/layout_builder_styles.style.section_layout_grid_1x3.yml
@@ -9,4 +9,4 @@ type: section
 group: default
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 36
+weight: 42

--- a/config/default/layout_builder_styles.style.section_layout_grid_3x2.yml
+++ b/config/default/layout_builder_styles.style.section_layout_grid_3x2.yml
@@ -11,4 +11,4 @@ type: section
 group: default
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 37
+weight: 43

--- a/config/default/layout_builder_styles.style.section_layout_grid_3x2_stacked.yml
+++ b/config/default/layout_builder_styles.style.section_layout_grid_3x2_stacked.yml
@@ -11,4 +11,4 @@ type: section
 group: default
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 38
+weight: 44

--- a/config/default/layout_builder_styles.style.section_margin_edge_to_edge.yml
+++ b/config/default/layout_builder_styles.style.section_margin_edge_to_edge.yml
@@ -11,4 +11,4 @@ type: section
 group: container
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 43
+weight: 49

--- a/config/default/layout_builder_styles.style.section_margin_extended_width_container.yml
+++ b/config/default/layout_builder_styles.style.section_margin_extended_width_container.yml
@@ -11,4 +11,4 @@ type: section
 group: container
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 41
+weight: 47

--- a/config/default/layout_builder_styles.style.section_margin_fixed_width_container.yml
+++ b/config/default/layout_builder_styles.style.section_margin_fixed_width_container.yml
@@ -11,4 +11,4 @@ type: section
 group: container
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 40
+weight: 46

--- a/config/default/layout_builder_styles.style.section_margin_full_width_container.yml
+++ b/config/default/layout_builder_styles.style.section_margin_full_width_container.yml
@@ -11,4 +11,4 @@ type: section
 group: container
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 42
+weight: 48

--- a/config/default/layout_builder_styles.style.section_margin_remove_default_margins.yml
+++ b/config/default/layout_builder_styles.style.section_margin_remove_default_margins.yml
@@ -11,4 +11,4 @@ type: section
 group: spacing
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 44
+weight: 50

--- a/config/default/layout_builder_styles.style.section_order_reversed.yml
+++ b/config/default/layout_builder_styles.style.section_order_reversed.yml
@@ -13,4 +13,4 @@ layout_restrictions:
   - layout_threecol
   - layout_fourcol
   - layout_page
-weight: 1
+weight: 6

--- a/config/default/layout_builder_styles.style.section_padding_bottom_extra.yml
+++ b/config/default/layout_builder_styles.style.section_padding_bottom_extra.yml
@@ -11,4 +11,4 @@ type: section
 group: spacing
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 45
+weight: 51

--- a/config/default/layout_builder_styles.style.section_padding_remove_default_padding.yml
+++ b/config/default/layout_builder_styles.style.section_padding_remove_default_padding.yml
@@ -9,4 +9,4 @@ type: section
 group: spacing
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 47
+weight: 53

--- a/config/default/layout_builder_styles.style.section_padding_top_extra.yml
+++ b/config/default/layout_builder_styles.style.section_padding_top_extra.yml
@@ -11,4 +11,4 @@ type: section
 group: spacing
 block_restrictions: {  }
 layout_restrictions: {  }
-weight: 46
+weight: 52

--- a/config/default/layout_builder_styles.style.stat_remove_hover_effect.yml
+++ b/config/default/layout_builder_styles.style.stat_remove_hover_effect.yml
@@ -10,4 +10,4 @@ group: default
 block_restrictions:
   - 'inline_block:uiowa_statistic'
 layout_restrictions: {  }
-weight: 15
+weight: 20

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -241,6 +241,10 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
                 $defaults['layout_builder_style_card_media_position'] = 'card_media_position_stacked';
                 break;
 
+              case 'inline_block:uiowa_image':
+                $defaults['layout_builder_style_media_format'] = 'media_format_widescreen';
+                break;
+
               case 'inline_block:uiowa_events':
               case 'views_block:events-card_list':
               case 'views_block:events_list_block-card_list':

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -241,10 +241,6 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
                 $defaults['layout_builder_style_card_media_position'] = 'card_media_position_stacked';
                 break;
 
-              case 'inline_block:uiowa_image':
-                $defaults['layout_builder_style_media_format'] = 'media_format_widescreen';
-                break;
-
               case 'inline_block:uiowa_events':
               case 'views_block:events-card_list':
               case 'views_block:events_list_block-card_list':

--- a/docroot/modules/custom/layout_builder_custom/src/EventSubscriber/SectionComponentSubscriber.php
+++ b/docroot/modules/custom/layout_builder_custom/src/EventSubscriber/SectionComponentSubscriber.php
@@ -106,6 +106,7 @@ class SectionComponentSubscriber implements EventSubscriberInterface {
                 'media--square' => 'full__square',
                 'media--ultrawide' => 'full__ultrawide',
                 'media--widescreen' => 'full__widescreen',
+                'media--no-crop' => 'full__no_crop',
               ];
             }
           }


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/6070. 

This pr adds a "No crop" option to the image block that uses the `Full - no crop` responsive image style. 

# How to test

- `ddev blt ds --site="sandbox.uiowa.edu"`
- Go to https://sandbox.uiowa.ddev.site/node/1231/layout
- Add an image block to the fourth column and select the "No crop" option. 
- Save and verify that the image is using the `full - no crop` style. 

