### PR TITLE
Brand - remove button per request

### DIFF
--- a/config/sites/brand.uiowa.edu/views.view.lockups.yml
+++ b/config/sites/brand.uiowa.edu/views.view.lockups.yml
@@ -897,18 +897,7 @@ display:
           required: false
       css_class: block-margin__top--extra
       use_ajax: true
-      header:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text_custom
-          empty: true
-          content: '<a class="btn btn-primary" href="/node/add/lockup">Create a Lockup</a><br><br>'
-          tokenize: false
+      header: {  }
       footer: {  }
       display_extenders: {  }
     cache_metadata:


### PR DESCRIPTION
Brand is reducing collaborator access on the site. Here are a few code changes they requested.

Button removed from https://brand.uiowa.ddev.site/lockup-system