### PR TITLE
Now migration updates

### DIFF
--- a/docroot/sites/now.uiowa.edu/modules/now_migrate/src/Plugin/migrate/source/Achievement.php
+++ b/docroot/sites/now.uiowa.edu/modules/now_migrate/src/Plugin/migrate/source/Achievement.php
@@ -52,7 +52,6 @@ class Achievement extends BaseNodeSource {
       'field_news_from',
       'field_news_about',
       'field_news_for',
-      'field_keywords',
     ] as $field_name) {
       $values = $row->getSourceProperty($field_name);
       if (!isset($values)) {

--- a/docroot/sites/now.uiowa.edu/modules/now_migrate/src/Plugin/migrate/source/InTheNews.php
+++ b/docroot/sites/now.uiowa.edu/modules/now_migrate/src/Plugin/migrate/source/InTheNews.php
@@ -109,7 +109,6 @@ class InTheNews extends BaseNodeSource {
       'field_news_from',
       'field_news_about',
       'field_news_for',
-      'field_keywords',
     ] as $field_name) {
       $values = $row->getSourceProperty($field_name);
       if (!isset($values)) {

--- a/docroot/sites/now.uiowa.edu/modules/now_migrate/src/Plugin/migrate/source/NewsFeature.php
+++ b/docroot/sites/now.uiowa.edu/modules/now_migrate/src/Plugin/migrate/source/NewsFeature.php
@@ -7,7 +7,6 @@ use Drupal\migrate\Row;
 use Drupal\sitenow_migrate\Plugin\migrate\source\BaseNodeSource;
 use Drupal\sitenow_migrate\Plugin\migrate\source\ProcessMediaTrait;
 use Drupal\taxonomy\Entity\Term;
-use function PHPUnit\Framework\isEmpty;
 
 /**
  * Migrate Source plugin.
@@ -119,7 +118,9 @@ class NewsFeature extends BaseNodeSource {
             // We need to unserialize the options,
             // and then check if there is a query (there are
             // other options possible we don't need).
-            $options = unserialize($redirect['redirect_options']);
+            $options = unserialize($redirect['redirect_options'], [
+              'allowed_classes' => TRUE,
+            ]);
             if (!empty($options) && isset($options['query'])) {
               // Start our query string, and
               // if we're not the first query parameter,

--- a/docroot/sites/now.uiowa.edu/modules/now_migrate/src/Plugin/migrate/source/NewsFeature.php
+++ b/docroot/sites/now.uiowa.edu/modules/now_migrate/src/Plugin/migrate/source/NewsFeature.php
@@ -47,7 +47,6 @@ class NewsFeature extends BaseNodeSource {
       'field_news_from',
       'field_news_about',
       'field_news_for',
-      'field_keywords',
     ] as $field_name) {
       $values = $row->getSourceProperty($field_name);
       if (!isset($values)) {


### PR DESCRIPTION
Resolves #6193 
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
## Redirect update
Sync the site in dev desktop (uiowa703)
`git checkout now-migration-updates && git pull && ddev blt ds --site=now.uiowa.edu && ddev drush @now.local en now_migrate -y && ddev drush @now.local uli /admin/config/sitenow/sitenow-migrate`
Complete the form
You can limit the `now_news_feature` to a subset of nodes based on the issue by either adding a check in `prepareRow` or adding something like 
```
$query->condition('n.nid', ['25136', '25271', '26861', '32481', '33211', '33246', '33351', '33376', '34441'], 'IN');
``` 
to the `query` method in `NewsFeature.php`. 
`ddev drush @now.local mim --limit=10` <- adjust this to however many you would like to run, based on if/how you adjusted the subset above. If you limit it to just redirected nodes, you don't need the `--limit` option at all. But, if you want to do it without adjusting the query, a `--limit` is HIGHLY recommended; likely around 200 - 300.
Check for the nodes listed in #6193 and see that they
 - Have the proper redirect listed in the source link
 - The redirect includes the correct query string attached and appropriately formatted
 - Are marked as "link directly to source"

## Keywords update
We're not going to be bringing over the "keywords" taxonomy, so that the new site can start fresh when it comes to these.
Check that the (non-people) migrations don't include the "keywords" taxonomy, but still include the "news from," "news about," "news for," and for achievement "achievement category." (code review is likely adequate.
Additionally, we can evaluate whether we can go back to the old mapping strategy, or continue with the on-the-fly lookups (https://github.com/uiowa/uiowa/pull/6167/commits/52e1c4a379da5a198633dfe22acd78516e503765 as an example of the changes). It might be fine to continue this way anyway, since it's already a memory-intensive migration.