### PR TITLE
Card headline styles

### DIFF
--- a/config/default/layout_builder_styles.style.banner_gradient_dark.yml
+++ b/config/default/layout_builder_styles.style.banner_gradient_dark.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: banner_gradient_dark
-label: 'Dark'
+label: Dark
 classes: banner--gradient-dark
 type: component
 group: banner_gradient

--- a/config/default/layout_builder_styles.style.banner_medium.yml
+++ b/config/default/layout_builder_styles.style.banner_medium.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: banner_medium
-label: 'Medium'
+label: Medium
 classes: banner--medium
 type: component
 group: banner_height

--- a/config/default/layout_builder_styles.style.button_primary.yml
+++ b/config/default/layout_builder_styles.style.button_primary.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: button_primary
-label: 'Gold'
+label: Gold
 classes: 'bttn bttn--primary'
 type: component
 group: button_style

--- a/config/default/layout_builder_styles.style.card_headline_style_sans_serif.yml
+++ b/config/default/layout_builder_styles.style.card_headline_style_sans_serif.yml
@@ -9,5 +9,11 @@ type: component
 group: card_headline_style
 block_restrictions:
   - 'inline_block:uiowa_card'
+  - 'inline_block:uiowa_event'
+  - 'inline_block:uiowa_events'
+  - 'inline_block:featured_content'
+  - 'inline_block:uiowa_aggregator'
+  - 'views_block:article_list_block-list_article'
+  - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
 weight: 5

--- a/config/default/layout_builder_styles.style.card_headline_style_sans_serif.yml
+++ b/config/default/layout_builder_styles.style.card_headline_style_sans_serif.yml
@@ -9,9 +9,7 @@ type: component
 group: card_headline_style
 block_restrictions:
   - 'inline_block:uiowa_card'
-  - 'inline_block:uiowa_event'
   - 'inline_block:uiowa_events'
-  - 'inline_block:featured_content'
   - 'inline_block:uiowa_aggregator'
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'

--- a/config/default/layout_builder_styles.style.card_headline_style_serif.yml
+++ b/config/default/layout_builder_styles.style.card_headline_style_serif.yml
@@ -9,5 +9,11 @@ type: component
 group: card_headline_style
 block_restrictions:
   - 'inline_block:uiowa_card'
+  - 'inline_block:uiowa_event'
+  - 'inline_block:uiowa_events'
+  - 'inline_block:featured_content'
+  - 'inline_block:uiowa_aggregator'
+  - 'views_block:article_list_block-list_article'
+  - 'views_block:people_list_block-list_card'
 layout_restrictions: {  }
 weight: 2

--- a/config/default/layout_builder_styles.style.card_headline_style_serif.yml
+++ b/config/default/layout_builder_styles.style.card_headline_style_serif.yml
@@ -9,9 +9,7 @@ type: component
 group: card_headline_style
 block_restrictions:
   - 'inline_block:uiowa_card'
-  - 'inline_block:uiowa_event'
   - 'inline_block:uiowa_events'
-  - 'inline_block:featured_content'
   - 'inline_block:uiowa_aggregator'
   - 'views_block:article_list_block-list_article'
   - 'views_block:people_list_block-list_card'

--- a/config/default/system.menu.main.yml
+++ b/config/default/system.menu.main.yml
@@ -5,6 +5,6 @@ dependencies: {  }
 _core:
   default_config_hash: Q2Ra3jfoIVk0f3SjxJX61byRQFVBAbpzYDQOiY-kno8
 id: main
-label: 'Section'
+label: Section
 description: 'Site section links'
 locked: true

--- a/docroot/modules/custom/sitenow_events/sitenow_events.module
+++ b/docroot/modules/custom/sitenow_events/sitenow_events.module
@@ -234,14 +234,16 @@ function sitenow_events_preprocess_block(&$variables) {
         }
 
         // Base styles.
-        $styles = ['headline--serif'];
+        $styles = [
+          'card_headline_style' => 'headline--serif',
+        ];
 
         // If there are override styles from the block, add them in.
         if (isset($variables['elements']['#override_styles']) && !empty($variables['elements']['#override_styles'])) {
-          $styles = [
+          $styles = array_values([
             ...$styles,
-            ...array_values($variables['elements']['#override_styles']),
-          ];
+            ...$variables['elements']['#override_styles'],
+          ]);
         }
 
         // Get site-wide configuration for use with constructing event link.

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -2293,3 +2293,42 @@ function sitenow_update_9058(&$sandbox) {
     }
   }
 }
+
+/**
+ * Set defaults for card headline styles.
+ */
+function sitenow_update_9059(&$sandbox) {
+  _update_all_blocks_by_plugin_id([
+    'inline_block:uiowa_events',
+    'inline_block:uiowa_aggregator',
+    'views_block:article_list_block-list_article',
+    'views_block:people_list_block-list_card',
+    'views_block:events_list_block-card_list',
+  ], function (&$component, $block) {
+    /** @var \Drupal\layout_builder\SectionComponent $component */
+    // @phpstan-ignore-next-line
+    $styles = $component->get('layout_builder_styles_style');
+
+    if (empty($styles)) {
+      $styles = [];
+    }
+
+    if (in_array('card_media_position_stacked', $styles)) {
+      $styles[] = 'card_headline_style_sans_serif';
+    }
+    else {
+      $styles[] = 'card_headline_style_serif';
+    }
+
+    // Still need to maintain this other set of styles for AJAX view pagers.
+    // @phpstan-ignore-next-line
+    $configuration = $component->get('configuration');
+    $configuration['layout_builder_styles'] = array_filter($styles);
+
+    $component->setConfiguration($configuration);
+
+    // Save updated styles.
+    // @phpstan-ignore-next-line
+    $component->set('layout_builder_styles_style', array_filter($styles));
+  });
+}


### PR DESCRIPTION
Resolves #6339 

# How to test

```
ddev blt ds --site sandbox.uiowa.edu && ddev drush @sandbox.local uli
```
- Check the following pages and confirm that in any cases where the card items are stacked the headline style is sans-serif and serif when the card items are not stacked.
  - https://sandbox.uiowa.ddev.site/events-listing
  - https://sandbox.uiowa.ddev.site/aggregator-examples
  - https://sandbox.uiowa.ddev.site/articles
  - https://sandbox.uiowa.ddev.site/people-directory
- Any additional checking you think is warranted.

```
ddev blt ds --site performingarts.uiowa.edu && ddev drush @performingarts.local uli
```
- View https://performingarts.uiowa.ddev.site/ and confirm the headline style for the cards in the News section have changed to sans-serif.