### PR TITLE
[Events feature] Add pager to page and sub events block

### DIFF
--- a/config/features/event/views.view.events.yml
+++ b/config/features/event/views.view.events.yml
@@ -81,10 +81,26 @@ display:
           separator: ', '
           field_api_classes: false
       pager:
-        type: some
+        type: full
         options:
           offset: 0
           items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
       exposed_form:
         type: basic
         options:
@@ -271,6 +287,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -602,6 +619,11 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: true
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 10
       sorts:
         sticky:
           id: sticky
@@ -791,6 +813,7 @@ display:
       defaults:
         title: false
         css_class: false
+        pager: false
         group_by: false
         style: false
         row: false
@@ -1371,6 +1394,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
       tags:
@@ -2000,6 +2024,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
       tags:


### PR DESCRIPTION
Resolves #6414 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

It looks like paging was removed from all displays of the events view, but should only be removed from the events by presenter display.

# How to test

<!-- Include detailed steps for how to test this PR. -->
`ddev blt ds --site=iowasummerwritingfestival.uiowa.edu`
Check out https://iowasummerwritingfestival.uiowa.ddev.site/events, and see that you can page through events
Check out https://iowasummerwritingfestival.uiowa.ddev.site/event/96/weeklong-session-july-9-july-14-2023 and see that you can page through events

Check that admissions or oniowa work correctly using events stuff.