### PR TITLE
P2LB - block style changes

### DIFF
--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -1239,16 +1239,18 @@ function _sitenow_p2lb_block_styles($block_type, $paragraph = NULL) {
       return [
         'block_background_style_light',
         'card_media_position_right',
+        'card_headline_style_serif',
         'media_format_widescreen',
-        'content_alignment_left',
-        'card_image_medium',
+        'media_size_small',
         'list_format_list',
         'block_grid_threecol_33_34_33',
+        'no_border',
       ];
 
     case 'uiowa_quote':
       return [
         'quote_left',
+        'quote_above',
       ];
 
     case 'uiowa_card':
@@ -1258,7 +1260,6 @@ function _sitenow_p2lb_block_styles($block_type, $paragraph = NULL) {
         'card_media_position_stacked',
         'content_alignment_left',
         'media_format_widescreen',
-        'block_card_style_border',
       ];
 
     case 'uiowa_slider':
@@ -1268,11 +1269,14 @@ function _sitenow_p2lb_block_styles($block_type, $paragraph = NULL) {
       return [
         'block_background_style_light',
         'card_media_position_left',
+        'card_headline_style_serif',
         'media_format_circle',
+        'media_size_small',
         'content_alignment_left',
         'card_image_small',
         'list_format_list',
         'block_grid_threecol_33_34_33',
+        'no_border',
       ];
 
     case 'featured_content':
@@ -1284,12 +1288,14 @@ function _sitenow_p2lb_block_styles($block_type, $paragraph = NULL) {
     case 'views_block:people_list_block-list_card':
       return [
         'block_background_style_light',
-        'card_media_position_right',
+        'card_media_position_left',
+        'card_headline_style_serif',
         'media_format_circle',
+        'media_size_small',
         'content_alignment_left',
-        'card_image_small',
         'list_format_list',
         'block_grid_threecol_33_34_33',
+        'no_border',
       ];
 
     case 'uiowa_text_area':


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt sync --site hawkeyemarchingband.uiowa.edu --define drush.aliases.remote=hawkeyemarchingband.test && ddev drush @hawkeyemarchingband.local config-split:activate p2lb -y && ddev drush @hawkeyemarchingband.local uli admin/content/sitenow-converter
```
Convert the pages below and then edit the layout and verify that you can resave the block without errors. 
- https://hawkeyemarchingband.uiowa.ddev.site/events
- https://hawkeyemarchingband.uiowa.ddev.site/people-list
- https://hawkeyemarchingband.uiowa.ddev.site/blockquote
- https://hawkeyemarchingband.uiowa.ddev.site/articles
