### PR TITLE
P2LB reporting tool

### DIFF
--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.links.task.yml
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.links.task.yml
@@ -8,3 +8,8 @@ sitenow_p2lb.content_converted:
   title: "Converted"
   base_route: sitenow_p2lb.content_converter
   weight: 100
+
+entity.node.conversion_status:
+  route_name: entity.node.p2lb_conversion_status
+  base_route: entity.node.canonical
+  title: 'V3 Status'

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -1207,6 +1207,7 @@ function _sitenow_p2lb_block_styles($block_type, $paragraph = NULL) {
         'card_image_medium',
         'list_format_list',
         'block_grid_threecol_33_34_33',
+        'no_border',
       ];
 
     case 'uiowa_quote':

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -13,6 +13,7 @@ use Drupal\Core\Url;
 use Drupal\layout_builder\Field\LayoutSectionItemList;
 use Drupal\layout_builder\InlineBlockUsage;
 use Drupal\layout_builder\Section;
+use Drupal\sitenow_p2lb\P2LbHelper;
 
 /**
  * Implements hook_form_alter().
@@ -48,6 +49,27 @@ function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_i
           $form['body']['#access'] = FALSE;
         }
       }
+    }
+  }
+}
+
+/**
+ * Implements hook_entity_view().
+ */
+function sitenow_p2lb_entity_view(array &$build, \Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display, $view_mode) {
+  if ($entity instanceof \Drupal\sitenow_pages\Entity\Page) {
+    $issues = P2LbHelper::analyzeNode($entity);
+
+    if (!empty($issues)) {
+      $build['issues'] = [
+        '#type' => 'container',
+        '#weight' => -10,
+      ];
+
+      $build['issues']['list'] = [
+        '#theme' => 'item_list',
+        '#items' => $issues,
+      ];
     }
   }
 }
@@ -565,46 +587,46 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
     case 'card':
       $type = 'uiowa_card';
       // Image isn't required. Check for one, or set to null.
-      $image = $paragraph->field_card_image?->target_id ?: '';
+      $image = ($paragraph->get('field_card_image')->getValue()) ?
+        $paragraph->get('field_card_image')->getValue()[0]['target_id'] : '';
 
       // Link isn't required. Check for one, or set to null.
-      $link = $paragraph->field_card_link?->value[0] ?: NULL;
+      $link = ($paragraph->get('field_card_link')->getValue()) ?
+        $paragraph->get('field_card_link')->getValue()[0] : '';
 
       // Label (title) isn't required. Check for one, or set to null.
-      $label = $paragraph->field_card_title?->value ?: '';
+      $label = ($paragraph->get('field_card_title')->getValue()) ?
+        $paragraph->get('field_card_title')->getString() : '';
       $display_label = ($label) ? 1 : 0;
 
       // Subtitle field isn't required. Check for one, or set to null.
-      $subtitle = $paragraph->field_card_subtitle?->value ?: '';
+      $subtitle = ($paragraph->get('field_card_subtitle')->getValue()) ?
+        $paragraph->get('field_card_subtitle')->getString() : '';
 
       // Card body isn't required. Check or set to array with empty value.
-      $excerpt = $paragraph->field_card_body?->getValue()[0] ?: NULL;
+      $excerpt = ($paragraph->get('field_card_body')->getValue()) ?
+        $paragraph->get('field_card_body')->getValue()[0] : '';
 
       if ($excerpt) {
         $excerpt['format'] = 'minimal';
       }
-
-      // Handle the case where there is only an image and optionally a link.
-      if ($image && (!$label && !$subtitle && !$excerpt)) {
-        $fields = ['field_uiowa_image_image' => $image];
-        if ($link) {
-          $fields['field_uiowa_image_link'] = $link;
-        }
-        $block_definition = sitenow_p2lb_block_definition('uiowa_image', $fields);
-      }
-      else {
-        $block_definition = sitenow_p2lb_block_definition('uiowa_card', [
-          'field_uiowa_card_author' => $subtitle,
-          'field_uiowa_card_excerpt' => $excerpt,
-          'field_uiowa_card_image' => $image,
-          'field_uiowa_card_link' => $link,
-          'field_uiowa_card_title' => [
-            // Size not set in paragraphs. Defaulting to h2. Can change later.
-            'size' => 'h2',
-            'text' => $label,
-          ],
-        ]);
-      }
+      $block_definition = [
+        'type' => $type,
+        'langcode' => 'en',
+        'status' => $paragraph->get('status')->getString(),
+        'info' => 'Card',
+        'reusable' => 0,
+        'default_langcode' => 1,
+        'field_uiowa_card_author' => $subtitle,
+        'field_uiowa_card_excerpt' => $excerpt,
+        'field_uiowa_card_image' => $image,
+        'field_uiowa_card_link' => $link,
+        'field_uiowa_card_title' => [
+          // Size not set in paragraphs. Defaulting to h2. Can change later.
+          'size' => 'h2',
+          'text' => $label,
+        ],
+      ];
 
       break;
 

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -56,6 +56,19 @@ function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_i
 /**
  * Implements hook_form_FORM_ID_alter().
  */
+function sitenow_p2lb_form_node_page_edit_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  $node = $form_state->getFormObject()?->getEntity();
+  if ($node instanceof \Drupal\sitenow_pages\Entity\Page) {
+    $issues = P2LbHelper::analyzeNode($node);
+    if (!empty($issues)) {
+      \Drupal::messenger()->addWarning(t('Some of the components on this cannot be fully converted to V3.'));
+    }
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
 function sitenow_p2lb_form_node_revision_delete_confirm_alter(&$form, FormStateInterface $form_state, $form_id) {
   $form_values = $form_state->getBuildInfo()['args'][0];
 
@@ -109,27 +122,6 @@ function sitenow_p2lb_form_node_revision_delete_confirm_alter(&$form, FormStateI
       "This is the last revision before converting from v2 to v3. It is protected and can't be deleted."
     );
     \Drupal::messenger()->addWarning($warning_text);
-  }
-}
-
-/**
- * Implements hook_entity_view().
- */
-function sitenow_p2lb_entity_view(array &$build, \Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display, $view_mode) {
-  if ($entity instanceof \Drupal\sitenow_pages\Entity\Page) {
-    $issues = P2LbHelper::analyzeNode($entity);
-
-    if (!empty($issues)) {
-      $build['issues'] = [
-        '#type' => 'container',
-        '#weight' => -10,
-      ];
-
-      $build['issues']['list'] = [
-        '#theme' => 'item_list',
-        '#items' => $issues,
-      ];
-    }
   }
 }
 

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -693,7 +693,7 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
       break;
 
     case 'carousel':
-      $type = 'uiowa_image_gallery';
+      $type = 'uiowa_slider';
       $title = $paragraph->field_uip_title->value;
       // Reverse the logic, because we're using it to
       // denote "hide," rather than display.
@@ -710,15 +710,56 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
         ->getStorage('paragraph');
       $carousel_images = $para_storage->loadMultiple($carousel_image_ids);
 
-      $fids = [];
-
       /** @var \Drupal\paragraphs\Entity\Paragraph $carousel_image */
       foreach ($carousel_images as $carousel_image) {
-        $fids[] = $carousel_image->get('field_carousel_image_image')->getString();
+        $caption = $carousel_image->get('field_carousel_image_caption');
+
+        if (!$caption->isEmpty()) {
+          $caption = $caption->getValue()[0];
+
+          // Grab the first complete text piece.
+          if (preg_match('|\A<(.*?\d?)>(.*?)<\/.*?\d?>|', $caption['value'], $matches)) {
+            // If it was an <h#> tag, grab it to set the proper level.
+            if (substr($matches[1], 0, 1) === 'h') {
+              $block->set('field_collection_heading_size', $matches[1])
+                ->save();
+            }
+            // Grab the new headline, and pull it out of the content.
+            $headline = $matches[2];
+            $caption['value'] = str_replace(
+              $matches[0],
+              '',
+              $caption['value']
+            );
+            // Only continue if we were able to create a headline.
+            $image_fid = $carousel_image->get('field_carousel_image_image')->getString();
+            $slide = $para_storage->create([
+              'type' => 'uiowa_slide',
+              'langcode' => 'en',
+              'status' => 1,
+              'parent_type' => 'block_content',
+              'parent_field_name' => 'field_uiowa_slider_slides',
+              'default_langcode' => 1,
+              'field_uiowa_slide_content' => $caption,
+              'field_collection_headline' => $headline,
+              'field_uiowa_slide_image' => $image_fid,
+            ]);
+            if ($slide->save()) {
+              $children[] = $slide;
+            };
+          }
+        }
       }
 
-      $block_definition = sitenow_p2lb_block_definition('uiowa_image_gallery', [
-        'field_uiowa_gallery_image' => $fids,
+      $block_definition = [
+        'type' => $type,
+        'langcode' => 'en',
+        'status' => 1,
+        'reusable' => 0,
+        'default_langcode' => 1,
+        'metatag' => [],
+        'field_collection_heading_size' => 'h2',
+        'field_uiowa_slider_slides' => $children,
         // Build a headline out of the title
         // and display title options.
         'field_uiowa_headline' => [
@@ -727,7 +768,7 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
           'hide_headline' => $display_title,
           'headline_style' => 'default',
         ],
-      ]);
+      ];
 
       break;
 

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -66,7 +66,9 @@ function sitenow_p2lb_form_node_page_edit_form_alter(&$form, FormStateInterface 
     if (empty($form_state->getUserInput())) {
       $issues = P2LbHelper::analyzeNode($node);
       if (!empty($issues)) {
-        \Drupal::messenger()->addWarning(t('Some of the components on this cannot be fully converted to V3.'));
+        \Drupal::messenger()->addWarning(t('Components on this page contain issues that prevent them from being fully converted to V3. See details in the @link.', [
+          '@link' => Link::createFromRoute('Conversion report', 'entity.node.p2lb_conversion_status', ['node' => $node->id()])->toString()
+        ]));
       }
     }
   }

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -14,6 +14,7 @@ use Drupal\layout_builder\Field\LayoutSectionItemList;
 use Drupal\layout_builder\InlineBlockUsage;
 use Drupal\layout_builder\Section;
 use Drupal\sitenow_p2lb\P2LbHelper;
+use Drupal\sitenow_pages\Entity\Page;
 
 /**
  * Implements hook_form_alter().
@@ -58,10 +59,14 @@ function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_i
  */
 function sitenow_p2lb_form_node_page_edit_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
   $node = $form_state->getFormObject()?->getEntity();
-  if ($node instanceof \Drupal\sitenow_pages\Entity\Page) {
-    $issues = P2LbHelper::analyzeNode($node);
-    if (!empty($issues)) {
-      \Drupal::messenger()->addWarning(t('Some of the components on this cannot be fully converted to V3.'));
+  if ($node instanceof Page) {
+    // Only do the processing and add a message if the form is first being
+    // displayed.
+    if (empty($form_state->getUserInput())) {
+      $issues = P2LbHelper::analyzeNode($node);
+      if (!empty($issues)) {
+        \Drupal::messenger()->addWarning(t('Some of the components on this cannot be fully converted to V3.'));
+      }
     }
   }
 }

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -565,47 +565,46 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
     case 'card':
       $type = 'uiowa_card';
       // Image isn't required. Check for one, or set to null.
-      $image = ($paragraph->get('field_card_image')->getValue()) ?
-        $paragraph->get('field_card_image')->getValue()[0]['target_id'] : '';
+      $image = $paragraph->field_card_image?->target_id ?: '';
 
       // Link isn't required. Check for one, or set to null.
-      $link = ($paragraph->get('field_card_link')->getValue()) ?
-        $paragraph->get('field_card_link')->getValue()[0] : '';
+      $link = $paragraph->field_card_link?->value[0] ?: NULL;
 
       // Label (title) isn't required. Check for one, or set to null.
-      $label = ($paragraph->get('field_card_title')->getValue()) ?
-        $paragraph->get('field_card_title')->getString() : '';
+      $label = $paragraph->field_card_title?->value ?: '';
       $display_label = ($label) ? 1 : 0;
 
       // Subtitle field isn't required. Check for one, or set to null.
-      $subtitle = ($paragraph->get('field_card_subtitle')->getValue()) ?
-        $paragraph->get('field_card_subtitle')->getString() : '';
+      $subtitle = $paragraph->field_card_subtitle?->value ?: '';
 
-      // Card body isn't required. Check or or set to array with empty value.
-      $excerpt = ($paragraph->get('field_card_body')->getValue()) ?
-        $paragraph->get('field_card_body')->getValue()[0] : '';
+      // Card body isn't required. Check or set to array with empty value.
+      $excerpt = $paragraph->field_card_body?->getValue()[0] ?: NULL;
 
       if ($excerpt) {
         $excerpt['format'] = 'minimal';
       }
 
-      $block_definition = [
-        'type' => $type,
-        'langcode' => 'en',
-        'status' => $paragraph->get('status')->getString(),
-        'info' => 'Card',
-        'reusable' => 0,
-        'default_langcode' => 1,
-        'field_uiowa_card_author' => $subtitle,
-        'field_uiowa_card_excerpt' => $excerpt,
-        'field_uiowa_card_image' => $image,
-        'field_uiowa_card_link' => $link,
-        'field_uiowa_card_title' => [
-          // Size not set in paragraphs. Defaulting to h2. Can change later.
-          'size' => 'h2',
-          'text' => $label,
-        ],
-      ];
+      // Handle the case where there is only an image and optionally a link.
+      if ($image && (!$label && !$subtitle && !$excerpt)) {
+        $fields = ['field_uiowa_image_image' => $image];
+        if ($link) {
+          $fields['field_uiowa_image_link'] = $link;
+        }
+        $block_definition = sitenow_p2lb_block_definition('uiowa_image', $fields);
+      }
+      else {
+        $block_definition = sitenow_p2lb_block_definition('uiowa_card', [
+          'field_uiowa_card_author' => $subtitle,
+          'field_uiowa_card_excerpt' => $excerpt,
+          'field_uiowa_card_image' => $image,
+          'field_uiowa_card_link' => $link,
+          'field_uiowa_card_title' => [
+            // Size not set in paragraphs. Defaulting to h2. Can change later.
+            'size' => 'h2',
+            'text' => $label,
+          ],
+        ]);
+      }
 
       break;
 
@@ -634,13 +633,7 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
         $fids[] = $carousel_image->get('field_carousel_image_image')->getString();
       }
 
-      $block_definition = [
-        'type' => $type,
-        'langcode' => 'en',
-        'status' => 1,
-        'reusable' => 0,
-        'default_langcode' => 1,
-        'metatag' => [],
+      $block_definition = sitenow_p2lb_block_definition('uiowa_image_gallery', [
         'field_uiowa_gallery_image' => $fids,
         // Build a headline out of the title
         // and display title options.
@@ -650,7 +643,7 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
           'hide_headline' => $display_title,
           'headline_style' => 'default',
         ],
-      ];
+      ]);
 
       break;
 
@@ -1296,4 +1289,19 @@ function _sitenow_p2lb_get_page_lb_sections_config() {
   $config = $source->read('core.entity_view_display.node.page.default');
 
   return $config['third_party_settings']['layout_builder']['sections'];
+}
+
+/**
+ * Helper function to provide a consistent block definition.
+ */
+function sitenow_p2lb_block_definition($type, array $fields) {
+  $block_definition = [
+    'langcode' => 'en',
+    'reusable' => 0,
+    'default_langcode' => 1,
+    'status' => 1,
+  ];
+
+  $block_definition['type'] = $type;
+  return array_merge($block_definition, $fields);
 }

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -96,7 +96,12 @@ function sitenow_p2lb_node_p2lb(ContentEntityInterface $node = NULL, $remove = F
 
   // Process all of the individual sections and update the layout.
   foreach ($section_ids as $section_id) {
-    $layout = sitenow_p2lb_process_section($section_id, $layout, $node);
+    // It's possible for the section to fail to load,
+    // such as if the paragraph no longer exists.
+    // Only overwrite if we successfully process.
+    if ($new_layout = sitenow_p2lb_process_section($section_id, $layout, $node)) {
+      $layout = $new_layout;
+    }
   }
 
   // Need to set with an array of sections, retrieved with getSections().

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -1232,11 +1232,14 @@ function _sitenow_p2lb_block_styles($block_type, $paragraph = NULL) {
       return [
         'block_background_style_light',
         'card_media_position_left',
+        'card_headline_style_serif',
         'media_format_circle',
+        'media_size_small',
         'content_alignment_left',
         'card_image_small',
         'list_format_list',
         'block_grid_threecol_33_34_33',
+        'no_border',
       ];
 
     case 'featured_content':

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -57,7 +57,7 @@ function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_i
 /**
  * Implements hook_form_FORM_ID_alter().
  */
-function sitenow_p2lb_form_node_page_edit_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+function sitenow_p2lb_form_node_page_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $node = $form_state->getFormObject()?->getEntity();
   if ($node instanceof Page) {
     // Only do the processing and add a message if the form is first being
@@ -172,7 +172,7 @@ function sitenow_p2lb_node_p2lb(ContentEntityInterface $node = NULL, $remove = F
     $layout->appendSection(Section::fromArray($default_sections[$i]));
   }
 
-  // Process all of the individual sections and update the layout.
+  // Process all the individual sections and update the layout.
   foreach ($section_ids as $section_id) {
     // It's possible for the section to fail to load,
     // such as if the paragraph no longer exists.
@@ -209,8 +209,9 @@ function sitenow_p2lb_node_p2lb(ContentEntityInterface $node = NULL, $remove = F
 
     return TRUE;
   }
+
   // Should be good to go, but if there was anything weird,
-  // return False to indicate no processing was done.
+  // return FALSE to indicate no processing was done.
   return FALSE;
 }
 

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -1202,9 +1202,9 @@ function _sitenow_p2lb_block_styles($block_type, $paragraph = NULL) {
       return [
         'block_background_style_light',
         'card_media_position_right',
+        'card_headline_style_serif',
         'media_format_widescreen',
-        'content_alignment_left',
-        'card_image_medium',
+        'media_size_small',
         'list_format_list',
         'block_grid_threecol_33_34_33',
         'no_border',
@@ -1222,7 +1222,6 @@ function _sitenow_p2lb_block_styles($block_type, $paragraph = NULL) {
         'card_media_position_stacked',
         'content_alignment_left',
         'media_format_widescreen',
-        'block_card_style_border',
       ];
 
     case 'uiowa_slider':

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -18,41 +18,11 @@ use Drupal\sitenow_p2lb\P2LbHelper;
 use Drupal\sitenow_pages\Entity\Page;
 
 /**
- * Implements hook_form_alter().
+ * Implements hook_form_FORM_ID_alter().
  */
-function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if (in_array($form_id, [
-    'node_page_form',
-    'node_page_edit_form',
-  ])) {
-    $entity = $form_state->getFormObject()->getEntity();
-
-    if ($form_id === 'node_page_form') {
-      // Disable display of the Paragraph sections for new content.
-      $form['field_page_content_block']['#access'] = FALSE;
-    }
-    elseif ($form_id === 'node_page_edit_form') {
-      // Check if field_v3_conversion_revision_id is set,
-      // and if the user hasn't yet interacted with the form
-      // (so that we don't duplicate our messages).
-      if ($entity->hasField('field_v3_conversion_revision_id') && empty($form_state->getUserInput())) {
-        if (is_numeric($entity->field_v3_conversion_revision_id->value)) {
-          // If we have a revision id, the page has been converted.
-          // Disable field_page_content_block and set a warning message.
-          \Drupal::messenger()->addWarning(t('This page has been converted to the SiteNow V3 format. Please add content through the "Body" field or click the "Layout" tab to edit an advanced page layout.'));
-          $form['field_page_content_block']['#access'] = FALSE;
-        }
-        else {
-          // If we didn't have a revision id, disable access to the body field
-          // and add a message directing to the converter.
-          \Drupal::messenger()->addMessage(t('This page can be converted to the SiteNow V3 format. Please visit the @link to convert this page.', [
-            '@link' => Drupal::service('link_generator')->generate('SiteNow Converter tool', Url::fromRoute('sitenow_p2lb.content_converter')),
-          ]));
-          $form['body']['#access'] = FALSE;
-        }
-      }
-    }
-  }
+function sitenow_p2lb_form_node_page_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Disable display of the Paragraph sections for new content.
+  $form['field_page_content_block']['#access'] = FALSE;
 }
 
 /**
@@ -60,15 +30,32 @@ function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_i
  */
 function sitenow_p2lb_form_node_page_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $node = $form_state->getFormObject()?->getEntity();
-  if ($node instanceof Page) {
-    // Only do the processing and add a message if the form is first being
-    // displayed.
-    if (empty($form_state->getUserInput())) {
-      $issues = P2LbHelper::analyzeNode($node);
-      if (!empty($issues)) {
-        \Drupal::messenger()->addWarning(t('Components on this page contain issues that prevent them from being fully converted to V3. See details in the @link.', [
-          '@link' => Link::createFromRoute('Conversion report', 'entity.node.p2lb_conversion_status', ['node' => $node->id()])->toString()
+  if ($node instanceof Page && empty($form_state->getUserInput())) {
+    // Check if field_v3_conversion_revision_id is set,
+    // and if the user hasn't yet interacted with the form
+    // (so that we don't duplicate our messages).
+    if ($node->hasField('field_v3_conversion_revision_id')) {
+      if (is_numeric($node->field_v3_conversion_revision_id->value)) {
+        // If we have a revision id, the page has been converted.
+        // Disable field_page_content_block and set a warning message.
+        \Drupal::messenger()->addWarning(t('This page has been converted to the SiteNow V3 format. Please add content through the "Body" field or click the "Layout" tab to edit an advanced page layout.'));
+        $form['field_page_content_block']['#access'] = FALSE;
+      }
+      else {
+        // If we didn't have a revision id, disable access to the body field
+        // and add a message directing to the converter.
+        \Drupal::messenger()->addMessage(t('This page can be converted to the SiteNow V3 format. Please visit the @link to convert this page.', [
+          '@link' => Drupal::service('link_generator')->generate('SiteNow Converter tool', Url::fromRoute('sitenow_p2lb.content_converter')),
         ]));
+        $form['body']['#access'] = FALSE;
+
+        // Get issues and add a message.
+        $issues = P2LbHelper::analyzeNode($node);
+        if (!empty($issues)) {
+          \Drupal::messenger()->addWarning(t('Components on this page contain issues that prevent them from being fully converted to V3. See details in the @link.', [
+            '@link' => Link::createFromRoute('Conversion report', 'entity.node.p2lb_conversion_status', ['node' => $node->id()])->toString()
+          ]));
+        }
       }
     }
   }
@@ -687,7 +674,7 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
           $type = 'uiowa_text_area';
         }
       }
-      elseif (!P2LbHelper::formattedTextIsSame($excerpt, 'filtered_html', 'minimal_plus')) {
+      elseif ($excerpt && !P2LbHelper::formattedTextIsSame($excerpt, 'filtered_html', 'minimal_plus')) {
         // Converting to a card would result in data loss. Convert to a text
         // area instead.
         $type = 'uiowa_text_area';

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -1202,18 +1202,16 @@ function _sitenow_p2lb_block_styles($block_type, $paragraph = NULL) {
       return [
         'block_background_style_light',
         'card_media_position_right',
-        'card_headline_style_serif',
         'media_format_widescreen',
-        'media_size_small',
+        'content_alignment_left',
+        'card_image_medium',
         'list_format_list',
         'block_grid_threecol_33_34_33',
-        'no_border',
       ];
 
     case 'uiowa_quote':
       return [
         'quote_left',
-        'quote_above',
       ];
 
     case 'uiowa_card':
@@ -1223,6 +1221,7 @@ function _sitenow_p2lb_block_styles($block_type, $paragraph = NULL) {
         'card_media_position_stacked',
         'content_alignment_left',
         'media_format_widescreen',
+        'block_card_style_border',
       ];
 
     case 'uiowa_slider':
@@ -1232,14 +1231,11 @@ function _sitenow_p2lb_block_styles($block_type, $paragraph = NULL) {
       return [
         'block_background_style_light',
         'card_media_position_left',
-        'card_headline_style_serif',
         'media_format_circle',
-        'media_size_small',
         'content_alignment_left',
         'card_image_small',
         'list_format_list',
         'block_grid_threecol_33_34_33',
-        'no_border',
       ];
 
     case 'featured_content':
@@ -1251,14 +1247,12 @@ function _sitenow_p2lb_block_styles($block_type, $paragraph = NULL) {
     case 'views_block:people_list_block-list_card':
       return [
         'block_background_style_light',
-        'card_media_position_left',
-        'card_headline_style_serif',
+        'card_media_position_right',
         'media_format_circle',
-        'media_size_small',
         'content_alignment_left',
+        'card_image_small',
         'list_format_list',
         'block_grid_threecol_33_34_33',
-        'no_border',
       ];
 
     case 'uiowa_text_area':

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -1250,12 +1250,14 @@ function _sitenow_p2lb_block_styles($block_type, $paragraph = NULL) {
     case 'views_block:people_list_block-list_card':
       return [
         'block_background_style_light',
-        'card_media_position_right',
+        'card_media_position_left',
+        'card_headline_style_serif',
         'media_format_circle',
+        'media_size_small',
         'content_alignment_left',
-        'card_image_small',
         'list_format_list',
         'block_grid_threecol_33_34_33',
+        'no_border',
       ];
 
     case 'uiowa_text_area':

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -18,6 +18,17 @@ use Drupal\sitenow_p2lb\P2LbHelper;
 use Drupal\sitenow_pages\Entity\Page;
 
 /**
+ * Implements hook_form_alter().
+ */
+function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if ($form_id === 'views_form_content_v3_converter_moderated_content') {
+    // Give both submit buttons their proper label.
+    $form['header']['node_bulk_form']['actions']['submit']['#value'] = t('Magic button');
+    $form['actions']['submit']['#value'] = t('Magic button');
+  }
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  */
 function sitenow_p2lb_form_node_page_form_alter(&$form, FormStateInterface $form_state, $form_id) {

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -605,7 +605,7 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
       break;
 
     case 'carousel':
-      $type = 'uiowa_slider';
+      $type = 'uiowa_image_gallery';
       $title = $paragraph->field_uip_title->value;
       // Reverse the logic, because we're using it to
       // denote "hide," rather than display.
@@ -622,45 +622,11 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
         ->getStorage('paragraph');
       $carousel_images = $para_storage->loadMultiple($carousel_image_ids);
 
+      $fids = [];
+
       /** @var \Drupal\paragraphs\Entity\Paragraph $carousel_image */
       foreach ($carousel_images as $carousel_image) {
-        $caption = $carousel_image->get('field_carousel_image_caption');
-
-        if (!$caption->isEmpty()) {
-          $caption = $caption->getValue()[0];
-
-          // Grab the first complete text piece.
-          if (preg_match('|\A<(.*?\d?)>(.*?)<\/.*?\d?>|', $caption['value'], $matches)) {
-            // If it was an <h#> tag, grab it to set the proper level.
-            if (substr($matches[1], 0, 1) === 'h') {
-              $block->set('field_collection_heading_size', $matches[1])
-                ->save();
-            }
-            // Grab the new headline, and pull it out of the content.
-            $headline = $matches[2];
-            $caption['value'] = str_replace(
-              $matches[0],
-              '',
-              $caption['value']
-            );
-            // Only continue if we were able to create a headline.
-            $image_fid = $carousel_image->get('field_carousel_image_image')->getString();
-            $slide = $para_storage->create([
-              'type' => 'uiowa_slide',
-              'langcode' => 'en',
-              'status' => 1,
-              'parent_type' => 'block_content',
-              'parent_field_name' => 'field_uiowa_slider_slides',
-              'default_langcode' => 1,
-              'field_uiowa_slide_content' => $caption,
-              'field_collection_headline' => $headline,
-              'field_uiowa_slide_image' => $image_fid,
-            ]);
-            if ($slide->save()) {
-              $children[] = $slide;
-            };
-          }
-        }
+        $fids[] = $carousel_image->get('field_carousel_image_image')->getString();
       }
 
       $block_definition = [
@@ -670,8 +636,7 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
         'reusable' => 0,
         'default_langcode' => 1,
         'metatag' => [],
-        'field_collection_heading_size' => 'h2',
-        'field_uiowa_slider_slides' => $children,
+        'field_uiowa_gallery_image' => $fids,
         // Build a headline out of the title
         // and display title options.
         'field_uiowa_headline' => [

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -1213,6 +1213,7 @@ function _sitenow_p2lb_block_styles($block_type, $paragraph = NULL) {
     case 'uiowa_quote':
       return [
         'quote_left',
+        'quote_above',
       ];
 
     case 'uiowa_card':

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.routing.yml
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.routing.yml
@@ -23,3 +23,17 @@ sitenow_p2lb.content_converted:
     _title: 'Converted'
   requirements:
     _permission: 'administer basic site settings'
+
+entity.node.p2lb_conversion_status:
+  path: '/node/{node}/conversion-status'
+  defaults:
+    _title: 'V3 Status'
+    _controller: '\Drupal\sitenow_p2lb\Controller\P2LbController::status'
+  requirements:
+    _entity_access: 'node.view all revisions'
+    node: \d+
+  options:
+    _node_operation_route: TRUE
+    parameters:
+      node:
+        type: entity:node

--- a/docroot/modules/custom/sitenow_p2lb/src/Controller/P2LbController.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/Controller/P2LbController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\sitenow_p2lb\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\node\NodeInterface;
+use Drupal\sitenow_p2lb\P2LbHelper;
+use Drupal\sitenow_pages\Entity\Page;
+
+/**
+ * Returns responses for P2LB routes.
+ */
+class P2LbController extends ControllerBase {
+
+  /**
+   * Generates a status report for converting a node to V3.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   A node object.
+   *
+   * @return array
+   *   An array as expected by \Drupal\Core\Render\RendererInterface::render().
+   */
+  public function status(NodeInterface $node) {
+    $build['#title'] = $this->t('V3 Conversion status for %title', ['%title' => $node->label()]);
+
+    if ($node instanceof Page) {
+      $issues = P2LbHelper::analyzeNode($node);
+
+      if (!empty($issues)) {
+        $build['issues'] = [
+          '#type' => 'container',
+          '#weight' => -10,
+        ];
+
+        $build['issues']['list'] = [
+          '#theme' => 'item_list',
+          '#items' => $issues,
+        ];
+      }
+      else {
+        $build['no_worries'] = [
+          '#markup' => $this->t('This content is ready to be converted and we do not expect any issues.'),
+        ];
+      }
+    }
+    else {
+      $build['not_applicable'] = [
+        '#markup' => $this->t('The @type content type does not need to be converted to V3.', [
+          '@type' => $node->getType(),
+        ]),
+      ];
+    }
+
+    return $build;
+  }
+}

--- a/docroot/modules/custom/sitenow_p2lb/src/Controller/P2LbController.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/Controller/P2LbController.php
@@ -29,12 +29,12 @@ class P2LbController extends ControllerBase {
     if ($node instanceof Page) {
       if (is_numeric($node->field_v3_conversion_revision_id->value)) {
         $build['done'] = [
-          '#markup' => $this->t('This page has been converted.'),
+          '#markup' => $this->t('<p>This page has been converted.</p>'),
         ];
       }
       else {
         $build['not_done'] = [
-          '#markup' => $this->t('This page has not been converted yet. You can convert it using the @link.', [
+          '#markup' => $this->t('<p>This page has not been converted yet. You can convert it using the @link.</p>', [
             '@link' => Link::fromTextAndUrl('SiteNow Converter tool', Url::fromRoute('sitenow_p2lb.content_converter'))->toString(),
           ]),
           '#weight' => 0,
@@ -64,14 +64,14 @@ class P2LbController extends ControllerBase {
         }
         else {
           $build['no_worries'] = [
-            '#markup' => $this->t('This content is ready to be converted and we do not expect any issues.'),
+            '#markup' => $this->t('<p>This content is ready to be converted and we do not expect any issues.</p>'),
           ];
         }
       }
     }
     else {
       $build['not_applicable'] = [
-        '#markup' => $this->t('The @type content type does not need to be converted to V3.', [
+        '#markup' => $this->t('<p>The @type content type does not need to be converted to V3.</p>', [
           '@type' => $node->getType(),
         ]),
       ];

--- a/docroot/modules/custom/sitenow_p2lb/src/Controller/P2LbController.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/Controller/P2LbController.php
@@ -3,6 +3,8 @@
 namespace Drupal\sitenow_p2lb\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Drupal\sitenow_p2lb\P2LbHelper;
 use Drupal\sitenow_pages\Entity\Page;
@@ -25,23 +27,46 @@ class P2LbController extends ControllerBase {
     $build['#title'] = $this->t('V3 Conversion status for %title', ['%title' => $node->label()]);
 
     if ($node instanceof Page) {
-      $issues = P2LbHelper::analyzeNode($node);
-
-      if (!empty($issues)) {
-        $build['issues'] = [
-          '#type' => 'container',
-          '#weight' => -10,
-        ];
-
-        $build['issues']['list'] = [
-          '#theme' => 'item_list',
-          '#items' => $issues,
+      if (is_numeric($node->field_v3_conversion_revision_id->value)) {
+        $build['done'] = [
+          '#markup' => $this->t('This page has been converted.'),
         ];
       }
       else {
-        $build['no_worries'] = [
-          '#markup' => $this->t('This content is ready to be converted and we do not expect any issues.'),
+        $build['not_done'] = [
+          '#markup' => $this->t('This page has not been converted yet. You can convert it using the @link.', [
+            '@link' => Link::fromTextAndUrl('SiteNow Converter tool', Url::fromRoute('sitenow_p2lb.content_converter'))->toString(),
+          ]),
+          '#weight' => 0,
         ];
+        $issues = P2LbHelper::analyzeNode($node);
+
+        if (!empty($issues)) {
+          $build['issues'] = [
+            '#type' => 'container',
+            '#weight' => 1,
+          ];
+
+          $build['issues']['title'] = [
+            '#markup' => $this->t('<h2>Conversion Issues</h2><p>The following issues will not prevent this page from being converted to V3, but may result in a degraded version of the content. For more information, please refer to the <a href="https://sitenow.uiowa.edu/documentation/sitenow-v2-v3-conversion">related documentation</a>.</p>'),
+          ];
+
+          $report_issues = [];
+
+          foreach ($issues as $issue => $count) {
+            $report_issues[] = "{$this->t($issue)} ($count)";
+          }
+
+          $build['issues']['list'] = [
+            '#theme' => 'item_list',
+            '#items' => $report_issues,
+          ];
+        }
+        else {
+          $build['no_worries'] = [
+            '#markup' => $this->t('This content is ready to be converted and we do not expect any issues.'),
+          ];
+        }
       }
     }
     else {

--- a/docroot/modules/custom/sitenow_p2lb/src/Controller/P2LbController.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/Controller/P2LbController.php
@@ -54,4 +54,5 @@ class P2LbController extends ControllerBase {
 
     return $build;
   }
+
 }

--- a/docroot/modules/custom/sitenow_p2lb/src/Form/P2LbSettingsForm.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/Form/P2LbSettingsForm.php
@@ -176,8 +176,9 @@ class P2LbSettingsForm extends ConfigFormBase {
 
     // Grab all nids for nodes with paragraphs.
     $nids = sitenow_p2lb_paragraph_nodes();
-    foreach ($nids as $nid) {
-      sitenow_p2lb_node_p2lb($nid, TRUE);
+    $nodes = \Drupal::entityTypeManager()->getStorage('node')->loadMultiple($nids);
+    foreach ($nodes as $node) {
+      sitenow_p2lb_node_p2lb($node, TRUE);
     }
     return $form_state;
   }

--- a/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
@@ -70,12 +70,12 @@ class P2LbHelper {
               // Check if card has a title.
               $label = $component->field_card_title?->value;
               if (!$label) {
-                $issues[] = t('Contains a card with no label. Label is required for V3.');
+                static::addIssue($issues, 'Contains cards with no label, which is required for V3. Affected cards will be converted to text areas.');
               }
               // Card body isn't required. Check or set to array with empty value.
               $excerpt = $component->field_card_body?->value;
               if ($excerpt && !static::formattedTextIsSame($excerpt, 'filtered_html', 'minimal')) {
-                $issues[] = t('Contains a card with a body that uses markup that is not allowed in V3.');
+                static::addIssue($issues, 'Contains cards with content that uses markup not allowed in V3. Affected cards will be converted to text areas.');
               }
               // Add the paragraph cache tags for invalidation.
               $cache_tags = Cache::mergeTags($cache_tags, $component->getCacheTags());
@@ -89,11 +89,11 @@ class P2LbHelper {
                 // Cases for carousel image ID and caption being set.
                 $caption = $carousel_item->field_carousel_image_caption?->value;
                 if ($caption) {
-                  $issues[] = t('Contains a carousel item with a caption. The caption will not be converted.');
+                  static::addIssue($issues, 'Contains carousel items with a caption. The caption will not be converted.');
                 }
                 $html_id = $carousel_item->field_uip_id?->value;
                 if ($html_id) {
-                  $issues[] = t('Contains a carousel item with an ID. The ID will not be converted.');
+                  static::addIssue($issues, 'Contains a carousel items with an ID. The ID will not be converted.');
                 }
                 // Add the paragraph cache tags for invalidation.
                 $cache_tags = Cache::mergeTags($cache_tags, $component->getCacheTags());
@@ -108,6 +108,21 @@ class P2LbHelper {
     \Drupal::cache()->set($cid, $issues, Cache::PERMANENT, $page->getCacheTags());
 
     return $issues;
+  }
+
+  /**
+   * Add an issue to the issues array.
+   *
+   * @param array $issues
+   *   The issues array.
+   * @param string $issue
+   *   The issue being added.
+   */
+  protected static function addIssue(array &$issues, string $issue) {
+    if (!isset($issues[$issue])) {
+      $issues[$issue] = 0;
+    }
+    $issues[$issue]++;
   }
 
 }

--- a/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
@@ -13,6 +13,7 @@ class P2LbHelper {
   }
 
   public static function analyzeNode(Page $page) {
+    // @todo Cache issues so they don't get generated every time this is run.
     $issues = [];
     /** @var \Drupal\entity_reference_revisions\EntityReferenceRevisionsFieldItemList $section_field */
     $section_field = $page->field_page_content_block;
@@ -33,7 +34,7 @@ class P2LbHelper {
         foreach ($components as $component_delta => $component) {
           switch ($component->getType()) {
             case 'card':
-              // @todo Check if card has a title.
+              // Check if card has a title.
               $label = $component->field_card_title?->value;
               if (!$label) {
                 $issues[] = t('Contains a card with no label. Label is required for V3.');
@@ -44,6 +45,8 @@ class P2LbHelper {
                 $issues[] = t('Contains a card with a body that uses markup that is not allowed in V3.');
               }
               break;
+            case 'carousel':
+              // @todo Add cases for carousel image ID and caption being set.
           }
         }
       }

--- a/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\sitenow_p2lb;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\sitenow_pages\Entity\Page;
+
+class P2LbHelper {
+
+  use StringTranslationTrait;
+  public static function formattedTextIsEquivalent($text, $format_one, $format_two) {
+    return check_markup($text, $format_one) === check_markup($text, $format_two);
+  }
+
+  public static function analyzeNode(Page $page) {
+    $issues = [];
+    /** @var \Drupal\entity_reference_revisions\EntityReferenceRevisionsFieldItemList $section_field */
+    $section_field = $page->field_page_content_block;
+    $sections = $section_field?->referencedEntities();
+    if (!is_null($sections)) {
+      /**
+       * @var int $section_delta
+       * @var \Drupal\paragraphs\ParagraphInterface $section
+       */
+      foreach ($sections as $section_delta => $section) {
+        /** @var \Drupal\entity_reference_revisions\EntityReferenceRevisionsFieldItemList $components_field */
+        $components_field = $section->field_section_content_block;
+        $components = $components_field->referencedEntities();
+        /**
+         * @var int $component_delta
+         * @var \Drupal\paragraphs\ParagraphInterface $component
+         */
+        foreach ($components as $component_delta => $component) {
+          switch ($component->getType()) {
+            case 'card':
+              // @todo Check if card has a title.
+              $label = $component->field_card_title?->value;
+              if (!$label) {
+                $issues[] = t('Contains a card with no label. Label is required for V3.');
+              }
+              // Card body isn't required. Check or set to array with empty value.
+              $excerpt = $component->field_card_body?->value;
+              if ($excerpt && !static::formattedTextIsEquivalent($excerpt, 'filtered_html', 'minimal')) {
+                $issues[] = t('Contains a card with a body that uses markup that is not allowed in V3.');
+              }
+              break;
+          }
+        }
+      }
+    }
+
+    return $issues;
+  }
+}


### PR DESCRIPTION
Resolves #6735 

# How to test

```
ddev blt ds --site brand.uiowa.edu && ddev drush @brand.local config-split:activate p2lb -y && ddev drush @brand.local cim -y && ddev drush @brand.local uli node/4406/edit
```
- Observe the warning.
- Click the "V3 Status" tab and observe output. It should match up to https://github.com/uiowa/uiowa/pull/6708#issuecomment-1662863485
- Convert the page.
- See the status is updated on the "V3 Status" tab.
- See that the warning no longer shows on the "Edit" tab.
- The idea with this is not that it is complete, but that the experience of using it is good enough to merge it so we can add more too it later.