### PR TITLE
[Iowa Now] Basic news type

### DIFF
--- a/config/sites/now.uiowa.edu/field.field.node.article.field_article_type.yml
+++ b/config/sites/now.uiowa.edu/field.field.node.article.field_article_type.yml
@@ -12,7 +12,7 @@ field_name: field_article_type
 entity_type: node
 bundle: article
 label: 'Article Type'
-description: 'A corresponding tag will be added/removed based on the article type selected.'
+description: 'A corresponding tag will be added/removed based on the article type selected. <em>Basic</em> article types can use any tags, and will not receive any auto tagging.'
 required: true
 translatable: false
 default_value:

--- a/config/sites/now.uiowa.edu/field.storage.node.field_article_type.yml
+++ b/config/sites/now.uiowa.edu/field.storage.node.field_article_type.yml
@@ -23,6 +23,9 @@ settings:
     -
       value: achievements
       label: Achievement
+    -
+      value: basic
+      label: Basic
   allowed_values_function: ''
 module: options
 locked: false

--- a/docroot/sites/now.uiowa.edu/modules/now_core/now_core.module
+++ b/docroot/sites/now.uiowa.edu/modules/now_core/now_core.module
@@ -23,6 +23,33 @@ function now_core_form_alter(&$form, FormStateInterface $form_state, $form_id) {
           ],
         ],
       ];
+
+      $form['field_embargo_information']['#states'] = [
+        'visible' => [
+          ':input[name="field_article_type"]' => [
+            'value' => 'featured',
+          ],
+        ],
+      ];
+
+      $form['field_original_publication_date']['#states'] = [
+        'visible' => [
+          ':input[name="field_article_type"]' => [
+            ['value' => 'in-the-news'],
+            'or',
+            ['value' => 'ui-spotlight'],
+          ],
+        ],
+      ];
+
+      // @todo Remove this when https://github.com/uiowa/uiowa/issues/2691
+      //   is resolved.
+      // Smart_date deals with ranges, but we only need a single date,
+      // so unset the extra "to" in the form and hide the end date.
+      // JS will update the end date to match the start date
+      // without showing clutter to the end user.
+      unset($form['field_original_publication_date']['widget'][0]['time_wrapper']['separator']);
+      $form['field_original_publication_date']['widget'][0]['time_wrapper']['end_value']['#attributes']['class'][] = 'hidden';
       break;
 
     // Article contacts are taken care of in sitenow_articles.module,
@@ -52,34 +79,6 @@ function now_core_form_alter(&$form, FormStateInterface $form_state, $form_id) {
         }
       }
 
-  }
-  if ($form_id === 'node_article_form' || $form_id === 'node_article_edit_form') {
-    $form['field_embargo_information']['#states'] = [
-      'visible' => [
-        ':input[name="field_article_type"]' => [
-          'value' => 'featured',
-        ],
-      ],
-    ];
-
-    $form['field_original_publication_date']['#states'] = [
-      'visible' => [
-        ':input[name="field_article_type"]' => [
-          ['value' => 'in-the-news'],
-          'or',
-          ['value' => 'ui-spotlight'],
-        ],
-      ],
-    ];
-
-    // @todo Remove this when https://github.com/uiowa/uiowa/issues/2691
-    //   is resolved.
-    // Smart_date deals with ranges, but we only need a single date,
-    // so unset the extra "to" in the form and hide the end date.
-    // JS will update the end date to match the start date
-    // without showing clutter to the end user.
-    unset($form['field_original_publication_date']['widget'][0]['time_wrapper']['separator']);
-    $form['field_original_publication_date']['widget'][0]['time_wrapper']['end_value']['#attributes']['class'][] = 'hidden';
   }
 }
 

--- a/docroot/sites/now.uiowa.edu/modules/now_core/now_core.module
+++ b/docroot/sites/now.uiowa.edu/modules/now_core/now_core.module
@@ -131,7 +131,7 @@ function now_core_node_presave($entity) {
       // To account for articles created prior to requiring this field,
       // we also need to check if the field is empty. If it was,
       // we won't have a TID to remove.
-      $old_tid = (!empty($entity->original->field_article_type_value)) ? now_core_article_type_tag_map($entity->original->field_article_type->value) : FALSE;
+      $old_tid = (!empty($entity->original->field_article_type->value)) ? now_core_article_type_tag_map($entity->original->field_article_type->value) : FALSE;
     }
     // If the old TID is the same as the new,
     // then we can treat it like the entity is new.


### PR DESCRIPTION
Resolves #6423 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

`git checkout now-basic-news && ddev blt ds --site=now.uiowa.edu && ddev drush @now.local uli`

- Create new articles and edit existing articles.
- Try out the "Basic" article type, as well as the existing article types.
- For "Basic": 
  - no additional fields (embargo info, original publication date, or points of contact) should be available
  - No tags should be auto-added
  - Any tags you manually add should remain untouched
- For other types:
  - News Feature/Achievements should get points of contact field
  - ui spotlight and in the news should get original publication date
  - News feature should get embargo info (and if it is filled, article should stay in draft state)
  - A corresponding tag related to the type should be added on save
- changing types and re-saving:
  - If a tag existed for the original type, it should be removed
  - If the new type has a corresponding tag (ie is not Basic) it should be added
  - If the new type is Basic, nothing should change in tags