### PR TITLE
[Admissions] Added subtitle field to pdf template 

### DIFF
--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/pdf.scss
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/pdf.scss
@@ -468,6 +468,19 @@ h6 {
     }
   }
 
+  .field--name-field-area-of-study-subtitle {
+    margin-bottom: 10px;
+    p, strong, em {
+      @extend .element--light-intro;
+      line-height: 1;
+      font-size: 1rem!important;
+      margin-bottom: 10px;
+    }
+    em {
+      font-weight: bold;
+    }
+  }
+
   .field--name-field-area-of-study-competitive,
   .field--name-field-area-of-study-four-year,
   .field--name-field-area-of-study-honors,

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/pdf.scss
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/pdf.scss
@@ -471,12 +471,6 @@ h6 {
   .field--name-field-area-of-study-subtitle {
     margin-bottom: 10px;
     p, strong, em {
-      @extend .element--light-intro;
-      line-height: 1;
-      font-size: 1rem!important;
-      margin-bottom: 10px;
-    }
-    em {
       font-weight: bold;
     }
   }

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/node--area-of-study--pdf.html.twig
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/templates/node--area-of-study--pdf.html.twig
@@ -131,6 +131,7 @@
         {{ content.field_area_of_study_scholarship|render|striptags('<p><strong><div>')|t }}
       </div>
 
+      {{ content.field_area_of_study_subtitle|render }}
       {{ content.body.0|render }}
       {{ content.field_area_of_study_why|render }}
       {{ content.field_area_of_study_requirement|render }}


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/5858. 

# How to test

```
ddev yarn workspace admissions_core build && ddev blt ds --site=admissions.uiowa.edu && ddev drush @admissions.local uli print/pdf/node/2786
```

Edit subtitle field on https://admissions.uiowa.ddev.site/node/2786/edit and try italic, underline, and a link and verify they are styled in the PDF. 

It should look like:

[1019 (1).pdf](https://github.com/uiowa/uiowa/files/12071177/1019.1.pdf)
