### PR TITLE
Hours - Closure support

### DIFF
--- a/docroot/modules/custom/uiowa_hours/src/Form/HoursFilterForm.php
+++ b/docroot/modules/custom/uiowa_hours/src/Form/HoursFilterForm.php
@@ -234,7 +234,18 @@ class HoursFilterForm extends FormBase {
         ];
 
         foreach ($date as $time) {
-          $markup = $this->t('<span class="badge badge--green">Open</span> @start - @end', [
+          // Mark as closed if "Closure" category is present, else mark as open.
+          if (in_array('Closure', $time['categories'])) {
+            $badge = 'badge--orange';
+            $status = 'Closed';
+          }
+          else {
+            $badge = 'badge--green';
+            $status = 'Open';
+          }
+          $markup = $this->t('<span class="badge @badge">@status</span> @start - @end', [
+            '@badge' => $badge,
+            '@status' => $status,
             '@start' => date('g:ia', strtotime($time['startHour'])),
             '@end' => date('g:ia', '00:00:00' ? strtotime($time['endHour'] . ', +1 day') : strtotime($time['endHour'])),
           ]);

--- a/docroot/modules/custom/uiowa_hours/src/Plugin/Block/HoursBlock.php
+++ b/docroot/modules/custom/uiowa_hours/src/Plugin/Block/HoursBlock.php
@@ -147,7 +147,7 @@ class HoursBlock extends BlockBase implements ContainerFactoryPluginInterface {
     $form['resource'] = [
       '#type' => 'select',
       '#title' => $this->t('Resource'),
-      '#description' => $this->t('The resource to display hours for.'),
+      '#description' => $this->t('The resource to display hours for. If <em>Closure</em> category is present, it will be marked as closed.'),
       '#required' => TRUE,
       '#default_value' => $config['resource'] ?? NULL,
       '#options' => array_combine($resources, $resources),


### PR DESCRIPTION
Resolves #6361 

# To Test

https://recserv.dev.drupal.uiowa.edu/ on the homepage, there is a fitness east block that i modified to show the event details (they plan to use once this is implemented).

After checking this resource for these dates. Check some of the others to confirm they are working as expected. Pick Jan 1 2023 for one of the facilities as it was probably closed.

>April 25 7pm – 9:30pm – FE Closed due to training
>April 26 7pm – 9:30pm – FE Closed for Cleaning
>April 27 2:00pm – 3:00pm – FE Bathrooms Closed for Cleaning  (This one actually overlaps our regular hours which is how we would most likely intend to use it)

https://hours.iowa.uiowa.edu/api/Hours/FusionRecServ/res-rec-fe?start=04/25/2023&end=04/25/2023
https://hours.iowa.uiowa.edu/api/Hours/FusionRecServ/res-rec-fe?start=04/26/2023&end=04/26/2023
https://hours.iowa.uiowa.edu/api/Hours/FusionRecServ/res-rec-fe?start=04/27/2023&end=04/27/2023


<img width="331" alt="Screenshot 2023-04-21 at 11 11 04 AM" src="https://user-images.githubusercontent.com/4663676/233684662-76eb4450-6214-48d1-acbf-dcb2ffe79809.png">
<img width="324" alt="Screenshot 2023-04-21 at 11 11 13 AM" src="https://user-images.githubusercontent.com/4663676/233684664-34965ad3-beec-4bc6-addb-4361a7c601c1.png">
<img width="326" alt="Screenshot 2023-04-21 at 11 11 25 AM" src="https://user-images.githubusercontent.com/4663676/233684667-23f2e554-b0f6-467f-806a-48341843426b.png">
