### PR TITLE
[Bug] V2 card titles on dark backgrounds

### DIFF
--- a/docroot/themes/custom/uids_base/scss/sitenow.scss
+++ b/docroot/themes/custom/uids_base/scss/sitenow.scss
@@ -3,6 +3,30 @@
 @import "uids3/components/typography/headings/headings.scss";
 @import "uids3/components/headline/headline.scss";
 
+@mixin bg-dark {
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    &.headline.default {
+      color: $secondary;
+    }
+  }
+}
+
+@mixin bg-black {
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    &.headline.default {
+      color: $secondary;
+    }
+  }
+}
+
 html {
   box-sizing: border-box;
   -ms-overflow-style: scrollbar;

--- a/docroot/themes/custom/uids_base/scss/sitenow.scss
+++ b/docroot/themes/custom/uids_base/scss/sitenow.scss
@@ -3,6 +3,8 @@
 @import "uids3/components/typography/headings/headings.scss";
 @import "uids3/components/headline/headline.scss";
 
+// @todo https://github.com/uiowa/uiowa/issues/6584
+
 @mixin bg-dark {
   h2,
   h3,


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

This fixes a `bg-black` and `bd-dark` mixin that was targeting `card__title`.   Since we no longer use that class, I am targeting the `headline.default` class for the mixin. 

Resolves https://github.com/uiowa/uiowa/issues/6572.  


# How to test

```
ddev blt frontend && ddev blt ds --site=pentacrestmuseums.uiowa.edu && ddev drush @pentacrestmuseums.local uli visit/group-visits-tours
```
- Test Background colors on the cards.
- Think of any other V2 implementation of headline classes where `headline.default` class would be targeted. 
