### PR TITLE
Formatting fix for `uiowa_core.libraries.yml`

### DIFF
--- a/docroot/modules/custom/uiowa_core/uiowa_core.libraries.yml
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.libraries.yml
@@ -13,6 +13,6 @@ exposedFormEnhancements:
       css/exposedFormEnhancements.css: {}
   js:
     js/exposedFormEnhancements.js: { }
-    dependencies:
-      - core/drupal
-      - core/once
+  dependencies:
+    - core/drupal
+    - core/once


### PR DESCRIPTION
Resolves a bug introduced in #6530 due to a formatting error.

# How to test

```
ddev blt ds --site hawkeyemarchingband.uiowa.edu && ddev drush @hawkeyemarchingband.local uli node/add/page
```
- Add a "Carousel"
- Click "Add media"
- Confirm that media library dialog pops up on the first attempt, that you can select and image, and it gets passed back to the page after being selected.