### PR TITLE
Memory limit increase for menu pages

### DIFF
--- a/docroot/sites/settings/global.settings.php
+++ b/docroot/sites/settings/global.settings.php
@@ -70,6 +70,7 @@ if (extension_loaded('newrelic')) {
   newrelic_set_appname("{$site_name};{$ah_group}.{$ah_env}", '', 'true');
 }
 
+// Memory increase for large menu pages so that webmasters can save changes.
 if (isset($_SERVER['REQUEST_URI']) && strpos($_SERVER['REQUEST_URI'], 'admin/structure/menu') !== false ) {
   ini_set('memory_limit', '256M');
 }

--- a/docroot/sites/settings/global.settings.php
+++ b/docroot/sites/settings/global.settings.php
@@ -69,3 +69,7 @@ ini_set('newrelic.loglevel', 'error');
 if (extension_loaded('newrelic')) {
   newrelic_set_appname("{$site_name};{$ah_group}.{$ah_env}", '', 'true');
 }
+
+if (isset($_SERVER['REQUEST_URI']) && strpos($_SERVER['REQUEST_URI'], 'admin/structure/menu') !== false ) {
+  ini_set('memory_limit', '256M');
+}

--- a/docroot/sites/settings/global.settings.php
+++ b/docroot/sites/settings/global.settings.php
@@ -70,7 +70,7 @@ if (extension_loaded('newrelic')) {
   newrelic_set_appname("{$site_name};{$ah_group}.{$ah_env}", '', 'true');
 }
 
-// Memory increase for large menu pages so that webmasters can save changes.
+// Memory increase for large menu pages so webmasters can save changes.
 if (isset($_SERVER['REQUEST_URI']) && strpos($_SERVER['REQUEST_URI'], 'admin/structure/menu') !== false ) {
   ini_set('memory_limit', '256M');
 }


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/6176

# How to test

<!-- Include detailed steps for how to test this PR. -->
1. Follow this to set DDEV `memory_limit` to 128: https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#custom-php-configuration-phpini
2. `blt ds --site=engineering.uiowa.edu`
3. Masquerade as a webmaster on Engineering.
4. Go to https://engineering.uiowa.ddev.site/admin/structure/menu/manage/main
5. Make changes to the menu and see if you can save it.
6. Did the changes stick?
7. Follow the same steps on a few other sites with large menus: Tippie is one.