### PR TITLE
hotfix - person type statuses

### DIFF
--- a/docroot/modules/custom/sitenow_people/sitenow_people.module
+++ b/docroot/modules/custom/sitenow_people/sitenow_people.module
@@ -902,20 +902,19 @@ function _sitenow_people_person_form_submit(array &$form, FormStateInterface $fo
 function sitenow_people_person_type_statuses_allowed_values(FieldStorageDefinitionInterface $definition, FieldableEntityInterface $entity = NULL, bool &$cacheable = FALSE): array {
   $types = [];
 
-  if (!is_null($entity)) {
-    $allowed_types = \Drupal::entityTypeManager()
-      ->getStorage('person_type')->loadByProperties([
-        'status' => TRUE,
-        'allow_former' => TRUE,
-      ]);
-    foreach ($allowed_types as $type) {
-      $types[$type->id()] = t('Former @type', [
-        '@type' => $type->label(),
-      ]);
-    }
+  $allowed_types = \Drupal::entityTypeManager()
+    ->getStorage('person_type')->loadByProperties([
+      'status' => TRUE,
+      'allow_former' => TRUE,
+    ]);
+  foreach ($allowed_types as $type) {
+    $types[$type->id()] = t('Former @type', [
+      '@type' => $type->label(),
+    ]);
   }
-  else {
-    // To resolve an issue with ListItemBase generateSampleValue.
+
+  // To resolve an issue with ListItemBase generateSampleValue.
+  if (empty($types)) {
     $types['_none'] = '-None-';
   }
 


### PR DESCRIPTION
Backstory: https://iowaweb.slack.com/archives/C0164FNN1PV/p1675458844301579

# How to test

- https://gradtoxicology.uiowa.ddev.site/students (loads fine and only shows current students (is none of former student))
- visit https://gradtoxicology.uiowa.ddev.site/admin/structure/types/manage/person/display and https://gradtoxicology.uiowa.ddev.site/admin/structure/types/manage/person/display/default/layout and not get a WSOD
- disable the former options for all types here: https://sandbox.uiowa.ddev.site/admin/structure/person-type and create a people list block filtering on faculty. no issue.
