### PR TITLE
Turn off revision deletion in P2LB

### DIFF
--- a/config/features/p2lb/config_split.patch.node.type.page.yml
+++ b/config/features/p2lb/config_split.patch.node.type.page.yml
@@ -1,0 +1,10 @@
+adding:
+  third_party_settings:
+    node_revision_delete:
+      amount:
+        status: false
+removing:
+  third_party_settings:
+    node_revision_delete:
+      amount:
+        status: true

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -17,84 +17,96 @@ use Drupal\layout_builder\Section;
 /**
  * Implements hook_form_alter().
  */
-function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  switch ($form_id) {
-    case 'node_page_form':
-    case 'node_page_edit_form':
-      $entity = $form_state->getFormObject()->getEntity();
+function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_id)
+{
+  if (in_array($form_id, [
+    'node_page_form',
+    'node_page_edit_form',
+  ])) {
+    $entity = $form_state->getFormObject()->getEntity();
 
-      if ($form_id === 'node_page_form') {
-        // Disable display of the Paragraph sections for new content.
-        $form['field_page_content_block']['#access'] = FALSE;
-      }
-      elseif ($form_id === 'node_page_edit_form') {
-        // Check if field_v3_conversion_revision_id is set,
-        // and if the user hasn't yet interacted with the form
-        // (so that we don't duplicate our messages).
-        if ($entity->hasField('field_v3_conversion_revision_id') && empty($form_state->getUserInput())) {
-          if (is_numeric($entity->field_v3_conversion_revision_id->value)) {
-            // If we have a revision id, the page has been converted.
-            // Disable field_page_content_block and set a warning message.
-            \Drupal::messenger()->addWarning(t('This page has been converted to the SiteNow V3 format. Please add content through the "Body" field or click the "Layout" tab to edit an advanced page layout.'));
-            $form['field_page_content_block']['#access'] = FALSE;
-          }
-          else {
-            // If we didn't have a revision id, disable access to the body field
-            // and add a message directing to the converter.
-            \Drupal::messenger()->addMessage(t('This page can be converted to the SiteNow V3 format. Please visit the @link to convert this page.', [
-              '@link' => Drupal::service('link_generator')->generate('SiteNow Converter tool', Url::fromRoute('sitenow_p2lb.content_converter')),
-            ]));
-            $form['body']['#access'] = FALSE;
-          }
+    if ($form_id === 'node_page_form') {
+      // Disable display of the Paragraph sections for new content.
+      $form['field_page_content_block']['#access'] = FALSE;
+    } elseif ($form_id === 'node_page_edit_form') {
+      // Check if field_v3_conversion_revision_id is set,
+      // and if the user hasn't yet interacted with the form
+      // (so that we don't duplicate our messages).
+      if ($entity->hasField('field_v3_conversion_revision_id') && empty($form_state->getUserInput())) {
+        if (is_numeric($entity->field_v3_conversion_revision_id->value)) {
+          // If we have a revision id, the page has been converted.
+          // Disable field_page_content_block and set a warning message.
+          \Drupal::messenger()->addWarning(t('This page has been converted to the SiteNow V3 format. Please add content through the "Body" field or click the "Layout" tab to edit an advanced page layout.'));
+          $form['field_page_content_block']['#access'] = FALSE;
+        } else {
+          // If we didn't have a revision id, disable access to the body field
+          // and add a message directing to the converter.
+          \Drupal::messenger()->addMessage(t('This page can be converted to the SiteNow V3 format. Please visit the @link to convert this page.', [
+            '@link' => Drupal::service('link_generator')->generate('SiteNow Converter tool', Url::fromRoute('sitenow_p2lb.content_converter')),
+          ]));
+          $form['body']['#access'] = FALSE;
         }
       }
+    }
+  }
+}
 
-      break;
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function sitenow_p2lb_form_node_revision_delete_confirm_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  $form_values = $form_state->getBuildInfo()['args'][0];
 
-    case 'node_revision_delete_confirm':
-      $form_values = $form_state->getBuildInfo()['args'][0];
+  // Get node id.
+  $nid = $form_values?->get('nid')?->getValue()[0]['value'] ?? null;
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
 
-      // Get node Id.
-      $nid = $form_values?->get('nid')?->getValue()[0]['value'];
-      $node_storage = \Drupal::entityTypeManager()->getStorage('node');
-      if(!$nid) {
-        break;
-      }
+  // Guard against not finding a node id.
+  if(!$nid) {
+    return;
+  }
 
-      // Get the most recent revision.
-      $most_recent_revision_id = $node_storage?->getLatestRevisionId($nid);
-      if(!$most_recent_revision_id) {
-        break;
-      }
-      $most_recent_revision = $node_storage?->loadRevision($most_recent_revision_id);
-      if(!$most_recent_revision) {
-        break;
-      }
+  // Get the most recent revision id.
+  $most_recent_revision_id = $node_storage?->getLatestRevisionId($nid);
 
-      // Get protected revision Id from that revision's values.
-      $protected_revision_id = $most_recent_revision->field_v3_conversion_revision_id?->value;
-      if(!$protected_revision_id) {
-        break;
-      }
+  // Guard against not finding the most recent revision id.
+  if(!$most_recent_revision_id) {
+    return;
+  }
 
-      // Get THIS revision Id.
-      $this_revision_id = $form_state->getBuildInfo()['args'][0]?->getLoadedRevisionId();
-      if(!$this_revision_id) {
-        break;
-      }
+  // Get the most recent revision id.
+  $most_recent_revision = $node_storage?->loadRevision($most_recent_revision_id);
 
-      // check them against each other.
-      if ($this_revision_id === $protected_revision_id) {
+  // Guard against not finding the most recent revision.
+  if(!$most_recent_revision) {
+    return;
+  }
 
-        // Disable delete button if they are the same, output error message.
-        $form['actions']['submit']['#disabled'] = TRUE;
-        $warning_text = t(
-          "This is the last revision before converting from v2 to v3. It is protected and can't be deleted."
-        );
-        \Drupal::messenger()->addWarning($warning_text);
-      }
+  // Get protected revision id from that revision's values.
+  $protected_revision_id = $most_recent_revision->field_v3_conversion_revision_id?->value;
 
-      break;
+  // Guard against not finding the protected revision id.
+  if(!$protected_revision_id) {
+    return;
+  }
+
+  // Get this revision's id.
+  $this_revision_id = $form_state->getBuildInfo()['args'][0]?->getLoadedRevisionId();
+
+  // Guard against not finding this revision's id.
+  if(!$this_revision_id) {
+    return;
+  }
+
+  // Check them against each other.
+  if ($this_revision_id === $protected_revision_id) {
+
+    // Disable delete button if they are the same, output error message.
+    $form['actions']['submit']['#disabled'] = TRUE;
+    $warning_text = t(
+      "This is the last revision before converting from v2 to v3. It is protected and can't be deleted."
+    );
+    \Drupal::messenger()->addWarning($warning_text);
   }
 }
 

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -72,7 +72,7 @@ function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_i
       }
 
       // Get protected revision Id from that revision's values.
-      $protected_revision_id = $most_recent_revision?->get('field_v3_conversion_revision_id')?->getValue()[0]['value'] ?? null;
+      $protected_revision_id = $most_recent_revision->field_v3_conversion_revision_id?->value;
       if(!$protected_revision_id) {
         break;
       }

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -75,7 +75,7 @@ function sitenow_p2lb_form_node_revision_delete_confirm_alter(&$form, FormStateI
     return;
   }
 
-  // Get the most recent revision id.
+  // Get the most recent revision.
   $most_recent_revision = $node_storage?->loadRevision($most_recent_revision_id);
 
   // Guard against not finding the most recent revision.

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -17,8 +17,7 @@ use Drupal\layout_builder\Section;
 /**
  * Implements hook_form_alter().
  */
-function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_id)
-{
+function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if (in_array($form_id, [
     'node_page_form',
     'node_page_edit_form',
@@ -28,7 +27,8 @@ function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_i
     if ($form_id === 'node_page_form') {
       // Disable display of the Paragraph sections for new content.
       $form['field_page_content_block']['#access'] = FALSE;
-    } elseif ($form_id === 'node_page_edit_form') {
+    }
+    elseif ($form_id === 'node_page_edit_form') {
       // Check if field_v3_conversion_revision_id is set,
       // and if the user hasn't yet interacted with the form
       // (so that we don't duplicate our messages).
@@ -38,7 +38,8 @@ function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_i
           // Disable field_page_content_block and set a warning message.
           \Drupal::messenger()->addWarning(t('This page has been converted to the SiteNow V3 format. Please add content through the "Body" field or click the "Layout" tab to edit an advanced page layout.'));
           $form['field_page_content_block']['#access'] = FALSE;
-        } else {
+        }
+        else {
           // If we didn't have a revision id, disable access to the body field
           // and add a message directing to the converter.
           \Drupal::messenger()->addMessage(t('This page can be converted to the SiteNow V3 format. Please visit the @link to convert this page.', [

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -114,6 +114,8 @@ function sitenow_p2lb_node_p2lb(ContentEntityInterface $node = NULL, $remove = F
     // Set the user id for the revision.
     $user_id = \Drupal::currentUser()->id();
     $node->setRevisionUserId($user_id);
+    $node->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+    $node->setChangedTime(\Drupal::time()->getRequestTime());
 
     $node->save();
 

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -55,15 +55,15 @@ function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_i
 /**
  * Implements hook_form_FORM_ID_alter().
  */
-function sitenow_p2lb_form_node_revision_delete_confirm_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+function sitenow_p2lb_form_node_revision_delete_confirm_alter(&$form, FormStateInterface $form_state, $form_id) {
   $form_values = $form_state->getBuildInfo()['args'][0];
 
   // Get node id.
-  $nid = $form_values?->get('nid')?->getValue()[0]['value'] ?? null;
+  $nid = $form_values?->get('nid')?->getValue()[0]['value'] ?? NULL;
   $node_storage = \Drupal::entityTypeManager()->getStorage('node');
 
   // Guard against not finding a node id.
-  if(!$nid) {
+  if (!$nid) {
     return;
   }
 
@@ -71,7 +71,7 @@ function sitenow_p2lb_form_node_revision_delete_confirm_alter(&$form, \Drupal\Co
   $most_recent_revision_id = $node_storage?->getLatestRevisionId($nid);
 
   // Guard against not finding the most recent revision id.
-  if(!$most_recent_revision_id) {
+  if (!$most_recent_revision_id) {
     return;
   }
 
@@ -79,7 +79,7 @@ function sitenow_p2lb_form_node_revision_delete_confirm_alter(&$form, \Drupal\Co
   $most_recent_revision = $node_storage?->loadRevision($most_recent_revision_id);
 
   // Guard against not finding the most recent revision.
-  if(!$most_recent_revision) {
+  if (!$most_recent_revision) {
     return;
   }
 
@@ -87,7 +87,7 @@ function sitenow_p2lb_form_node_revision_delete_confirm_alter(&$form, \Drupal\Co
   $protected_revision_id = $most_recent_revision->field_v3_conversion_revision_id?->value;
 
   // Guard against not finding the protected revision id.
-  if(!$protected_revision_id) {
+  if (!$protected_revision_id) {
     return;
   }
 
@@ -95,7 +95,7 @@ function sitenow_p2lb_form_node_revision_delete_confirm_alter(&$form, \Drupal\Co
   $this_revision_id = $form_state->getBuildInfo()['args'][0]?->getLoadedRevisionId();
 
   // Guard against not finding this revision's id.
-  if(!$this_revision_id) {
+  if (!$this_revision_id) {
     return;
   }
 
@@ -110,7 +110,6 @@ function sitenow_p2lb_form_node_revision_delete_confirm_alter(&$form, \Drupal\Co
     \Drupal::messenger()->addWarning($warning_text);
   }
 }
-
 
 /**
  * Check for nodes which are using paragraphs.

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -18,39 +18,86 @@ use Drupal\layout_builder\Section;
  * Implements hook_form_alter().
  */
 function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if (in_array($form_id, [
-    'node_page_form',
-    'node_page_edit_form',
-  ])) {
-    $entity = $form_state->getFormObject()->getEntity();
+  switch ($form_id) {
+    case 'node_page_form':
+    case 'node_page_edit_form':
+      $entity = $form_state->getFormObject()->getEntity();
 
-    if ($form_id === 'node_page_form') {
-      // Disable display of the Paragraph sections for new content.
-      $form['field_page_content_block']['#access'] = FALSE;
-    }
-    elseif ($form_id === 'node_page_edit_form') {
-      // Check if field_v3_conversion_revision_id is set,
-      // and if the user hasn't yet interacted with the form
-      // (so that we don't duplicate our messages).
-      if ($entity->hasField('field_v3_conversion_revision_id') && empty($form_state->getUserInput())) {
-        if (is_numeric($entity->field_v3_conversion_revision_id->value)) {
-          // If we have a revision id, the page has been converted.
-          // Disable field_page_content_block and set a warning message.
-          \Drupal::messenger()->addWarning(t('This page has been converted to the SiteNow V3 format. Please add content through the "Body" field or click the "Layout" tab to edit an advanced page layout.'));
-          $form['field_page_content_block']['#access'] = FALSE;
-        }
-        else {
-          // If we didn't have a revision id, disable access to the body field
-          // and add a message directing to the converter.
-          \Drupal::messenger()->addMessage(t('This page can be converted to the SiteNow V3 format. Please visit the @link to convert this page.', [
-            '@link' => Drupal::service('link_generator')->generate('SiteNow Converter tool', Url::fromRoute('sitenow_p2lb.content_converter')),
-          ]));
-          $form['body']['#access'] = FALSE;
+      if ($form_id === 'node_page_form') {
+        // Disable display of the Paragraph sections for new content.
+        $form['field_page_content_block']['#access'] = FALSE;
+      }
+      elseif ($form_id === 'node_page_edit_form') {
+        // Check if field_v3_conversion_revision_id is set,
+        // and if the user hasn't yet interacted with the form
+        // (so that we don't duplicate our messages).
+        if ($entity->hasField('field_v3_conversion_revision_id') && empty($form_state->getUserInput())) {
+          if (is_numeric($entity->field_v3_conversion_revision_id->value)) {
+            // If we have a revision id, the page has been converted.
+            // Disable field_page_content_block and set a warning message.
+            \Drupal::messenger()->addWarning(t('This page has been converted to the SiteNow V3 format. Please add content through the "Body" field or click the "Layout" tab to edit an advanced page layout.'));
+            $form['field_page_content_block']['#access'] = FALSE;
+          }
+          else {
+            // If we didn't have a revision id, disable access to the body field
+            // and add a message directing to the converter.
+            \Drupal::messenger()->addMessage(t('This page can be converted to the SiteNow V3 format. Please visit the @link to convert this page.', [
+              '@link' => Drupal::service('link_generator')->generate('SiteNow Converter tool', Url::fromRoute('sitenow_p2lb.content_converter')),
+            ]));
+            $form['body']['#access'] = FALSE;
+          }
         }
       }
-    }
+
+      break;
+
+    case 'node_revision_delete_confirm':
+      $form_values = $form_state->getBuildInfo()['args'][0];
+
+      // Get node Id.
+      $nid = $form_values?->get('nid')?->getValue()[0]['value'];
+      $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+      if(!$nid) {
+        break;
+      }
+
+      // Get the most recent revision.
+      $most_recent_revision_id = $node_storage?->getLatestRevisionId($nid);
+      if(!$most_recent_revision_id) {
+        break;
+      }
+      $most_recent_revision = $node_storage?->loadRevision($most_recent_revision_id);
+      if(!$most_recent_revision) {
+        break;
+      }
+
+      // Get protected revision Id from that revision's values.
+      $protected_revision_id = $most_recent_revision?->get('field_v3_conversion_revision_id')?->getValue()[0]['value'] ?? null;
+      if(!$protected_revision_id) {
+        break;
+      }
+
+      // Get THIS revision Id.
+      $this_revision_id = $form_state->getBuildInfo()['args'][0]?->getLoadedRevisionId();
+      if(!$this_revision_id) {
+        break;
+      }
+
+      // check them against each other.
+      if ($this_revision_id === $protected_revision_id) {
+
+        // Disable delete button if they are the same, output error message.
+        $form['actions']['submit']['#disabled'] = TRUE;
+        $warning_text = t(
+          "This is the last revision before converting from v2 to v3. It is protected and can't be deleted."
+        );
+        \Drupal::messenger()->addWarning($warning_text);
+      }
+
+      break;
   }
 }
+
 
 /**
  * Check for nodes which are using paragraphs.
@@ -1225,33 +1272,6 @@ function sitenow_p2lb_section_image($section_image_fid, $banner_text, $node) {
 
   }
   return $section_array;
-}
-
-function sitenow_p2lbnode_confirm_form_alter(&$form, FormStateInterface $form_state) {
-  // Check/prevent front page from being deleted on single delete.
-  // Only need to alter the delete operation form.
-  $form_object = $form_state->getFormObject();
-  if ($form_object instanceof EntityFormInterface) {
-    if ($form_object->getOperation() !== 'delete') {
-      return;
-    }
-    /** @var Drupal\Core\Entity\EntityInterface $node */
-    $node = $form_object->getEntity();
-
-    // Get and dissect front page path.
-    $front = \Drupal::config('system.site')->get('page.front');
-    $url = Url::fromUri("internal:" . $front);
-
-    if ($url->isRouted()) {
-      $params = $url->getRouteParameters();
-
-      if (isset($params['node']) && $params['node'] === $node->id()) {
-        // Disable the 'Delete' button.
-        $form['actions']['submit']['#disabled'] = TRUE;
-        _sitenow_prevent_front_delete_message($node->label());
-      }
-    }
-  }
 }
 
 /**

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -1227,6 +1227,33 @@ function sitenow_p2lb_section_image($section_image_fid, $banner_text, $node) {
   return $section_array;
 }
 
+function sitenow_p2lbnode_confirm_form_alter(&$form, FormStateInterface $form_state) {
+  // Check/prevent front page from being deleted on single delete.
+  // Only need to alter the delete operation form.
+  $form_object = $form_state->getFormObject();
+  if ($form_object instanceof EntityFormInterface) {
+    if ($form_object->getOperation() !== 'delete') {
+      return;
+    }
+    /** @var Drupal\Core\Entity\EntityInterface $node */
+    $node = $form_object->getEntity();
+
+    // Get and dissect front page path.
+    $front = \Drupal::config('system.site')->get('page.front');
+    $url = Url::fromUri("internal:" . $front);
+
+    if ($url->isRouted()) {
+      $params = $url->getRouteParameters();
+
+      if (isset($params['node']) && $params['node'] === $node->id()) {
+        // Disable the 'Delete' button.
+        $form['actions']['submit']['#disabled'] = TRUE;
+        _sitenow_prevent_front_delete_message($node->label());
+      }
+    }
+  }
+}
+
 /**
  * Default block style settings.
  */


### PR DESCRIPTION
Remove revision limit for pages where p2lb is enabled

# How to test

`ddev blt ds --site brand.uiowa.edu && ddev drush @brand.local config-split:activate p2lb -y && ddev drush @brand.local uli
`
Check the page content type
ensure that in publishing options, revisions are not limited