### PR TITLE
event attendance hotfix

### DIFF
--- a/docroot/modules/custom/sitenow_events/sitenow_events.module
+++ b/docroot/modules/custom/sitenow_events/sitenow_events.module
@@ -530,6 +530,9 @@ function sitenow_events_preprocess_field(&$variables) {
       if (isset($variables['items'][0]['content']['#markup']) && $variables['items'][0]['content']['#markup'] === 'Yes') {
         $variables['items'][0]['content']['#markup'] = '<span class="badge badge--secondary">' . $field_label . '</span>';
       }
+      else {
+        uiowa_core_set_attributes($variables, 'sr-only');
+      }
       break;
 
     case 'field_event_category':


### PR DESCRIPTION
This _is_ an issue for all sites using the events feature. It renders once the field is "set" with either true/false. In cases where it wasn't showing yet, the node had not been resaved (no update hook was done) and the field was not set. This seems like an appropriate fix given that the field_block in preprocess_block is doing something similar.

https://github.com/uiowa/uiowa/blob/main/docroot/modules/custom/sitenow_events/sitenow_events.module#L203-L205

<img width="722" alt="Screenshot 2023-06-01 at 12 52 52 PM" src="https://github.com/uiowa/uiowa/assets/4663676/a29b192f-cbb2-4cf6-9c17-b7091db3ad32">


# To Test

On `main` sync iswf and oniowa. save some events. some with the boolean checked some without. go to /events and see the no values.

Pull this PR down and do some `cr` see that the "no" values don't show.


