### PR TITLE
now.uiowa.edu: moved article teaser label to inline instead of above to fix icon positioning

### DIFF
--- a/config/sites/now.uiowa.edu/core.entity_view_display.node.article.teaser.yml
+++ b/config/sites/now.uiowa.edu/core.entity_view_display.node.article.teaser.yml
@@ -40,7 +40,7 @@ content:
     region: content
   field_article_author:
     type: entity_reference_label
-    label: above
+    label: inline
     settings:
       link: true
     third_party_settings:


### PR DESCRIPTION
I just noticed the icon position being a little off on now.uiowa.edu.   This fixes the label settings to be like our default config implementation. 

Before:

<img width="674" alt="Screenshot 2023-05-04 at 10 10 37 AM" src="https://user-images.githubusercontent.com/1036433/236250977-cdbc970e-2a28-4f82-ae89-5329ff0f42f4.png">

After:

<img width="702" alt="Screenshot 2023-05-04 at 10 10 46 AM" src="https://user-images.githubusercontent.com/1036433/236250992-3c882eab-1da3-4404-921e-03a13dcd278a.png">
