### PR TITLE
Fix for slider headline/apostrophe issue

### DIFF
--- a/docroot/themes/custom/uids_base/templates/paragraphs/paragraph--uiowa-slide.html.twig
+++ b/docroot/themes/custom/uids_base/templates/paragraphs/paragraph--uiowa-slide.html.twig
@@ -45,7 +45,7 @@
   'slide_expanded': delta == 0 ? true : false,
   'slide_image': content.field_uiowa_slide_image,
   'slide_summary': content.field_uiowa_slide_content,
-  'slide_title': content.field_collection_headline|render|striptags,
+  'slide_title': slide_headline|render,
   'headline_level': h_size,
   'link': {
     'link_url': content.field_uiowa_slide_link[0]['#url'],

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -974,6 +974,15 @@ function uids_base_preprocess_paragraph__card(&$variables) {
  * Implements hook_preprocess_HOOK().
  */
 function uids_base_preprocess_paragraph(&$variables) {
+
+  $paragraph = $variables['paragraph'];
+  // Get the value of the collection headline field.
+  if ($paragraph->getType() == 'uiowa_slide') {
+    $uiowa_slide_headline = $paragraph->get('field_collection_headline')->getValue()[0]['value'];
+    // Strip tags.
+    $variables['slide_headline'] = strip_tags($uiowa_slide_headline);
+  }
+
   $admin_context = \Drupal::service('router.admin_context');
   if (!$admin_context->isAdminRoute()) {
     /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/4864. 

# How to test

- `ddev blt ds --site=sandbox.uiowa.edu` 
- Edit slider on the home page and add an apostrophe to the slider headline. 
- Save the page and see if apostrophe renders
- Verify that `slider__teaser` and the banner `headline` both render the apostrophe. 