### PR TITLE
Proof of concept for copy class.

### DIFF
--- a/docroot/profiles/custom/sitenow/js/copy.js
+++ b/docroot/profiles/custom/sitenow/js/copy.js
@@ -63,7 +63,3 @@
     }
   };
 })(jQuery, Drupal);
-
-// bttn--copy-clipboard
-
-

--- a/docroot/profiles/custom/sitenow/js/copy.js
+++ b/docroot/profiles/custom/sitenow/js/copy.js
@@ -1,0 +1,69 @@
+/**
+ * @file
+ * Sitenow copy script. Attached to every page.
+ */
+
+(function ($, Drupal) {
+  Drupal.behaviors.copy = {
+    attach: function (context, setting) {
+      $(".copy-clipboard", context).once('copy').each(function () {
+        const text = this.innerText;
+
+        this.innerHTML += '' +
+          '<button class="bttn--copy-clipboard">' +
+            '<i role="presentation" class="fas fa-clipboard"></i>' +
+          '</button>'
+        ;
+
+        const delay = 1200;
+        const button = $(this).find('.bttn--copy-clipboard')[0];
+        button.onmousedown = function() {
+          copyToClipboard(text);
+          const timeStamp = Date.now();
+
+          button.classList.forEach(function(buttonClass){
+            if (buttonClass.startsWith('copy-tooltip-')){
+              button.classList.remove(buttonClass);
+            }
+          });
+          button.classList.add('copy-tooltip-' + timeStamp);
+
+          window.rtimeOut(()=>{
+            button.classList.forEach(function(buttonClass){
+              if (buttonClass.startsWith('copy-tooltip-')){
+                const addTime = Number(buttonClass.replace('copy-tooltip-', ''));
+
+                if (Date.now() >= (addTime + delay)) {
+                  button.classList.remove(buttonClass);
+                }
+
+              }
+            });
+          }, delay);
+        };
+
+        function copyToClipboard(String) {
+          navigator.clipboard.writeText(String);
+        }
+
+        window.rtimeOut=function(callback,delay){
+          var dateNow=Date.now,
+            requestAnimation=window.requestAnimationFrame,
+            start=dateNow(),
+            stop,
+            timeoutFunc=function(){
+              dateNow()-start<delay?stop||requestAnimation(timeoutFunc):callback()
+            };
+          requestAnimation(timeoutFunc);
+          return{
+            clear:function(){stop=1}
+          }
+        }
+      });
+    }
+  };
+})(jQuery, Drupal);
+
+// bttn--copy-clipboard
+
+

--- a/docroot/profiles/custom/sitenow/sitenow.libraries.yml
+++ b/docroot/profiles/custom/sitenow/sitenow.libraries.yml
@@ -6,6 +6,7 @@ admin-overrides:
 global-scripts:
   js:
     js/sitenow.behaviors.js: {}
+    js/copy.js: {}
   dependencies:
     - core/drupal
     - core/jquery

--- a/docroot/themes/custom/uids_base/scss/components/copy.scss
+++ b/docroot/themes/custom/uids_base/scss/components/copy.scss
@@ -1,0 +1,47 @@
+.copy-clipboard {
+  border: 1px solid grey;
+  padding: 1rem;
+  padding-right: 3rem;
+  border-radius: 4px;
+  position: relative;
+}
+
+.bttn--copy-clipboard {
+  position: absolute;
+  right: 0;
+  height: 100%;
+  top: 0;
+  border: none;
+  background: #969696;
+  color: #fafafa;
+
+  &:hover, &:focus {
+    background: #858585;
+  }
+
+  &:active {
+    background: #606060;
+  }
+
+  &::before {
+    content: 'Copied!';
+    position: absolute;
+    font-size: 0.8rem;
+    color: #fafafa;
+    background-color: #040404d7;
+    display: inline-block;
+    width: 5rem;
+    padding: 3px 5px;
+    right: calc(100% + 5px);
+    border-radius: 6px;
+    border: 1px solid #464b52d7;
+    pointer-events: none;
+    top: calc(50% - 0.5rem);
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out 0.08s;
+  }
+}
+
+[class*=copy-tooltip-]::before {
+  opacity: 1;
+}

--- a/docroot/themes/custom/uids_base/uids_base.libraries.yml
+++ b/docroot/themes/custom/uids_base/uids_base.libraries.yml
@@ -11,6 +11,7 @@ global-styling:
       assets/css/components/badge.css: {}
       assets/css/components/breadcrumbs.css: {}
       assets/css/components/colors.css: {}
+      assets/css/components/copy.css: {}
       assets/css/components/blockquote.css: {}
       assets/css/components/button.css: {}
       assets/css/components/form/forms.css: {}


### PR DESCRIPTION
This is an idea that @pyrello had that I thought I would make a proof of concept for. I ripped some of the code from an earlier project of mine to make this.

## To test

```
composer install
```
compile styles


Add the class `copy-clipboard` to any tag as a class in a WYSIWYG.
Observe that when it is rendered there is a clipboard button and that clicking it shows a tooltip that says "Copied!"
Ensure that you can actually paste the content that was said to be copied.