### PR TITLE
P2LB - V2 Card Cases

### DIFF
--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -592,7 +592,7 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
           $type = 'uiowa_text_area';
         }
       }
-      elseif (!P2LbHelper::formattedTextIsEquivalent($excerpt['value'], 'filtered_html', 'minimal_plus')) {
+      elseif (!P2LbHelper::formattedTextIsSame($excerpt, 'filtered_html', 'minimal_plus')) {
         // Converting to a card would result in data loss. Convert to a text
         // area instead.
         $type = 'uiowa_text_area';
@@ -602,7 +602,11 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
 
       switch ($type) {
         case 'uiowa_card':
-          $fields['field_uiowa_card_title'] = _sitenow_p2lb_headline_config($label, $display_label);
+          $fields['field_uiowa_card_title'] = [
+            // Size not set in paragraphs. Defaulting to h2. Can change later.
+            'size' => 'h2',
+            'text' => $label,
+          ];
 
           // Add the image, if its set.
           if ($image) {
@@ -638,13 +642,21 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
 
         case 'uiowa_text_area':
           $output = '';
+          if ($image) {
+            /** @var \Drupal\media\MediaInterface[] $images */
+            $images = $paragraph->field_card_image->referencedEntities();
+            if (!empty($images)) {
+              foreach ($images as $image) {
+                $output .= '<drupal-media data-entity-type="media" data-entity-uuid="' . $image->uuid() . '" data-view-mode="large__widescreen"></drupal-media>';
+              }
+            }
+          }
           if ($subtitle) {
             $output .= $subtitle;
           }
           if ($excerpt) {
             $output .= $excerpt;
           }
-          // @todo How do we account for an image, if there is one?
           $fields = [
             'field_uiowa_text_area' => [
               'value' => $output,

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -13,6 +13,7 @@ use Drupal\Core\Url;
 use Drupal\layout_builder\Field\LayoutSectionItemList;
 use Drupal\layout_builder\InlineBlockUsage;
 use Drupal\layout_builder\Section;
+use Drupal\sitenow_p2lb\P2LbHelper;
 
 /**
  * Implements hook_form_alter().
@@ -76,6 +77,8 @@ function sitenow_p2lb_paragraph_nodes() {
  *   Node being processed.
  * @param bool $remove
  *   Indicator whether old paragraphs should be removed following processing.
+ *
+ * @throws \Drupal\Core\Entity\EntityStorageException
  */
 function sitenow_p2lb_node_p2lb(ContentEntityInterface $node = NULL, $remove = FALSE) {
   // Get sections from the page.
@@ -94,7 +97,7 @@ function sitenow_p2lb_node_p2lb(ContentEntityInterface $node = NULL, $remove = F
     $layout->appendSection(Section::fromArray($default_sections[$i]));
   }
 
-  // Process all of the individual sections and update the layout.
+  // Process all the individual sections and update the layout.
   foreach ($section_ids as $section_id) {
     $layout = sitenow_p2lb_process_section($section_id, $layout, $node);
   }
@@ -124,8 +127,9 @@ function sitenow_p2lb_node_p2lb(ContentEntityInterface $node = NULL, $remove = F
 
     return TRUE;
   }
+
   // Should be good to go, but if there was anything weird,
-  // return False to indicate no processing was done.
+  // return FALSE to indicate no processing was done.
   return FALSE;
 }
 
@@ -579,26 +583,46 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
         $excerpt['format'] = 'minimal';
       }
 
-      // Handle the case where there is only an image and optionally a link.
-      if ($image && (!$label && !$subtitle && !$excerpt)) {
-        $fields = ['field_uiowa_image_image' => $image];
-        if ($link) {
-          $fields['field_uiowa_image_link'] = $link;
+      // If the card has no title
+      if (!$label) {
+        // Handle the case where there is only an image and optionally a link.
+        if ($image && (!$subtitle && !$excerpt)) {
+          $fields = ['field_uiowa_image_image' => $image];
+          if ($link) {
+            $fields['field_uiowa_image_link'] = $link;
+          }
+          $block_definition = sitenow_p2lb_block_definition('uiowa_image', $fields);
         }
-        $block_definition = sitenow_p2lb_block_definition('uiowa_image', $fields);
+        else {
+          // Converting to a card is not possible because the label is required
+          // in V3. Convert to a text area instead.
+          $block_definition = sitenow_p2lb_block_definition('uiowa_text_area', [
+            // @todo Figure out how this works.
+          ]);
+        }
       }
       else {
-        $block_definition = sitenow_p2lb_block_definition('uiowa_card', [
-          'field_uiowa_card_author' => $subtitle,
-          'field_uiowa_card_excerpt' => $excerpt,
-          'field_uiowa_card_image' => $image,
-          'field_uiowa_card_link' => $link,
-          'field_uiowa_card_title' => [
-            // Size not set in paragraphs. Defaulting to h2. Can change later.
-            'size' => 'h2',
-            'text' => $label,
-          ],
-        ]);
+        if (!P2LbHelper::formattedTextIsEquivalent($excerpt['value'], 'filtered_html', 'minimal_plus')) {
+          // Converting to a card would result in data loss. Convert to a text
+          // area instead.
+          $block_definition = sitenow_p2lb_block_definition('uiowa_text_area', [
+            // @todo Figure out how this works.
+          ]);
+        }
+        else {
+          // We're good to create a card.
+          $block_definition = sitenow_p2lb_block_definition('uiowa_card', [
+            'field_uiowa_card_author' => $subtitle,
+            'field_uiowa_card_excerpt' => $excerpt,
+            'field_uiowa_card_image' => $image,
+            'field_uiowa_card_link' => $link,
+            'field_uiowa_card_title' => [
+              // Size not set in paragraphs. Defaulting to h2. Can change later.
+              'size' => 'h2',
+              'text' => $label,
+            ],
+          ]);
+        }
       }
 
       break;

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -9,6 +9,7 @@ use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Database\Database;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\layout_builder\Field\LayoutSectionItemList;
 use Drupal\layout_builder\InlineBlockUsage;
@@ -566,7 +567,7 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
       $image = $paragraph->field_card_image?->target_id ?: '';
 
       // Link isn't required. Check for one, or set to null.
-      $link = $paragraph->field_card_link?->value[0] ?? NULL;
+      $link = $paragraph->field_card_link?->first()?->getValue();
 
       // Label (title) isn't required. Check for one, or set to null.
       $label = $paragraph->field_card_title?->value;
@@ -578,6 +579,7 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
       // Card body isn't required. Check or set to array with empty value.
       $excerpt = $paragraph->field_card_body?->value;
 
+      // By default, we're assuming this will become a V3 card.
       $type = 'uiowa_card';
 
       // If the card has no title
@@ -600,25 +602,28 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
 
       $fields = [];
 
+      // Set fields based on the type of block we are creating.
       switch ($type) {
         case 'uiowa_card':
+          // The card title doesn't use the headline field type, so we can't use
+          // the helper function here.
           $fields['field_uiowa_card_title'] = [
-            // Size not set in paragraphs. Defaulting to h2. Can change later.
-            'size' => 'h2',
             'text' => $label,
+            // Size not set in paragraphs. Defaulting to h2.
+            'size' => 'h2',
           ];
 
-          // Add the image, if its set.
+          // Add the image, if set.
           if ($image) {
             $fields['field_uiowa_card_image'] = $image;
           }
 
-          // Add the subtitle, if its set.
+          // Add the subtitle, if set.
           if ($subtitle) {
             $fields['field_uiowa_card_author'] = $subtitle;
           }
 
-          // Add the excerpt, if its set.
+          // Add the excerpt, if set, and set the format to minimal_plus.
           if ($excerpt) {
             $fields['field_uiowa_card_excerpt'] = [
               'value' => $excerpt,
@@ -626,22 +631,27 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
             ];
           }
 
-          // Add the link, if its set.
+          // Add the link, if set.
           if ($link) {
             $fields['field_uiowa_card_link'] = $link;
           }
-
           break;
 
         case 'uiowa_image':
           $fields = ['field_uiowa_image_image' => $image];
+
+          // Add the link, if set.
           if ($link) {
             $fields['field_uiowa_image_link'] = $link;
           }
           break;
 
         case 'uiowa_text_area':
+          // Compile a string with the values of the fields that are present
+          // and set that to the text field of the V3 text area.
           $output = '';
+
+          // If an image is set, convert it to its <drupal-media> equivalent.
           if ($image) {
             /** @var \Drupal\media\MediaInterface[] $images */
             $images = $paragraph->field_card_image->referencedEntities();
@@ -651,25 +661,41 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
               }
             }
           }
+
+          // Add the subtitle, if set.
           if ($subtitle) {
             $output .= $subtitle;
           }
+
+          // Add the excerpt, if set.
           if ($excerpt) {
             $output .= $excerpt;
           }
+
+          // Convert the link to an HTML representation.
+          if (isset($link['uri']) && isset($link['title'])) {
+            $url = Url::fromUri($link['uri']);
+            $output .= Link::fromTextAndUrl($link['title'], $url)?->toString();
+          }
+
+          // Set the string as the field value and set the format to
+          // filtered_html.
           $fields = [
             'field_uiowa_text_area' => [
               'value' => $output,
               'format' => 'filtered_html',
             ],
           ];
+
+          // If there is a title, set it to the headline field.
           if ($label) {
-            $fields['field_uiowa_headline'] = _sitenow_p2lb_headline_config($label, $display_label);
+            $fields['field_uiowa_headline'] = _sitenow_p2lb_headline_config($label, !$display_label);
           }
           break;
 
       }
 
+      // Create the block definition based on what has been put together above.
       $block_definition = sitenow_p2lb_block_definition($type, $fields);
 
       break;

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -54,6 +54,27 @@ function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_i
 }
 
 /**
+ * Implements hook_entity_view().
+ */
+function sitenow_p2lb_entity_view(array &$build, \Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display, $view_mode) {
+  if ($entity instanceof \Drupal\sitenow_pages\Entity\Page) {
+    $issues = P2LbHelper::analyzeNode($entity);
+
+    if (!empty($issues)) {
+      $build['issues'] = [
+        '#type' => 'container',
+        '#weight' => -10,
+      ];
+
+      $build['issues']['list'] = [
+        '#theme' => 'item_list',
+        '#items' => $issues,
+      ];
+    }
+  }
+}
+
+/**
  * Check for nodes which are using paragraphs.
  */
 function sitenow_p2lb_paragraph_nodes() {

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -560,47 +560,46 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
     case 'card':
       $type = 'uiowa_card';
       // Image isn't required. Check for one, or set to null.
-      $image = ($paragraph->get('field_card_image')->getValue()) ?
-        $paragraph->get('field_card_image')->getValue()[0]['target_id'] : '';
+      $image = $paragraph->field_card_image?->target_id ?: '';
 
       // Link isn't required. Check for one, or set to null.
-      $link = ($paragraph->get('field_card_link')->getValue()) ?
-        $paragraph->get('field_card_link')->getValue()[0] : '';
+      $link = $paragraph->field_card_link?->value[0] ?: NULL;
 
       // Label (title) isn't required. Check for one, or set to null.
-      $label = ($paragraph->get('field_card_title')->getValue()) ?
-        $paragraph->get('field_card_title')->getString() : '';
+      $label = $paragraph->field_card_title?->value ?: '';
       $display_label = ($label) ? 1 : 0;
 
       // Subtitle field isn't required. Check for one, or set to null.
-      $subtitle = ($paragraph->get('field_card_subtitle')->getValue()) ?
-        $paragraph->get('field_card_subtitle')->getString() : '';
+      $subtitle = $paragraph->field_card_subtitle?->value ?: '';
 
-      // Card body isn't required. Check or or set to array with empty value.
-      $excerpt = ($paragraph->get('field_card_body')->getValue()) ?
-        $paragraph->get('field_card_body')->getValue()[0] : '';
+      // Card body isn't required. Check or set to array with empty value.
+      $excerpt = $paragraph->field_card_body?->getValue()[0] ?: NULL;
 
       if ($excerpt) {
         $excerpt['format'] = 'minimal';
       }
 
-      $block_definition = [
-        'type' => $type,
-        'langcode' => 'en',
-        'status' => $paragraph->get('status')->getString(),
-        'info' => 'Card',
-        'reusable' => 0,
-        'default_langcode' => 1,
-        'field_uiowa_card_author' => $subtitle,
-        'field_uiowa_card_excerpt' => $excerpt,
-        'field_uiowa_card_image' => $image,
-        'field_uiowa_card_link' => $link,
-        'field_uiowa_card_title' => [
-          // Size not set in paragraphs. Defaulting to h2. Can change later.
-          'size' => 'h2',
-          'text' => $label,
-        ],
-      ];
+      // Handle the case where there is only an image and optionally a link.
+      if ($image && (!$label && !$subtitle && !$excerpt)) {
+        $fields = ['field_uiowa_image_image' => $image];
+        if ($link) {
+          $fields['field_uiowa_image_link'] = $link;
+        }
+        $block_definition = sitenow_p2lb_block_definition('uiowa_image', $fields);
+      }
+      else {
+        $block_definition = sitenow_p2lb_block_definition('uiowa_card', [
+          'field_uiowa_card_author' => $subtitle,
+          'field_uiowa_card_excerpt' => $excerpt,
+          'field_uiowa_card_image' => $image,
+          'field_uiowa_card_link' => $link,
+          'field_uiowa_card_title' => [
+            // Size not set in paragraphs. Defaulting to h2. Can change later.
+            'size' => 'h2',
+            'text' => $label,
+          ],
+        ]);
+      }
 
       break;
 
@@ -1326,4 +1325,19 @@ function _sitenow_p2lb_get_page_lb_sections_config() {
   $config = $source->read('core.entity_view_display.node.page.default');
 
   return $config['third_party_settings']['layout_builder']['sections'];
+}
+
+/**
+ * Helper function to provide a consistent block definition.
+ */
+function sitenow_p2lb_block_definition($type, array $fields) {
+  $block_definition = [
+    'langcode' => 'en',
+    'reusable' => 0,
+    'default_langcode' => 1,
+    'status' => 1,
+  ];
+
+  $block_definition['type'] = $type;
+  return array_merge($block_definition, $fields);
 }

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -54,27 +54,6 @@ function sitenow_p2lb_form_alter(&$form, FormStateInterface $form_state, $form_i
 }
 
 /**
- * Implements hook_entity_view().
- */
-function sitenow_p2lb_entity_view(array &$build, \Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display, $view_mode) {
-  if ($entity instanceof \Drupal\sitenow_pages\Entity\Page) {
-    $issues = P2LbHelper::analyzeNode($entity);
-
-    if (!empty($issues)) {
-      $build['issues'] = [
-        '#type' => 'container',
-        '#weight' => -10,
-      ];
-
-      $build['issues']['list'] = [
-        '#theme' => 'item_list',
-        '#items' => $issues,
-      ];
-    }
-  }
-}
-
-/**
  * Check for nodes which are using paragraphs.
  */
 function sitenow_p2lb_paragraph_nodes() {
@@ -583,68 +562,103 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
       break;
 
     case 'card':
-      $type = 'uiowa_card';
       // Image isn't required. Check for one, or set to null.
       $image = $paragraph->field_card_image?->target_id ?: '';
 
       // Link isn't required. Check for one, or set to null.
-      $link = $paragraph->field_card_link?->value[0] ?: NULL;
+      $link = $paragraph->field_card_link?->value[0] ?? NULL;
 
       // Label (title) isn't required. Check for one, or set to null.
-      $label = $paragraph->field_card_title?->value ?: '';
+      $label = $paragraph->field_card_title?->value;
       $display_label = ($label) ? 1 : 0;
 
       // Subtitle field isn't required. Check for one, or set to null.
-      $subtitle = $paragraph->field_card_subtitle?->value ?: '';
+      $subtitle = $paragraph->field_card_subtitle?->value;
 
       // Card body isn't required. Check or set to array with empty value.
-      $excerpt = $paragraph->field_card_body?->getValue()[0] ?: NULL;
+      $excerpt = $paragraph->field_card_body?->value;
 
-      if ($excerpt) {
-        $excerpt['format'] = 'minimal';
-      }
+      $type = 'uiowa_card';
 
       // If the card has no title
       if (!$label) {
-        // Handle the case where there is only an image and optionally a link.
         if ($image && (!$subtitle && !$excerpt)) {
-          $fields = ['field_uiowa_image_image' => $image];
-          if ($link) {
-            $fields['field_uiowa_image_link'] = $link;
-          }
-          $block_definition = sitenow_p2lb_block_definition('uiowa_image', $fields);
+          // Image and optionally a link.
+          $type = 'uiowa_image';
         }
         else {
           // Converting to a card is not possible because the label is required
           // in V3. Convert to a text area instead.
-          $block_definition = sitenow_p2lb_block_definition('uiowa_text_area', [
-            // @todo Figure out how this works.
-          ]);
+          $type = 'uiowa_text_area';
         }
       }
-      else {
-        if (!P2LbHelper::formattedTextIsEquivalent($excerpt['value'], 'filtered_html', 'minimal_plus')) {
-          // Converting to a card would result in data loss. Convert to a text
-          // area instead.
-          $block_definition = sitenow_p2lb_block_definition('uiowa_text_area', [
-            // @todo Figure out how this works.
-          ]);
-        }
-        else {
-          // We're good to create a card.
-          $block_definition = sitenow_p2lb_block_definition('uiowa_card', [
-            'field_uiowa_card_author' => $subtitle,
-            'field_uiowa_card_excerpt' => $excerpt,
-            'field_uiowa_card_image' => $image,
-            'field_uiowa_card_link' => $link,
-            'field_uiowa_card_title' => [
-              // Size not set in paragraphs. Defaulting to h2. Can change later.
-              'size' => 'h2',
-              'text' => $label,
+      elseif (!P2LbHelper::formattedTextIsEquivalent($excerpt['value'], 'filtered_html', 'minimal_plus')) {
+        // Converting to a card would result in data loss. Convert to a text
+        // area instead.
+        $type = 'uiowa_text_area';
+      }
+
+      $fields = [];
+
+      switch ($type) {
+        case 'uiowa_card':
+          $fields['field_uiowa_card_title'] = _sitenow_p2lb_headline_config($label, $display_label);
+
+          // Add the image, if its set.
+          if ($image) {
+            $fields['field_uiowa_card_image'] = $image;
+          }
+
+          // Add the subtitle, if its set.
+          if ($subtitle) {
+            $fields['field_uiowa_card_author'] = $subtitle;
+          }
+
+          // Add the excerpt, if its set.
+          if ($excerpt) {
+            $fields['field_uiowa_card_excerpt'] = [
+              'value' => $excerpt,
+              'format' => 'minimal_plus',
+            ];
+          }
+
+          // Add the link, if its set.
+          if ($link) {
+            $fields['field_uiowa_card_link'] = $link;
+          }
+
+          break;
+
+        case 'uiowa_image':
+          $fields = ['field_uiowa_image_image' => $image];
+          if ($link) {
+            $fields['field_uiowa_image_link'] = $link;
+          }
+          break;
+
+        case 'uiowa_text_area':
+          $output = '';
+          if ($subtitle) {
+            $output .= $subtitle;
+          }
+          if ($excerpt) {
+            $output .= $excerpt;
+          }
+          // @todo How do we account for an image, if there is one?
+          $fields = [
+            'field_uiowa_text_area' => [
+              'value' => $output,
+              'format' => 'filtered_html',
             ],
-          ]);
-        }
+          ];
+          if ($label) {
+            $fields['field_uiowa_headline'] = _sitenow_p2lb_headline_config($label, $display_label);
+          }
+          break;
+
       }
+
+      $block_definition = sitenow_p2lb_block_definition($type, $fields);
 
       break;
 

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -582,7 +582,7 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
       // By default, we're assuming this will become a V3 card.
       $type = 'uiowa_card';
 
-      // If the card has no title
+      // If the card has no title...
       if (!$label) {
         if ($image && (!$subtitle && !$excerpt)) {
           // Image and optionally a link.

--- a/docroot/modules/custom/sitenow_p2lb/src/Form/P2LbSettingsForm.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/Form/P2LbSettingsForm.php
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Site\Settings;
+use Drupal\sitenow_p2lb\P2LbHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -75,6 +76,12 @@ class P2LbSettingsForm extends ConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form = parent::buildForm($form, $form_state);
+
+    $form['issues'] = [
+      '#type' => 'container',
+    ];
+
+    $this->buildIssueList($form['issues']);
 
     $form['markup'] = [
       '#type' => 'markup',
@@ -181,6 +188,36 @@ class P2LbSettingsForm extends ConfigFormBase {
       sitenow_p2lb_node_p2lb($node, TRUE);
     }
     return $form_state;
+  }
+
+  protected function buildIssueList(&$form) {
+    $query = \Drupal::entityQuery('paragraph')
+      ->condition('type', 'card')
+      ->accessCheck(TRUE);
+
+    $pids = $query->execute();
+
+    foreach ($pids as $pid) {
+      /** @var \Drupal\paragraphs\ParagraphInterface $paragraph */
+      $paragraph = $this->entityTypeManager->getStorage('paragraph')->load($pid);
+      $body = $paragraph->field_card_body?->value;
+      if (is_null($body)) {
+        continue;
+      }
+
+      if (P2LbHelper::formattedTextIsEquivalent($body, 'filtered_html', 'minimal_plus')) {
+        continue;
+      }
+
+      $parent = $paragraph->getParentEntity();
+      $parent = $parent->getParentEntity();
+      if (!is_null($parent)) {
+        $form[$parent->id()] = [
+          '#type' => 'markup',
+          '#markup' => '<div><a href="/node/' . $parent->id() . '">' . $parent->id() . '</a> - V2 card body is incompatible with V3 card body.</div>',
+        ];
+      }
+    }
   }
 
 }

--- a/docroot/modules/custom/sitenow_p2lb/src/Form/P2LbSettingsForm.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/Form/P2LbSettingsForm.php
@@ -77,12 +77,6 @@ class P2LbSettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form = parent::buildForm($form, $form_state);
 
-    $form['issues'] = [
-      '#type' => 'container',
-    ];
-
-    $this->buildIssueList($form['issues']);
-
     $form['markup'] = [
       '#type' => 'markup',
       '#markup' => <<< 'EOD'
@@ -188,36 +182,6 @@ class P2LbSettingsForm extends ConfigFormBase {
       sitenow_p2lb_node_p2lb($node, TRUE);
     }
     return $form_state;
-  }
-
-  protected function buildIssueList(&$form) {
-    $query = \Drupal::entityQuery('paragraph')
-      ->condition('type', 'card')
-      ->accessCheck(TRUE);
-
-    $pids = $query->execute();
-
-    foreach ($pids as $pid) {
-      /** @var \Drupal\paragraphs\ParagraphInterface $paragraph */
-      $paragraph = $this->entityTypeManager->getStorage('paragraph')->load($pid);
-      $body = $paragraph->field_card_body?->value;
-      if (is_null($body)) {
-        continue;
-      }
-
-      if (P2LbHelper::formattedTextIsEquivalent($body, 'filtered_html', 'minimal_plus')) {
-        continue;
-      }
-
-      $parent = $paragraph->getParentEntity();
-      $parent = $parent->getParentEntity();
-      if (!is_null($parent)) {
-        $form[$parent->id()] = [
-          '#type' => 'markup',
-          '#markup' => '<div><a href="/node/' . $parent->id() . '">' . $parent->id() . '</a> - V2 card body is incompatible with V3 card body.</div>',
-        ];
-      }
-    }
   }
 
 }

--- a/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
@@ -23,8 +23,10 @@ class P2LbHelper {
    *   The second format.
    *
    * @return bool
+   *   If the tests match.
    */
   public static function formattedTextIsSame(string $text, string $format_one, string $format_two): bool {
     return check_markup($text, $format_one) == check_markup($text, $format_two);
   }
+
 }

--- a/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Drupal\sitenow_p2lb;
+
+class P2LbHelper {
+  public static function formattedTextIsEquivalent($text, $format_one, $format_two) {
+    return check_markup($text, $format_one) === check_markup($text, $format_two);
+  }
+}

--- a/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
@@ -2,8 +2,53 @@
 
 namespace Drupal\sitenow_p2lb;
 
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\sitenow_pages\Entity\Page;
+
 class P2LbHelper {
+
+  use StringTranslationTrait;
   public static function formattedTextIsEquivalent($text, $format_one, $format_two) {
     return check_markup($text, $format_one) === check_markup($text, $format_two);
+  }
+
+  public static function analyzeNode(Page $page) {
+    $issues = [];
+    /** @var \Drupal\entity_reference_revisions\EntityReferenceRevisionsFieldItemList $section_field */
+    $section_field = $page->field_page_content_block;
+    $sections = $section_field?->referencedEntities();
+    if (!is_null($sections)) {
+      /**
+       * @var int $section_delta
+       * @var \Drupal\paragraphs\ParagraphInterface $section
+       */
+      foreach ($sections as $section_delta => $section) {
+        /** @var \Drupal\entity_reference_revisions\EntityReferenceRevisionsFieldItemList $components_field */
+        $components_field = $section->field_section_content_block;
+        $components = $components_field->referencedEntities();
+        /**
+         * @var int $component_delta
+         * @var \Drupal\paragraphs\ParagraphInterface $component
+         */
+        foreach ($components as $component_delta => $component) {
+          switch ($component->getType()) {
+            case 'card':
+              // @todo Check if card has a title.
+              $label = $component->field_card_title?->value;
+              if (!$label) {
+                $issues[] = t('Contains a card with no label. Label is required for V3.');
+              }
+              // Card body isn't required. Check or set to array with empty value.
+              $excerpt = $component->field_card_body?->value;
+              if ($excerpt && !static::formattedTextIsEquivalent($excerpt, 'filtered_html', 'minimal')) {
+                $issues[] = t('Contains a card with a body that uses markup that is not allowed in V3.');
+              }
+              break;
+          }
+        }
+      }
+    }
+
+    return $issues;
   }
 }

--- a/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
@@ -5,10 +5,26 @@ namespace Drupal\sitenow_p2lb;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\sitenow_pages\Entity\Page;
 
+/**
+ * A helper class for P2LB.
+ */
 class P2LbHelper {
 
   use StringTranslationTrait;
-  public static function formattedTextIsEquivalent($text, $format_one, $format_two) {
+
+  /**
+   * Compare a string of text using two different formats.
+   *
+   * @param string $text
+   *   The text being tested.
+   * @param string $format_one
+   *   The first format.
+   * @param string $format_two
+   *   The second format.
+   *
+   * @return bool
+   */
+  public static function formattedTextIsEquivalent(string $text, string $format_one, string $format_two): bool {
     return check_markup($text, $format_one) === check_markup($text, $format_two);
   }
 }

--- a/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
@@ -11,44 +11,4 @@ class P2LbHelper {
   public static function formattedTextIsEquivalent($text, $format_one, $format_two) {
     return check_markup($text, $format_one) === check_markup($text, $format_two);
   }
-
-  public static function analyzeNode(Page $page) {
-    $issues = [];
-    /** @var \Drupal\entity_reference_revisions\EntityReferenceRevisionsFieldItemList $section_field */
-    $section_field = $page->field_page_content_block;
-    $sections = $section_field?->referencedEntities();
-    if (!is_null($sections)) {
-      /**
-       * @var int $section_delta
-       * @var \Drupal\paragraphs\ParagraphInterface $section
-       */
-      foreach ($sections as $section_delta => $section) {
-        /** @var \Drupal\entity_reference_revisions\EntityReferenceRevisionsFieldItemList $components_field */
-        $components_field = $section->field_section_content_block;
-        $components = $components_field->referencedEntities();
-        /**
-         * @var int $component_delta
-         * @var \Drupal\paragraphs\ParagraphInterface $component
-         */
-        foreach ($components as $component_delta => $component) {
-          switch ($component->getType()) {
-            case 'card':
-              // @todo Check if card has a title.
-              $label = $component->field_card_title?->value;
-              if (!$label) {
-                $issues[] = t('Contains a card with no label. Label is required for V3.');
-              }
-              // Card body isn't required. Check or set to array with empty value.
-              $excerpt = $component->field_card_body?->value;
-              if ($excerpt && !static::formattedTextIsEquivalent($excerpt, 'filtered_html', 'minimal')) {
-                $issues[] = t('Contains a card with a body that uses markup that is not allowed in V3.');
-              }
-              break;
-          }
-        }
-      }
-    }
-
-    return $issues;
-  }
 }

--- a/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/P2LbHelper.php
@@ -24,7 +24,7 @@ class P2LbHelper {
    *
    * @return bool
    */
-  public static function formattedTextIsEquivalent(string $text, string $format_one, string $format_two): bool {
-    return check_markup($text, $format_one) === check_markup($text, $format_two);
+  public static function formattedTextIsSame(string $text, string $format_one, string $format_two): bool {
+    return check_markup($text, $format_one) == check_markup($text, $format_two);
   }
 }


### PR DESCRIPTION
Resolves #6714 

# How to test
```
ddev blt ds --site brand.uiowa.edu && ddev drush @brand.local config-split:activate p2lb -y && ddev drush @brand.local cim -y && ddev drush @brand.local uli admin/content/sitenow-converter
```
- Find existing examples or create examples of the cases below and validate what happens during the conversion.
- Optionally provide feedback about the result.

## Cases
- A card has no title and only an image or an image and a link => V3 image block
- A card has no title => V3 text block
- A card has a body with content that is incompatible with the Minimal + format => V3 text block
- Otherwise => V3 card block