### PR TITLE
[Classrooms] Additional layout adjustments

### DIFF
--- a/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/classrooms_core.module
+++ b/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/classrooms_core.module
@@ -465,28 +465,8 @@ function classrooms_core_theme($existing, $type, $theme, $path) {
       'template' => 'field--node--field-room-seating-chart--room--default',
       'base hook' => 'field',
     ],
-    'field__node__field_room_accessibility__room__default' => [
-      'template' => 'field--node--field-room-accessibility--room--default',
-      'base hook' => 'field',
-    ],
-    'field__node__field_room_features__room__default' => [
-      'template' => 'field--node--field-room-features--room--default',
-      'base hook' => 'field',
-    ],
-    'field__node__field_room_classroom_furniture' => [
-      'template' => 'field--node--field-room-classroom-furniture',
-      'base hook' => 'field',
-    ],
-    'field__node__field_room_tile_details' => [
-      'template' => 'field--node--field-room-tile-details',
-      'base hook' => 'field',
-    ],
     'field__node__field_room_guide__room__default' => [
       'template' => 'field--node--field-room-guide--room--default',
-      'base hook' => 'field',
-    ],
-    'field__node__field_room_design_details' => [
-      'template' => 'field--node--field-room-design-details',
       'base hook' => 'field',
     ],
     'taxonomy_term__technology_features' => [

--- a/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/src/Entity/ClassroomsRoom.php
+++ b/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/src/Entity/ClassroomsRoom.php
@@ -85,8 +85,7 @@ class ClassroomsRoom extends NodeBundleBase implements RendersAsCardInterface {
   public function getDefaultCardStyles(): array {
     return [
       ...parent::getDefaultCardStyles(),
-      'card_media_position' => 'card--stacked',
-      'media_size' => 'media--large',
+      'media_size' => 'media--medium',
       'headline_class' => 'headline--serif headline--underline h4',
       'styles' => 'card--button-align-bottom',
       'border' => '',

--- a/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/src/Entity/ClassroomsRoom.php
+++ b/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/src/Entity/ClassroomsRoom.php
@@ -85,7 +85,8 @@ class ClassroomsRoom extends NodeBundleBase implements RendersAsCardInterface {
   public function getDefaultCardStyles(): array {
     return [
       ...parent::getDefaultCardStyles(),
-      'media_size' => 'media--medium',
+      'card_media_position' => 'card--stacked',
+      'media_size' => 'media--large',
       'headline_class' => 'headline--serif headline--underline h4',
       'styles' => 'card--button-align-bottom',
       'border' => '',

--- a/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/templates/field--node--field-room-accessibility--room--default.html.twig
+++ b/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/templates/field--node--field-room-accessibility--room--default.html.twig
@@ -1,8 +1,0 @@
-<div{{ title_attributes.addclass(title_classes) }}>{{ label }}</div>
-<ul class="element--list-none element--margin-none">
-  {% for item in items %}
-    <li>
-      <span class="badge badge--primary">{{ item.content }}</span>
-    </li>
-  {% endfor %}
-</ul>

--- a/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/templates/field--node--field-room-classroom-furniture.html.twig
+++ b/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/templates/field--node--field-room-classroom-furniture.html.twig
@@ -1,8 +1,0 @@
-<div{{ title_attributes.addclass(title_classes) }}>{{ label }}</div>
-<ul class="element--list-none element--margin-none">
-  {% for item in items %}
-    <li>
-      <span class="badge badge--light">{{ item.content }}</span>
-    </li>
-  {% endfor %}
-</ul>

--- a/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/templates/field--node--field-room-design-details.html.twig
+++ b/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/templates/field--node--field-room-design-details.html.twig
@@ -1,9 +1,0 @@
-<div{{ title_attributes.addclass(title_classes) }}>{{ label }}</div>
-<ul class="element--list-none element--margin-none">
-  {% for item in items %}
-    <li>
-      <span class="badge badge--light">{{ item.content }}</span>
-    </li>
-  {% endfor %}
-</ul>
-

--- a/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/templates/field--node--field-room-features--room--default.html.twig
+++ b/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/templates/field--node--field-room-features--room--default.html.twig
@@ -1,8 +1,0 @@
-<div{{ title_attributes.addclass(title_classes) }}>{{ label }}</div>
-<ul class="element--list-none element--margin-none">
-  {% for item in items %}
-    <li>
-      <span class="badge badge--light">{{ item.content }}</span>
-    </li>
-  {% endfor %}
-</ul>

--- a/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/templates/field--node--field-room-tile-details.html.twig
+++ b/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/templates/field--node--field-room-tile-details.html.twig
@@ -1,8 +1,0 @@
-<div{{ title_attributes.addclass(title_classes) }}>{{ label }}</div>
-<ul class="element--list-none element--margin-none">
-  {% for item in items %}
-    <li>
-      <span class="badge badge--light">{{ item.content }}</span>
-    </li>
-  {% endfor %}
-</ul>


### PR DESCRIPTION
- Removes the badge styling from the room feature details as requested from the classrooms team. 

# How to test
```
ddev blt ds --site=classrooms.uiowa.edu
```
- Review code changes
- Go to https://classrooms.uiowa.ddev.site/mh-27 and verify that furniture details no longer renders in the "badge" style and renders like the screenshot below. 

<img width="1649" alt="Screenshot 2023-05-22 at 2 03 55 PM" src="https://github.com/uiowa/uiowa/assets/1036433/485d8b39-4649-442c-8db4-e7f0524860d3">

<!-- Include detailed steps for how to test this PR. -->
