### PR TITLE
Add setting for displaying search option.

### DIFF
--- a/docroot/modules/custom/uiowa_search/src/Controller/UiowaSearchResultsController.php
+++ b/docroot/modules/custom/uiowa_search/src/Controller/UiowaSearchResultsController.php
@@ -38,14 +38,18 @@ class UiowaSearchResultsController extends ControllerBase {
       'site' => 'default_collection',
     ];
 
-    $build['search'] = [
-      '#type' => 'link',
-      '#title' => $this->t('Search all University of Iowa for @terms', ['@terms' => $search_terms]),
-      '#url' => Url::fromUri('https://search.uiowa.edu', ['query' => $search_params]),
-      '#attributes' => [
-        'target' => '_blank',
-      ],
-    ];
+    $display_search_all_uiowa = $config['display_search_all_uiowa'] ?? TRUE;
+
+    if ($display_search_all_uiowa) {
+      $build['search'] = [
+        '#type' => 'link',
+        '#title' => $this->t('Search all University of Iowa for @terms', ['@terms' => $search_terms]),
+        '#url' => Url::fromUri('https://search.uiowa.edu', ['query' => $search_params]),
+        '#attributes' => [
+          'target' => '_blank',
+        ],
+      ];
+    }
 
     $build['results_container'] = [
       '#type' => 'container',

--- a/docroot/modules/custom/uiowa_search/src/Form/SettingsForm.php
+++ b/docroot/modules/custom/uiowa_search/src/Form/SettingsForm.php
@@ -42,7 +42,7 @@ class SettingsForm extends ConfigFormBase {
     ];
     $form['display_search_all_uiowa'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Display the "Search all University of Iowa for <i>TERM</i>" link'),
+      '#title' => $this->t('Display the "Search all University of Iowa for ..." link'),
       '#default_value' => $config->get('uiowa_search.display_search_all_uiowa') ?? TRUE,
     ];
     $form['cse_engine_id'] = [

--- a/docroot/modules/custom/uiowa_search/src/Form/SettingsForm.php
+++ b/docroot/modules/custom/uiowa_search/src/Form/SettingsForm.php
@@ -40,6 +40,11 @@ class SettingsForm extends ConfigFormBase {
       '#title' => $this->t('Display search box'),
       '#default_value' => $config->get('uiowa_search.display_search'),
     ];
+    $form['display_search_all_uiowa'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Display the "Search all University of Iowa for <i>TERM</i>" link'),
+      '#default_value' => $config->get('uiowa_search.display_search_all_uiowa') ?? TRUE,
+    ];
     $form['cse_engine_id'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Search Engine ID'),
@@ -67,6 +72,7 @@ class SettingsForm extends ConfigFormBase {
       ->set('uiowa_search.cse_engine_id', $form_state->getValue('cse_engine_id'))
       ->set('uiowa_search.cse_scope', $form_state->getValue('cse_scope'))
       ->set('uiowa_search.display_search', $form_state->getValue('display_search'))
+      ->set('uiowa_search.display_search_all_uiowa', $form_state->getValue('display_search_all_uiowa'))
       ->save();
     parent::submitForm($form, $form_state);
 

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -213,7 +213,7 @@ function uids_base_preprocess_page(&$variables) {
     $variables['is_off_brand'] = TRUE;
   }
 
-  if (theme_get_setting('logo.use_default') != 1) {
+  if (!theme_get_setting('logo.use_default')) {
     $logo_path = theme_get_setting('logo.path');
     if (!empty($logo_path)) {
       $file_system = \Drupal::service('file_system');


### PR DESCRIPTION
This  tracks #6231

As a user with an off brand theme, I want to remove the "Search all University of Iowa for <i>TERM</i>" link from the search form.

# How to test

1. Sync a site
2. Go to `/search?terms=yeehaw`
3. Observe that nothing is broken.
4. Go to `/admin/config/sitenow/uiowa-search`
5. Toggle off the new setting.
6. return to `/search?terms=yeehaw`
7. Observe that the "Search all University of Iowa for <i>TERM</i>" link is gone.
