### PR TITLE
Metatag token overrides

### DIFF
--- a/config/default/metatag.metatag_defaults.403.yml
+++ b/config/default/metatag.metatag_defaults.403.yml
@@ -8,5 +8,5 @@ id: '403'
 label: '403 access denied'
 tags:
   shortlink: '[site:url]'
-  title: '[current-page:title] | [site:name] - The University of Iowa'
+  title: '[current-page:title] | [site:name] - [uiowa_core:org_name]'
   canonical_url: '[site:url]'

--- a/config/default/metatag.metatag_defaults.404.yml
+++ b/config/default/metatag.metatag_defaults.404.yml
@@ -8,5 +8,5 @@ id: '404'
 label: '404 page not found'
 tags:
   shortlink: '[site:url]'
-  title: '[current-page:title] | [site:name] - The University of Iowa'
+  title: '[current-page:title] | [site:name] - [uiowa_core:org_name]'
   canonical_url: '[site:url]'

--- a/config/default/metatag.metatag_defaults.front.yml
+++ b/config/default/metatag.metatag_defaults.front.yml
@@ -8,7 +8,7 @@ id: front
 label: 'Front page'
 tags:
   shortlink: '[site:url]'
-  title: '[site:name] | The University of Iowa'
+  title: '[site:name] | [uiowa_core:org_name]'
   canonical_url: '[site:url]'
   description: '[node:field_teaser]'
   image_src: '[node:field_image:entity:field_media_image:large]'
@@ -16,7 +16,7 @@ tags:
   og_url: '[site:url]'
   og_description: '[node:field_teaser]'
   og_site_name: '[site:name]'
-  og_title: '[site:name] | The University of Iowa'
+  og_title: '[site:name] | [uiowa_core:org_name]'
   twitter_cards_image: '[node:field_image:entity:field_media_image:large]'
   twitter_cards_description: '[node:field_teaser]'
   twitter_cards_type: summary_large_image

--- a/config/default/metatag.metatag_defaults.global.yml
+++ b/config/default/metatag.metatag_defaults.global.yml
@@ -9,29 +9,29 @@ label: Global
 tags:
   shortlink: '[current-page:url:unaliased]'
   referrer: no-referrer-when-downgrade
-  title: '[current-page:title] | [site:name] | The University of Iowa'
+  title: '[current-page:title] | [site:name] | [uiowa_core:org_name]'
   robots: 'index, follow'
   canonical_url: '[current-page:url:absolute]'
-  apple_touch_icon: /profiles/custom/sitenow/assets/apple-touch-icon-60x60.png
-  apple_touch_icon_76x76: /profiles/custom/sitenow/assets/apple-touch-icon-76x76.png
-  apple_touch_icon_precomposed_180x180: /profiles/custom/sitenow/assets/apple-touch-icon-precomposed.png
-  icon_192x192: /profiles/custom/sitenow/assets/android-chrome-192x192.png
-  apple_touch_icon_120x120: /profiles/custom/sitenow/assets/apple-touch-icon-120x120.png
-  shortcut_icon: /profiles/custom/sitenow/assets/favicon.ico
-  icon_96x96: /profiles/custom/sitenow/assets/favicon-96x96.png
-  apple_touch_icon_152x152: /profiles/custom/sitenow/assets/apple-touch-icon-152x152.png
-  apple_touch_icon_72x72: /profiles/custom/sitenow/assets/apple-touch-icon-72x72.png
-  apple_touch_icon_180x180: /profiles/custom/sitenow/assets/apple-touch-icon-180x180.png
-  icon_32x32: /profiles/custom/sitenow/assets/favicon-32x32.png
-  apple_touch_icon_114x114: /profiles/custom/sitenow/assets/apple-touch-icon-114x114.png
-  icon_16x16: /profiles/custom/sitenow/assets/favicon-16x16.png
-  apple_touch_icon_144x144: /profiles/custom/sitenow/assets/apple-touch-icon-144x144.png
+  apple_touch_icon: '[uiowa_core:favicon_assets_path]apple-touch-icon-60x60.png'
+  apple_touch_icon_76x76: '[uiowa_core:favicon_assets_path]apple-touch-icon-76x76.png'
+  apple_touch_icon_precomposed_180x180: '[uiowa_core:favicon_assets_path]apple-touch-icon-precomposed.png'
+  icon_192x192: '[uiowa_core:favicon_assets_path]android-chrome-192x192.png'
+  apple_touch_icon_120x120: '[uiowa_core:favicon_assets_path]apple-touch-icon-120x120.png'
+  shortcut_icon: '[uiowa_core:favicon_assets_path]favicon.ico'
+  icon_96x96: '[uiowa_core:favicon_assets_path]favicon-96x96.png'
+  apple_touch_icon_152x152: '[uiowa_core:favicon_assets_path]apple-touch-icon-152x152.png'
+  apple_touch_icon_72x72: '[uiowa_core:favicon_assets_path]apple-touch-icon-72x72.png'
+  apple_touch_icon_180x180: '[uiowa_core:favicon_assets_path]apple-touch-icon-180x180.png'
+  icon_32x32: '[uiowa_core:favicon_assets_path]favicon-32x32.png'
+  apple_touch_icon_114x114: '[uiowa_core:favicon_assets_path]apple-touch-icon-114x114.png'
+  icon_16x16: '[uiowa_core:favicon_assets_path]favicon-16x16.png'
+  apple_touch_icon_144x144: '[uiowa_core:favicon_assets_path]apple-touch-icon-144x144.png'
   apple_mobile_web_app_status_bar_style: black
-  msapplication_tileimage: /profiles/custom/sitenow/assets/mstile-150x150.png
-  web_manifest: /profiles/custom/sitenow/assets/site.webmanifest
+  msapplication_tileimage: '[uiowa_core:favicon_assets_path]mstile-150x150.png'
+  web_manifest: '[uiowa_core:favicon_assets_path]site.webmanifest'
   theme_color: '#000000'
   x_ua_compatible: IE=edge
   msapplication_tilecolor: '#000000'
-  msapplication_square150x150logo: /profiles/custom/sitenow/assets/mstile-150x150.png
+  msapplication_square150x150logo: '[uiowa_core:favicon_assets_path]mstile-150x150.png'
   mask_icon:
-    href: /profiles/custom/sitenow/assets/safari-pinned-tab.svg
+    href: '[uiowa_core:favicon_assets_path]safari-pinned-tab.svg'

--- a/config/default/metatag.metatag_defaults.node.yml
+++ b/config/default/metatag.metatag_defaults.node.yml
@@ -12,11 +12,11 @@ tags:
   canonical_url: '[current-page:url:absolute]'
   image_src: '[node:field_image:entity:field_media_image:large]'
   description: '[node:field_teaser]'
-  title: '[node:title] | [site:name] - The University of Iowa'
+  title: '[node:title] | [site:name] - [uiowa_core:org_name]'
   mask_icon:
     href: ''
     color: ''
-  og_site_name: '[site:name] - The University of Iowa'
+  og_site_name: '[site:name] - [uiowa_core:org_name]'
   og_description: '[node:field_teaser]'
   og_image_url: '[node:field_image:entity:field_media_image:large]'
   og_url: '[current-page:url:absolute]'

--- a/config/default/metatag.metatag_defaults.node__article.yml
+++ b/config/default/metatag.metatag_defaults.node__article.yml
@@ -6,14 +6,14 @@ id: node__article
 label: 'Content: Article'
 tags:
   shortlink: '[current-page:url:unaliased]'
-  title: '[node:title] | [site:name] - The University of Iowa'
+  title: '[node:title] | [site:name] - [uiowa_core:org_name]'
   canonical_url: '[current-page:url:absolute]'
   description: '[node:field_teaser:value]'
   image_src: '[node:field_image:entity:field_media_image:large]'
   og_image_url: '[node:field_image:entity:field_media_image:large]'
   og_url: '[current-page:url:absolute]'
   og_description: '[node:field_teaser:value]'
-  og_site_name: '[site:name] - The University of Iowa'
+  og_site_name: '[site:name] - [uiowa_core:org_name]'
   og_title: '[node:title]'
   schema_article_date_modified: '[node:changed:html_datetime]'
   schema_article_type: NewsArticle

--- a/config/default/metatag.metatag_defaults.node__person.yml
+++ b/config/default/metatag.metatag_defaults.node__person.yml
@@ -6,7 +6,7 @@ id: node__person
 label: 'Content: Person'
 tags:
   shortlink: '[current-page:url:unaliased]'
-  title: '[node:title] | [site:name] - The University of Iowa'
+  title: '[node:title] | [site:name] - [uiowa_core:org_name]'
   canonical_url: '[current-page:url:absolute]'
   description: '[node:field_teaser:value]'
   image_src: '[node:field_image:entity:field_media_image:large]'
@@ -14,7 +14,7 @@ tags:
   og_image_url: '[node:field_image:entity:field_media_image:large]'
   og_url: '[current-page:url:absolute]'
   og_description: '[node:field_teaser:value]'
-  og_site_name: '[site:name] - The University of Iowa'
+  og_site_name: '[site:name] - [uiowa_core:org_name]'
   og_title: '[node:title]'
   schema_person_type: Person
   schema_person_image: 'a:3:{s:5:"@type";s:11:"ImageObject";s:20:"representativeOfPage";s:4:"True";s:3:"url";s:49:"[node:field_image:entity:field_media_image:large]";}'

--- a/config/default/metatag.metatag_defaults.taxonomy_term.yml
+++ b/config/default/metatag.metatag_defaults.taxonomy_term.yml
@@ -8,6 +8,6 @@ id: taxonomy_term
 label: 'Taxonomy term'
 tags:
   shortlink: '[current-page:url:unaliased]'
-  title: '[term:name] | [site:name] - The University of Iowa'
+  title: '[term:name] | [site:name] - [uiowa_core:org_name]'
   canonical_url: '[current-page:url:absolute]'
   description: '[term:description]'

--- a/config/default/metatag.metatag_defaults.user.yml
+++ b/config/default/metatag.metatag_defaults.user.yml
@@ -8,5 +8,5 @@ id: user
 label: User
 tags:
   shortlink: '[current-page:url:unaliased]'
-  title: '[user:name] | [site:name] - The University of Iowa'
+  title: '[user:name] | [site:name] - [uiowa_core:org_name]'
   canonical_url: '[current-page:url:absolute]'

--- a/docroot/modules/custom/layout_builder_custom/src/EventSubscriber/SectionComponentSubscriber.php
+++ b/docroot/modules/custom/layout_builder_custom/src/EventSubscriber/SectionComponentSubscriber.php
@@ -12,7 +12,6 @@ use Drupal\layout_builder\LayoutBuilderEvents;
 use Drupal\layout_builder\Plugin\Block\FieldBlock;
 use Drupal\layout_builder_custom\LayoutBuilderStylesHelper;
 use Drupal\uiowa_core\Element\Card;
-use Drupal\views\Plugin\Block\ViewsBlock;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**

--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -893,11 +893,11 @@ function uiowa_core_tokens($type, $tokens, array $data, array $options, Bubbleab
       // Find the desired token by name.
       switch ($name) {
         case 'org_name':
-          $replacements[$original] = $config->get('org_name') ?? 'The University of Iowa';
+          $replacements[$original] = $config->get('uiowa_core.org_name') ?? 'The University of Iowa';
           break;
 
         case 'favicon_assets_path':
-          $replacements[$original] = $config->get('favicon_assets_path') ?? '/profiles/custom/sitenow/assets/';
+          $replacements[$original] = $config->get('uiowa_core.favicon_assets_path') ?? '/profiles/custom/sitenow/assets/';
           break;
       }
     }

--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -14,6 +14,7 @@ use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\field\Entity\FieldStorageConfig;
@@ -856,6 +857,51 @@ function uiowa_core_preprocess_block(&$variables) {
       break;
 
   }
+}
+
+/**
+ * Implements hook_token_info().
+ */
+function uiowa_core_token_info(): array {
+  $info = [];
+  $info['types']['uiowa_core'] = [
+    'name' => t('UIowa Core'),
+    'description' => t('Tokens for UIowa Core.'),
+  ];
+  $info['tokens']['uiowa_core']['org_name'] = [
+    'name' => 'Organization Name',
+    'description' => 'A token to override the default University of Iowa organization name.',
+  ];
+  $info['tokens']['uiowa_core']['favicon_assets_path'] = [
+    'name' => 'Favicon assets path',
+    'description' => 'A token to override the default favicons path.',
+  ];
+  return $info;
+}
+
+/**
+ * Implements hook_tokens().
+ */
+function uiowa_core_tokens($type, $tokens, array $data, array $options, BubbleableMetadata $bubbleable_metadata) {
+  $replacements = [];
+  if ($type === 'uiowa_core') {
+
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('uiowa_core.settings');
+
+    foreach ($tokens as $name => $original) {
+      // Find the desired token by name.
+      switch ($name) {
+        case 'org_name':
+          $replacements[$original] = $config->get('org_name') ?? 'The University of Iowa';
+          break;
+        case 'favicon_assets_path':
+          $replacements[$original] = $config->get('favicon_assets_path') ?? '/profiles/custom/sitenow/assets/';
+          break;
+      }
+    }
+  }
+  return $replacements;
 }
 
 /**

--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -895,6 +895,7 @@ function uiowa_core_tokens($type, $tokens, array $data, array $options, Bubbleab
         case 'org_name':
           $replacements[$original] = $config->get('org_name') ?? 'The University of Iowa';
           break;
+
         case 'favicon_assets_path':
           $replacements[$original] = $config->get('favicon_assets_path') ?? '/profiles/custom/sitenow/assets/';
           break;


### PR DESCRIPTION
Minimal slice to get regents-option sites setup with a few metatag/favicon overrides. If we do this often enough we might want to capture some of this through a UI.

# How to test

Example override:

`ddev drush @sitesgis.dev cset uiowa_core.settings uiowa_core.org_name "Alternative Organization Name"`
`ddev drush @sitesgis.dev cset uiowa_core.settings uiowa_core.favicon_assets_path "/sites/gis.sites.uiowa.edu/files/favicons_alt/"`

Example config delete:

`ddev drush @sitesgis.dev cdel uiowa_core.settings uiowa_core.org_name`
`ddev drush @sitesgis.dev cdel uiowa_core.settings uiowa_core.favicon_assets_path`

Example rsync/permissions set:
`ddev drush rsync -v @sitesgis.local:%files/favicons_alt @sitesgis.dev:%files/`
`ddev drush @sitesgis.dev ssh`
`cd sites/gis.sites.uiowa.edu/files`
`chmod ug=rwx,o=rx favicons_alt` or `chmod 775 favicons_alt`
`cd favicons_alt`
confirm you are in the favicons_alt directory!
`find . -type f -print0 | xargs -0 chmod 0644`

Reload the homepage and inspect the source. You should see the overridden values. You should also be able to see the favicon replacement after a `cr`

Example assets:
[favicons_alt.zip](https://github.com/uiowa/uiowa/files/11290568/favicons_alt.zip)


<img width="735" alt="Screenshot 2023-04-21 at 10 45 20 AM" src="https://user-images.githubusercontent.com/4663676/233679246-648a4f65-061b-483f-ae39-3a39b00902b6.png">

