### PR TITLE
[Event feature] Removed menu entry for /events

### DIFF
--- a/config/features/event/views.view.events.yml
+++ b/config/features/event/views.view.events.yml
@@ -9,7 +9,6 @@ dependencies:
     - field.storage.node.field_image
     - field.storage.node.field_teaser
     - node.type.event
-    - system.menu.main
   module:
     - better_exposed_filters
     - node
@@ -2005,8 +2004,8 @@ display:
           tokenize: false
       path: events
       menu:
-        type: normal
-        title: Events
+        type: none
+        title: ''
         description: ''
         weight: 0
         expanded: false


### PR DESCRIPTION
```
ddev blt ds --site=oniowa.uiowa.edu
```
```
ddev blt ds --site=iowasummerwritingfestival.uiowa.edu
```

Verify in the main menu settings (https://iowasummerwritingfestival.uiowa.ddev.site/admin/structure/menu/manage/main)  that there is no entry for "Events"