### PR TITLE
Hotfix: Fixed typo in template to resolve admissions.uiowa.edu bug

### DIFF
--- a/docroot/themes/custom/uids_base/templates/views/views-view.html.twig
+++ b/docroot/themes/custom/uids_base/templates/views/views-view.html.twig
@@ -59,7 +59,7 @@
   {% endif %}
   {% if exposed %}
     {% set views_filter_attributes = views_filter_attributes ?: create_attribute() %}
-    <div {{ views_filter_attributes.addclass(views_filter_classes, 'views-filters') }}>
+    <div {{ views_filter_attributes.addclass(views_filter_classes, 'view-filters') }}>
       {{ exposed }}
     </div>
   {% endif %}


### PR DESCRIPTION
# How to test

`ddev blt ds --site=admissions.uiowa.edu`
Go to admissions.uiowa.edu/areas-of-study


<img width="1471" alt="Screenshot 2023-02-02 at 7 58 28 AM" src="https://user-images.githubusercontent.com/1036433/216352851-ea885349-8fc7-469d-9c35-c790151fc597.png">
