### PR TITLE
Hotfix: Added style fix to adjust author to display separate lines for articles_narrow

### DIFF
--- a/docroot/themes/custom/uids_base/scss/content/node--type--article.scss
+++ b/docroot/themes/custom/uids_base/scss/content/node--type--article.scss
@@ -170,6 +170,12 @@
     font-weight: 400;
   }
 
+  .article--meta {
+    .field__item {
+      display: block;
+    }
+  }
+
   .field--name-field-article-subhead {
     margin: $gutter 0;
   }


### PR DESCRIPTION
This splits the authors on to separate fields. 

# How to test
- Code review or
- `ddev blt frontend`
- `ddev blt ds --site=ilr.law.uiowa.edu`
-  `ddev drush @lawilr.local config-split:activate articles_narrow`
-  Go to https://lawilr.uiowa.ddev.site/news/2023/01/ai-taxation-and-valuation and verify authors are on separate lines. 

Before:

<img width="1457" alt="Screenshot 2023-02-16 at 1 43 22 PM" src="https://user-images.githubusercontent.com/1036433/219470583-4a3e8cbe-658a-43e3-a180-b32ad762b4ee.png">


After:

<img width="1422" alt="Screenshot 2023-02-16 at 1 43 07 PM" src="https://user-images.githubusercontent.com/1036433/219470570-a39cc008-ca53-4d38-9163-01548130f2d4.png">
