### PR TITLE
Fix for cached view cards

### DIFF
--- a/docroot/modules/custom/uiowa_core/src/Entity/NodeBundleBase.php
+++ b/docroot/modules/custom/uiowa_core/src/Entity/NodeBundleBase.php
@@ -54,14 +54,13 @@ abstract class NodeBundleBase extends Node implements RendersAsCardInterface {
       $build['#link_indicator'] = $link_indicator;
     }
 
+    // At this point, we aren't always aware if this is coming from a view.
     // If this is a view, there is a chance that the teasers can be displayed in
     // more than one place. Unsetting the cache keys prevents the same cached
     // version from being shared from instance to instance in case we are
     // hiding fields or overriding styles.
-    if (!is_null($this->view)) {
-      if (isset($build['#cache']['keys'])) {
-        unset($build['#cache']['keys']);
-      }
+    if (isset($build['#cache']['keys'])) {
+      unset($build['#cache']['keys']);
     }
   }
 


### PR DESCRIPTION
Resolves #6383 
# To Test

- Clear cache and varnish on engineering.dev.
- Go to https://engineering.dev.drupal.uiowa.edu/people
- Then go to https://engineering.dev.drupal.uiowa.edu/people/me-people (all images should be right side).
- Now these pages should remain cached on refresh. If a node is re-saved (logged in a separate browser, caches should clear for the anonymous session).

Compare this with main locally where the first result is left side. https://github.com/uiowa/uiowa/issues/6383#issuecomment-1542854112