### PR TITLE
Search Block Hotfix

### DIFF
--- a/docroot/modules/custom/uiowa_core/src/Plugin/Block/SearchBlock.php
+++ b/docroot/modules/custom/uiowa_core/src/Plugin/Block/SearchBlock.php
@@ -52,17 +52,25 @@ class SearchBlock extends BlockBase implements ContainerFactoryPluginInterface {
   public function build() {
     $block = [];
     $config = $this->getConfiguration();
+    $params = [];
+
+    // Build a list of parameters, if they are set.
+    foreach ([
+      'endpoint',
+      'query_parameter',
+      'query_prepend',
+      'additional_parameters',
+      'button_text',
+      'search_label',
+    ] as $param) {
+      if (isset($config[$param])) {
+        $params[$param] = $config[$param];
+      }
+    }
 
     $block['form'] = $this->formBuilder->getForm(
       'Drupal\uiowa_core\Form\SearchBlock',
-      [
-        'endpoint' => $config['endpoint'],
-        'query_parameter' => $config['query_parameter'],
-        'query_prepend' => $config['query_prepend'],
-        'additional_parameters' => $config['additional_parameters'],
-        'button_text' => $config['button_text'],
-        'search_label' => $config['search_label'],
-      ],
+      $params,
     );
 
     return $block;

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -2293,3 +2293,17 @@ function sitenow_update_9058(&$sandbox) {
     }
   }
 }
+
+/**
+ * Update search blocks to be aware of new fields.
+ */
+function sitenow_update_9059() {
+  _update_all_blocks_by_plugin_id('uiowa_core_search_block', function (&$component, $block) {
+
+    $config = $component->get('configuration');
+    $config['query_prepend'] = '';
+    $config['additional_parameters'] = '';
+    $component->setConfiguration($config);
+
+  });
+}


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

- On `main`, sync admissions.uiowa.edu, `uli` and view homepage. See warnings like the following:
```
Warning: Undefined array key "query_prepend" in Drupal\uiowa_core\Plugin\Block\SearchBlock->build() (line 61 of modules/custom/uiowa_core/src/Plugin/Block/SearchBlock.php).
```
- Checkout `hotfix-search-block` and run `ddev drush @admissions.local updb`
- Reload the homepage and don't see the earlier warnings.
