### PR TITLE
Timeline Bug

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/timeline.scss
+++ b/docroot/themes/custom/uids_base/scss/components/timeline.scss
@@ -2,6 +2,10 @@
 @import "uids3/assets/scss/_utilities.scss";
 
 // Timeline block
+.block-inline-blockuiowa-timeline {
+  position: relative;
+}
+
 .timeline {
   transition: all 0.4s ease;
   position: relative;
@@ -219,9 +223,16 @@ li:first-child .timeline--card.js-scroll {
 }
 
 .timeline-line {
+  top: 0;
   position: absolute;
   left: 50%;
   height: 100%;
+}
+
+
+.headline + .timeline-line .timeline-line__mask {
+  height: 95%;
+  top: 5%;
 }
 
 .timeline-line__mask {


### PR DESCRIPTION
## Problem

Timeline was not contained to only its element, and would extend the line very far if not alone in a section. This was especially egregious if there was a headline. This may not be a perfect solution, but it is probably good enough.

## Solution

Fix the css. Code review and potential visual review will suffice. Try both with and without this PR.
