### PR TITLE
Hotfix - UI Events v2 Card Links

### DIFF
--- a/docroot/modules/custom/sitenow_events/modules/sitenow_events_paragraph/sitenow_events_paragraph.module
+++ b/docroot/modules/custom/sitenow_events/modules/sitenow_events_paragraph/sitenow_events_paragraph.module
@@ -108,6 +108,9 @@ function sitenow_events_paragraph_preprocess_paragraph(&$variables) {
           'items_per_page' => $paragraph->get('field_events_results')->getString(),
         ]);
 
+        // Get site-wide configuration for use with constructing event link.
+        $config = \Drupal::config('sitenow_events.settings');
+
         if (!empty($data['events'])) {
           foreach ($data['events'] as $key => $value) {
             // The API nests each event as an array.
@@ -123,6 +126,8 @@ function sitenow_events_paragraph_preprocess_paragraph(&$variables) {
               'media--border',
               'media--small',
             ];
+
+            $event['sitenow_events_config'] = $config;
 
             $event['attributes']['class'] = $styles;
             $event['heading_size'] = 'h2';

--- a/docroot/modules/custom/sitenow_events/sitenow_events.module
+++ b/docroot/modules/custom/sitenow_events/sitenow_events.module
@@ -255,24 +255,7 @@ function sitenow_events_preprocess_block(&$variables) {
           $event['attributes']['class'] = $styles;
           $event['heading_size'] = $heading_size ?? 'h3';
 
-          // Construct event link based on site-wide configuration.
-          $external_link = ($config->get('event_link') === 'event-link-external');
-          if ($external_link) {
-            $event['url'] = $event['events_site_url'];
-          }
-          else {
-            $single_event_path = $config->get('single_event_path');
-
-            // Add a parameter on the URL for event instances.
-            foreach ($event['event_instances'] as $instance_key => $instance) {
-              if ($event['instance_start'] === $instance['event_instance']['start']) {
-                $instance_id = $instance_key;
-              }
-            }
-
-            $event_path = isset($instance_id) ? "{$event['id']}/{$instance_id}" : $event['id'];
-            $event['url'] = Url::fromUri("internal:/{$single_event_path}/{$event_path}", ['alias' => TRUE]);
-          }
+          $event['sitenow_events_config'] = $config;
 
           // Pass off to helper function to build card render.
           $variables['content'][$key] = sitenow_events_build_card($event);
@@ -319,6 +302,26 @@ function sitenow_events_preprocess_block(&$variables) {
  * Helper function to build out card renders from event data.
  */
 function sitenow_events_build_card(array $event): array {
+
+  // Construct event link based on site-wide configuration.
+  $external_link = ($event['sitenow_events_config']->get('event_link') === 'event-link-external');
+  if ($external_link) {
+    $event['url'] = $event['events_site_url'];
+  }
+  else {
+    $single_event_path = $event['sitenow_events_config']->get('single_event_path');
+
+    // Add a parameter on the URL for event instances.
+    foreach ($event['event_instances'] as $instance_key => $instance) {
+      if ($event['instance_start'] === $instance['event_instance']['start']) {
+        $instance_id = $instance_key;
+      }
+    }
+
+    $event_path = isset($instance_id) ? "{$event['id']}/{$instance_id}" : $event['id'];
+    $event['url'] = Url::fromUri("internal:/{$single_event_path}/{$event_path}", ['alias' => TRUE]);
+  }
+
   $card = [
     '#type' => 'card',
     '#attributes' => $event['attributes'],


### PR DESCRIPTION
Seems I got careless in trying to consolidate code for UI Events between v2/v3 during card_4x. v2 was not able to properly construct a link and was falling back to the current path.

# To Test

```
ddev blt ds --site=pentacrestmuseums.uiowa.edu && ddev drush @pentacrestmuseums.local uli /tree-tours
```

Compared to PROD, this should now have the events link to their specific instances within the site.

Go to https://pentacrestmuseums.uiowa.ddev.site/admin/config/sitenow/sitenow-events and change to "Link to events.uiowa.edu"

```
ddev drush @pentacrestmuseums.local cr
```

The events should now link to events.uiowa.edu.

Confirm this is still working for a v3 website: https://sandbox.uiowa.ddev.site/events-listing