### PR TITLE
SPPA - Unpublished content access fix

### DIFF
--- a/docroot/sites/sppa.uiowa.edu/modules/sppa_core/sppa_core.install
+++ b/docroot/sites/sppa.uiowa.edu/modules/sppa_core/sppa_core.install
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @file
+ * Update hooks for sppa_core.
+ */
+
+use Drupal\node\Entity\Node;
+
+/**
+ * Update all unpublished nodes to set grant access.
+ */
+function sppa_core_update_9001(&$sandbox) {
+
+  // Process all the unpublished nodes.
+  if (!isset($sandbox['total'])) {
+    $query = \Drupal::entityQuery('node')
+      ->accessCheck(FALSE)
+      ->condition('status', 0)
+      ->execute();
+
+    $sandbox['total'] = count($query);
+    $sandbox['current'] = 0;
+    $sandbox['query'] = $query;
+
+    if (empty($sandbox['total'])) {
+      $sandbox['#finished'] = 1;
+      return;
+    }
+  }
+  // Loop through the same nodes in batches.
+  $nodes_per_batch = 25;
+  $batch = array_slice($sandbox['query'], $sandbox['current'], $sandbox['current'] + $nodes_per_batch);
+  if (empty($batch)) {
+    $sandbox['#finished'] = 1;
+    return;
+  }
+
+  foreach ($batch as $nid) {
+    // Load the node, add a revision message, save.
+    $node = Node::load($nid);
+    // Set revision message and save.
+    $node->setRevisionLogMessage('Automated save.');
+    $node->save();
+    $sandbox['current']++;
+  }
+
+  \Drupal::messenger()
+    ->addMessage($sandbox['current'] . ' nodes processed.');
+
+  if ($sandbox['current'] >= $sandbox['total']) {
+    $sandbox['#finished'] = 1;
+  }
+  else {
+    $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
+  }
+}

--- a/docroot/sites/sppa.uiowa.edu/modules/sppa_core/sppa_core.module
+++ b/docroot/sites/sppa.uiowa.edu/modules/sppa_core/sppa_core.module
@@ -48,9 +48,16 @@ function sppa_core_degrees_allowed_values(FieldStorageConfig $definition, Conten
 function sppa_core_node_grants(AccountInterface $account, $op) {
   $grants = [];
 
-  if (($op == 'view') && ($account->id() != 0) && $account->hasPermission('view own unpublished content')) {
-    // Grant to the author for own unpublished content.
-    $grants['private_author_unpublished'] = [$account->id()];
+  if ($op === 'view') {
+    // Assign grants for nodes that are unpublished. Drupal has three permissions related to viewing unpublished content.
+    // The "view any unpublished content" permissions is actually part of the content moderation module, but there
+    // is an effort to migrate it to core: https://drupal.org/i/273595
+    if ($account->hasPermission('view any unpublished content') || $account->hasPermission('bypass node access')) {
+      $grants['unpublished_all'] = [1];
+    }
+    if ($account->hasPermission('view own unpublished content')) {
+      $grants['unpublished_own'] = [$account->id()];
+    }
   }
 
   return $grants;
@@ -62,15 +69,24 @@ function sppa_core_node_grants(AccountInterface $account, $op) {
 function sppa_core_node_access_records(NodeInterface $node) {
   $grants = [];
 
-  // Set a low priority to allow another modules to override.
-  if (!$node->isPublished() && ($node->getOwnerId() != 0)) {
+  if (!$node->isPublished()) {
+    // For unpublished nodes, create two grants. One which can be unlocked
+    // if the user has permission to bypass or view any unpublished nodes,
+    // and the other which can be unlocked if the user has permission to
+    // view only unpublished nodes they authored.
     $grants[] = [
-      'realm' => 'private_author_unpublished',
+      'realm' => 'unpublished_all',
+      'gid' => 1,
+      'grant_view' => 1,
+      'grant_update' => 0,
+      'grant_delete' => 0,
+    ];
+    $grants[] = [
+      'realm' => 'unpublished_own',
       'gid' => $node->getOwnerId(),
       'grant_view' => 1,
       'grant_update' => 0,
       'grant_delete' => 0,
-      'priority' => -100,
     ];
   }
 

--- a/docroot/sites/sppa.uiowa.edu/modules/sppa_core/sppa_core.module
+++ b/docroot/sites/sppa.uiowa.edu/modules/sppa_core/sppa_core.module
@@ -6,7 +6,9 @@
  */
 
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_state_options_alter().
@@ -38,4 +40,39 @@ function sppa_core_degrees_allowed_values(FieldStorageConfig $definition, Conten
     'MPA' => 'MPA',
   ];
   return $options;
+}
+
+/**
+ * Implements hook_node_grants().
+ */
+function sppa_core_node_grants(AccountInterface $account, $op) {
+  $grants = [];
+
+  if (($op == 'view') && ($account->id() != 0) && $account->hasPermission('view own unpublished content')) {
+    // Grant to the author for own unpublished content.
+    $grants['private_author_unpublished'] = [$account->id()];
+  }
+
+  return $grants;
+}
+
+/**
+ * Implements hook_node_access_records().
+ */
+function sppa_core_node_access_records(NodeInterface $node) {
+  $grants = [];
+
+  // Set a low priority to allow another modules to override.
+  if (!$node->isPublished() && ($node->getOwnerId() != 0)) {
+    $grants[] = [
+      'realm' => 'private_author_unpublished',
+      'gid' => $node->getOwnerId(),
+      'grant_view' => 1,
+      'grant_update' => 0,
+      'grant_delete' => 0,
+      'priority' => -100,
+    ];
+  }
+
+  return $grants;
 }


### PR DESCRIPTION
Resolves #6377 

By enabling private_content, the node_grants functionality in core is enabled which handles access checking in places like views listings. That means additional code is necessary to apply the same permissions we take for granted (pun intended).  This was recently "lost" for SPPA when the bypass content access control was [removed from all sites](https://github.com/uiowa/uiowa/issues/5659#issuecomment-1374111499). This node grants system is handled on node save though which means for SPPA to use this, all nodes (or a least the unpublished ones) need to be re-saved.

https://git.drupalcode.org/project/private_content#warning
https://api.drupal.org/api/drupal/core%21modules%21node%21node.module/group/node_access/8.8.x

# To Test

```
ddev blt ds --site=sppa.uiowa.edu && ddev drush @sppa.local uli --uid=6 "admin/content?&status=2"
```

Masquerade as other users with different roles and see how they are affected by the change.

Note: jabell can't see mccnnell's [unpublished page](https://sppa.uiowa.ddev.site/current-students) in the content overview. and mccnnell can't see jabell's unpublished articles as the `view any unpublished content` permission is not checked against in the node grants method.