### PR TITLE
Hotfix for main navigation label on menu blocks

### DIFF
--- a/config/default/system.menu.main.yml
+++ b/config/default/system.menu.main.yml
@@ -5,6 +5,6 @@ dependencies: {  }
 _core:
   default_config_hash: Q2Ra3jfoIVk0f3SjxJX61byRQFVBAbpzYDQOiY-kno8
 id: main
-label: Section
+label: Main navigation
 description: 'Site section links'
 locked: true

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -758,7 +758,7 @@ function uids_base_preprocess_block(&$variables) {
         // Make the block title available to pass to accessible-menu.init.js.
         if (isset($variables['elements']['content']['#title'])) {
           $block_title = $variables['elements']['content']['#title']['#markup'];
-          if ($variables["configuration"]["label_type"] == "block") {
+          if ($variables['configuration']['label_type'] == 'block') {
             $block_title = t('Section');
           }
           $block_name = $variables['elements']['#configuration']['id'];

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -755,11 +755,12 @@ function uids_base_preprocess_block(&$variables) {
         break;
 
       case 'main':
-        // Append 'Menu' to the end of the block label.
-        $variables['configuration']['label'] .= ' Menu';
         // Make the block title available to pass to accessible-menu.init.js.
         if (isset($variables['elements']['content']['#title'])) {
           $block_title = $variables['elements']['content']['#title']['#markup'];
+          if ($block_title === 'Main navigation') {
+            $block_title = t('Section');
+          }
           $block_name = $variables['elements']['#configuration']['id'];
           $variables['#attached']['drupalSettings']['block_title'][$block_name] = $block_title;
         }

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -758,7 +758,7 @@ function uids_base_preprocess_block(&$variables) {
         // Make the block title available to pass to accessible-menu.init.js.
         if (isset($variables['elements']['content']['#title'])) {
           $block_title = $variables['elements']['content']['#title']['#markup'];
-          if ($block_title === 'Main navigation') {
+          if ($variables["configuration"]["label_type"] == "block") {
             $block_title = t('Section');
           }
           $block_name = $variables['elements']['#configuration']['id'];


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/6387.

# How to test
`ddev blt ds --site=tippie.uiowa.edu`
Run through testing instructions or verify the functionality still works from: https://github.com/uiowa/uiowa/pull/6353.

Plus, verify that the "Main navigation" label appears on https://tippie.uiowa.ddev.site/admin/structure/menu. 

