### PR TITLE
Hotfix: Added articles_narrow to config ignore file

### DIFF
--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -9,6 +9,7 @@ ignored_config_entities:
   - 'config_split.config_split.additional_person_types:status'
   - 'config_split.config_split.apr:status'
   - 'config_split.config_split.areas_of_study:status'
+  - 'config_split.config_split.articles_narrow:status'
   - 'config_split.config_split.collegiate:status'
   - 'config_split.config_split.event:status'
   - 'config_split.config_split.grad_person_extended:status'


### PR DESCRIPTION
# How to test

- Make sure this is the correct entry for the `articles_narrow` feature split. 