### PR TITLE
Block ip htaccess part deux

### DIFF
--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -2,6 +2,15 @@
 # Apache/PHP/Drupal settings:
 #
 
+# Block these IP addresses.
+# https://docs.acquia.com/cloud-platform/arch/security/restrict/#blocking-by-ip-with-mod-rewrite-in-htaccess
+<ifmodule mod_setenvif.c>
+SetEnvIf AH_CLIENT_IP ^193\.42\.33\.66$ DENY=1
+Order allow,deny
+Allow From All
+Deny from env=DENY
+</ifmodule>
+
 # Protect files and directories from prying eyes.
 <FilesMatch "\.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock)|web\.config)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$">
   <IfModule mod_authz_core.c>
@@ -66,6 +75,60 @@ AddEncoding gzip svgz
 # Various rewrite rules.
 <IfModule mod_rewrite.c>
   RewriteEngine on
+
+  # Return a 403 for autodiscover requests.
+  RewriteCond %{REQUEST_URI} /autodiscover/autodiscover.xml [NC]
+  RewriteRule ^ - [F,L]
+
+  # Redirect http(s)://www.domain.com to https://domain.com.
+  RewriteCond %{HTTP_HOST} !\.acquia-sites\.com [NC]
+  RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
+  RewriteRule ^(.*)$ https://%1%{REQUEST_URI} [L,R=301]
+
+  # Redirect all traffic from HTTP to HTTPS.
+  RewriteCond %{HTTP_HOST} !\.acquia-sites\.com [NC]
+  RewriteCond %{HTTPS} off
+  RewriteCond %{HTTP:X-Forwarded-Proto} !https
+  RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
+  # Redirect legacy stories site for the homepage.
+  RewriteCond %{HTTP_HOST} ^uiowa.edu$
+  RewriteRule ^stories(.*)$  https://stories.uiowa.edu$1 [R,L]
+
+  # Redirect engineering.uiowa.edu/~ to user.engineering.uiowa.edu for Engineering
+  RewriteCond %{HTTP_HOST} engineering\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteCond %{REQUEST_URI} /~(.*)
+  RewriteRule ^(.*)$ https://user.engineering.uiowa.edu/$1 [L,R=301]
+
+  # Redirect veterans.org.uiowa.edu to veterans.uiowa.edu/uiva.
+  RewriteCond %{HTTP_HOST} veterans.org.uiowa.edu [NC]
+  RewriteRule ^ https://veterans.uiowa.edu/uiva%{REQUEST_URI} [L,R=301]
+
+  # Redirect iconsortium.subst-abuse.uiowa.edu to icsa.uiowa.edu
+  RewriteCond %{HTTP_HOST} iconsortium\.subst-abuse\.uiowa\.edu$ [NC]
+  RewriteRule ^ https://icsa.uiowa.edu/ [L,R=301]
+
+  # Redirect www.(cs|math|stat).uiowa.edu/~ to homepage.divms.uiowa.edu for CS, Math, Stats
+  RewriteCond %{HTTP_HOST} ^(www\.)?(cs|math|stat)\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteCond %{REQUEST_URI} /~(.*)
+  RewriteRule ^(.*)$ http://homepage.divms.uiowa.edu/$1 [L,R=301]
+
+  # Redirect physics.uiowa.edu/~ to homepage.physics.uiowa.edu for Physics and Astronomy
+  RewriteCond %{HTTP_HOST} physics\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteCond %{REQUEST_URI} /~(.*)
+  RewriteRule ^(.*)$ http://homepage.physics.uiowa.edu/$1 [L,R=301]
+
+  # Redirect physics.uiowa.edu/itu/* to itu.physics.uiowa.edu/* for Physics and Astronomy ITU
+  RewriteCond %{HTTP_HOST} physics\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteCond %{REQUEST_URI} ^/itu/(.*) [NC,OR]
+  RewriteCond %{REQUEST_URI} ^/itu$ [NC]
+  RewriteRule ^itu(.*)$ https://itu.physics.uiowa.edu/$1 [L,R=301]
 
   # Set "protossl" to "s" if we were accessed via https://.  This is used later
   # if you enable "www." stripping or enforcement, in order to ensure that

--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -2,13 +2,6 @@
 # Apache/PHP/Drupal settings:
 #
 
-<ifmodule mod_setenvif.c>
-SetEnvIf AH_CLIENT_IP ^193\.42\.33\.66$ DENY=1
-Order allow,deny
-Allow From All
-Deny from env=DENY
-</ifmodule>
-
 # Protect files and directories from prying eyes.
 <FilesMatch "\.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock)|web\.config)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$">
   <IfModule mod_authz_core.c>

--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -67,60 +67,6 @@ AddEncoding gzip svgz
 <IfModule mod_rewrite.c>
   RewriteEngine on
 
-  # Return a 403 for autodiscover requests.
-  RewriteCond %{REQUEST_URI} /autodiscover/autodiscover.xml [NC]
-  RewriteRule ^ - [F,L]
-
-  # Redirect http(s)://www.domain.com to https://domain.com.
-  RewriteCond %{HTTP_HOST} !\.acquia-sites\.com [NC]
-  RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
-  RewriteRule ^(.*)$ https://%1%{REQUEST_URI} [L,R=301]
-
-  # Redirect all traffic from HTTP to HTTPS.
-  RewriteCond %{HTTP_HOST} !\.acquia-sites\.com [NC]
-  RewriteCond %{HTTPS} off
-  RewriteCond %{HTTP:X-Forwarded-Proto} !https
-  RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
-
-  # Redirect legacy stories site for the homepage.
-  RewriteCond %{HTTP_HOST} ^uiowa.edu$
-  RewriteRule ^stories(.*)$  https://stories.uiowa.edu$1 [R,L]
-
-  # Redirect engineering.uiowa.edu/~ to user.engineering.uiowa.edu for Engineering
-  RewriteCond %{HTTP_HOST} engineering\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteCond %{REQUEST_FILENAME} !-f
-  RewriteCond %{REQUEST_FILENAME} !-d
-  RewriteCond %{REQUEST_URI} /~(.*)
-  RewriteRule ^(.*)$ https://user.engineering.uiowa.edu/$1 [L,R=301]
-
-  # Redirect veterans.org.uiowa.edu to veterans.uiowa.edu/uiva.
-  RewriteCond %{HTTP_HOST} veterans.org.uiowa.edu [NC]
-  RewriteRule ^ https://veterans.uiowa.edu/uiva%{REQUEST_URI} [L,R=301]
-
-  # Redirect iconsortium.subst-abuse.uiowa.edu to icsa.uiowa.edu
-  RewriteCond %{HTTP_HOST} iconsortium\.subst-abuse\.uiowa\.edu$ [NC]
-  RewriteRule ^ https://icsa.uiowa.edu/ [L,R=301]
-
-  # Redirect www.(cs|math|stat).uiowa.edu/~ to homepage.divms.uiowa.edu for CS, Math, Stats
-  RewriteCond %{HTTP_HOST} ^(www\.)?(cs|math|stat)\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteCond %{REQUEST_FILENAME} !-f
-  RewriteCond %{REQUEST_FILENAME} !-d
-  RewriteCond %{REQUEST_URI} /~(.*)
-  RewriteRule ^(.*)$ http://homepage.divms.uiowa.edu/$1 [L,R=301]
-
-  # Redirect physics.uiowa.edu/~ to homepage.physics.uiowa.edu for Physics and Astronomy
-  RewriteCond %{HTTP_HOST} physics\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteCond %{REQUEST_FILENAME} !-f
-  RewriteCond %{REQUEST_FILENAME} !-d
-  RewriteCond %{REQUEST_URI} /~(.*)
-  RewriteRule ^(.*)$ http://homepage.physics.uiowa.edu/$1 [L,R=301]
-
-  # Redirect physics.uiowa.edu/itu/* to itu.physics.uiowa.edu/* for Physics and Astronomy ITU
-  RewriteCond %{HTTP_HOST} physics\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteCond %{REQUEST_URI} ^/itu/(.*) [NC,OR]
-  RewriteCond %{REQUEST_URI} ^/itu$ [NC]
-  RewriteRule ^itu(.*)$ https://itu.physics.uiowa.edu/$1 [L,R=301]
-
   # Set "protossl" to "s" if we were accessed via https://.  This is used later
   # if you enable "www." stripping or enforcement, in order to ensure that
   # you don't bounce between http and https.

--- a/patches/core_htaccess.patch
+++ b/patches/core_htaccess.patch
@@ -1,8 +1,24 @@
 diff --git a/docroot/.htaccess b/docroot/.htaccess
-index b1ee36bf4..4d5f58364 100644
+index 4d19147cc..251237123 100644
 --- a/docroot/.htaccess
 +++ b/docroot/.htaccess
-@@ -62,6 +62,60 @@ AddEncoding gzip svgz
+@@ -2,6 +2,15 @@
+ # Apache/PHP/Drupal settings:
+ #
+ 
++# Block these IP addresses.
++# https://docs.acquia.com/cloud-platform/arch/security/restrict/#blocking-by-ip-with-mod-rewrite-in-htaccess
++<ifmodule mod_setenvif.c>
++SetEnvIf AH_CLIENT_IP ^193\.42\.33\.66$ DENY=1
++Order allow,deny
++Allow From All
++Deny from env=DENY
++</ifmodule>
++
+ # Protect files and directories from prying eyes.
+ <FilesMatch "\.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock)|web\.config)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$">
+   <IfModule mod_authz_core.c>
+@@ -67,6 +76,60 @@ AddEncoding gzip svgz
  <IfModule mod_rewrite.c>
    RewriteEngine on
  


### PR DESCRIPTION
Make sure nothing is lost from our htaccess patch file:

https://github.com/uiowa/uiowa/blob/d0c2095edd975eb840b0f786fbdac64b52afd638/patches/core_htaccess.patch

# To Test

`ddev composer install` should only add the IP block and not remove any of the redirects