### PR TITLE
UIowa Hours - Change js local date creation

### DIFF
--- a/docroot/modules/custom/uiowa_hours/js/filter_form.js
+++ b/docroot/modules/custom/uiowa_hours/js/filter_form.js
@@ -10,7 +10,10 @@
           $('.uiowa-hours-container', this).html('<p>Placeholder for ' + hoursConfig[0] + ' data</p>');
         }
         else {
-          let today = new Date().toLocaleDateString('en-CA', {timeZone: 'America/Chicago'});
+          let date = new Date();
+          let today = new Date(date.getTime() - (date.getTimezoneOffset() * 60000 ))
+            .toISOString()
+            .split("T")[0];
           $('input[type="date"]', this).val(today);
           $('input[type="submit"]', this).mousedown();
         }


### PR DESCRIPTION
From its-web:

>The hours are displaying on Firefox but not Google Chrome or Edge. Can you look into this?
https://recserv.uiowa.edu/

# How to test

- Before checking out this branch, pull recserv down locally and try a chrome browser. You will see Dec 1969 results. In Firefox, you will see today's date results.
- Checkout `hours_today_hotfix` and run `cr`
- In all browser you should see the today's results on load and be able to pick a different date to other results.

>The *60000 is indicating the UTC -6 which is CST
