### PR TITLE
Collection Item Unique ID with p2lb support

### DIFF
--- a/config/default/core.entity_form_display.paragraph.uiowa_collection_item.default.yml
+++ b/config/default/core.entity_form_display.paragraph.uiowa_collection_item.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.paragraph.uiowa_collection_item.field_automatically_open
     - field.field.paragraph.uiowa_collection_item.field_collection_body
     - field.field.paragraph.uiowa_collection_item.field_collection_headline
+    - field.field.paragraph.uiowa_collection_item.field_unique_id
     - paragraphs.paragraphs_type.uiowa_collection_item
   module:
     - text
@@ -32,6 +33,14 @@ content:
   field_collection_headline:
     type: string_textfield
     weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_unique_id:
+    type: string_textfield
+    weight: 4
     region: content
     settings:
       size: 60

--- a/config/default/core.entity_view_display.paragraph.uiowa_collection_item.accordion.yml
+++ b/config/default/core.entity_view_display.paragraph.uiowa_collection_item.accordion.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.paragraph.uiowa_collection_item.field_automatically_open
     - field.field.paragraph.uiowa_collection_item.field_collection_body
     - field.field.paragraph.uiowa_collection_item.field_collection_headline
+    - field.field.paragraph.uiowa_collection_item.field_unique_id
     - paragraphs.paragraphs_type.uiowa_collection_item
   module:
     - layout_builder
@@ -34,6 +35,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_unique_id:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
     region: content
 hidden:
   entity_print_view_epub: true

--- a/config/default/core.entity_view_display.paragraph.uiowa_collection_item.default.yml
+++ b/config/default/core.entity_view_display.paragraph.uiowa_collection_item.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.paragraph.uiowa_collection_item.field_automatically_open
     - field.field.paragraph.uiowa_collection_item.field_collection_body
     - field.field.paragraph.uiowa_collection_item.field_collection_headline
+    - field.field.paragraph.uiowa_collection_item.field_unique_id
     - paragraphs.paragraphs_type.uiowa_collection_item
   module:
     - text
@@ -34,4 +35,5 @@ hidden:
   entity_print_view_pdf: true
   entity_print_view_word_docx: true
   field_automatically_open: true
+  field_unique_id: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.paragraph.uiowa_collection_item.descriptive_list.yml
+++ b/config/default/core.entity_view_display.paragraph.uiowa_collection_item.descriptive_list.yml
@@ -36,10 +36,17 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  field_unique_id:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
 hidden:
   entity_print_view_epub: true
   entity_print_view_pdf: true
   entity_print_view_word_docx: true
   field_automatically_open: true
-  field_unique_id: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.paragraph.uiowa_collection_item.descriptive_list.yml
+++ b/config/default/core.entity_view_display.paragraph.uiowa_collection_item.descriptive_list.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.paragraph.uiowa_collection_item.field_automatically_open
     - field.field.paragraph.uiowa_collection_item.field_collection_body
     - field.field.paragraph.uiowa_collection_item.field_collection_headline
+    - field.field.paragraph.uiowa_collection_item.field_unique_id
     - paragraphs.paragraphs_type.uiowa_collection_item
   module:
     - layout_builder
@@ -40,4 +41,5 @@ hidden:
   entity_print_view_pdf: true
   entity_print_view_word_docx: true
   field_automatically_open: true
+  field_unique_id: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.paragraph.uiowa_collection_item.tab.yml
+++ b/config/default/core.entity_view_display.paragraph.uiowa_collection_item.tab.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.paragraph.uiowa_collection_item.field_automatically_open
     - field.field.paragraph.uiowa_collection_item.field_collection_body
     - field.field.paragraph.uiowa_collection_item.field_collection_headline
+    - field.field.paragraph.uiowa_collection_item.field_unique_id
     - paragraphs.paragraphs_type.uiowa_collection_item
   module:
     - layout_builder
@@ -34,6 +35,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_unique_id:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
     region: content
 hidden:
   entity_print_view_epub: true

--- a/config/default/field.field.paragraph.uiowa_collection_item.field_unique_id.yml
+++ b/config/default/field.field.paragraph.uiowa_collection_item.field_unique_id.yml
@@ -1,0 +1,19 @@
+uuid: 5b09e1c0-c6e3-4db0-9e0d-58df75ecf6cc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unique_id
+    - paragraphs.paragraphs_type.uiowa_collection_item
+id: paragraph.uiowa_collection_item.field_unique_id
+field_name: field_unique_id
+entity_type: paragraph
+bundle: uiowa_collection_item
+label: 'Unique ID'
+description: 'Provide a unique identifier for this collection item. Primarily used for anchor links. Input will be cleaned to convert spaces and remove special characters. The collection item headline will be used if no value is provided.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.storage.paragraph.field_unique_id.yml
+++ b/config/default/field.storage.paragraph.field_unique_id.yml
@@ -1,0 +1,21 @@
+uuid: fa7dc290-85d9-47b9-9f8c-ff446eb7d7b3
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_unique_id
+field_name: field_unique_id
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -1454,11 +1454,11 @@ function _layout_builder_custom_unique_id(array &$form, FormStateInterface $form
 
   // @todo Figure out a better way of doing this.
   if (isset($triggering_element['#field_parents'])) {
-    $delta = $triggering_element["#field_parents"][3];
+    $delta = $triggering_element['#field_parents'][3];
     // Same as $triggering_element['#array_parents'] + ['#value'].
-    $form["settings"]["block_form"]["field_uiowa_collection_items"]["widget"][$delta]["subform"]["field_unique_id"]["widget"][0]["value"]["#value"] = $unique_id;
+    $form['settings']['block_form']['field_uiowa_collection_items']['widget'][$delta]['subform']['field_unique_id']['widget'][0]['value']['#value'] = $unique_id;
     // Same as $triggering_element['#field_parents'].
-    return $form["settings"]["block_form"]["field_uiowa_collection_items"]["widget"][$delta]["subform"];
+    return $form['settings']['block_form']['field_uiowa_collection_items']['widget'][$delta]['subform'];
   }
   else {
     $form['unique_id_wrapper']['unique_id']['#value'] = $unique_id;

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -1455,7 +1455,7 @@ function _layout_builder_custom_unique_id(array &$form, FormStateInterface $form
 
   // Check if the trigger element is a nested field.
   if (isset($triggering_element['#field_parents']) && isset($triggering_element['#array_parents'])) {
-    // Create a reference
+    // Access the part of the form we want to return.
     $parent = NestedArray::getValue($form, array_slice($triggering_element['#array_parents'], 0, -4));
     $parent['field_unique_id']['widget'][0]['value']['#value'] = $unique_id;
     return $parent;

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -1052,6 +1052,16 @@ function layout_builder_custom_field_widget_paragraphs_form_alter(array &$elemen
     switch ($element['#paragraph_type']) {
 
       case 'uiowa_collection_item':
+        if (isset($element['subform']['field_unique_id'])) {
+          $element['subform']['#prefix'] = '<div id="unique_id_wrapper">';
+          $element['subform']['#suffix'] = '</div>';
+          $element['subform']['field_unique_id']['widget'][0]['value']['#ajax'] = [
+            'callback' => '_layout_builder_custom_unique_id',
+            'event' => 'change',
+            'wrapper' => 'unique_id_wrapper',
+            'disable-refocus' => TRUE,
+          ];
+        }
       case 'uiowa_slide':
         // If it exists, pop the headline and place it in the label.
         if (!empty($element['top']['summary']['fields_info']['#summary']['content'])) {
@@ -1439,11 +1449,19 @@ function layout_builder_custom_views_pre_render(ViewExecutable $view) {
  *   The form element.
  */
 function _layout_builder_custom_unique_id(array &$form, FormStateInterface $form_state) {
-  $unique_id = Html::cleanCssIdentifier($form_state->getValue([
-    'unique_id_wrapper',
-    'unique_id',
-  ]));
+  $triggering_element = $form_state->getTriggeringElement();
+  $unique_id = Html::cleanCssIdentifier($triggering_element['#value']);
 
-  $form['unique_id_wrapper']['unique_id']['#value'] = $unique_id;
-  return $form['unique_id_wrapper'];
+  // @todo Figure out a better way of doing this.
+  if (isset($triggering_element['#field_parents'])) {
+    $delta = $triggering_element["#field_parents"][3];
+    // Same as $triggering_element['#array_parents'] + ['#value'].
+    $form["settings"]["block_form"]["field_uiowa_collection_items"]["widget"][$delta]["subform"]["field_unique_id"]["widget"][0]["value"]["#value"] = $unique_id;
+    // Same as $triggering_element['#field_parents'].
+    return $form["settings"]["block_form"]["field_uiowa_collection_items"]["widget"][$delta]["subform"];
+  }
+  else {
+    $form['unique_id_wrapper']['unique_id']['#value'] = $unique_id;
+    return $form['unique_id_wrapper'];
+  }
 }

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
@@ -1053,12 +1054,12 @@ function layout_builder_custom_field_widget_paragraphs_form_alter(array &$elemen
 
       case 'uiowa_collection_item':
         if (isset($element['subform']['field_unique_id'])) {
-          $element['subform']['#prefix'] = '<div id="unique_id_wrapper">';
+          $element['subform']['#prefix'] = '<div id="unique-id-wrapper-child">';
           $element['subform']['#suffix'] = '</div>';
           $element['subform']['field_unique_id']['widget'][0]['value']['#ajax'] = [
             'callback' => '_layout_builder_custom_unique_id',
             'event' => 'change',
-            'wrapper' => 'unique_id_wrapper',
+            'wrapper' => 'unique-id-wrapper-child',
             'disable-refocus' => TRUE,
           ];
         }
@@ -1452,16 +1453,16 @@ function _layout_builder_custom_unique_id(array &$form, FormStateInterface $form
   $triggering_element = $form_state->getTriggeringElement();
   $unique_id = Html::cleanCssIdentifier($triggering_element['#value']);
 
-  // @todo Figure out a better way of doing this.
-  if (isset($triggering_element['#field_parents'])) {
-    $delta = $triggering_element['#field_parents'][3];
-    // Same as $triggering_element['#array_parents'] + ['#value'].
-    $form['settings']['block_form']['field_uiowa_collection_items']['widget'][$delta]['subform']['field_unique_id']['widget'][0]['value']['#value'] = $unique_id;
-    // Same as $triggering_element['#field_parents'].
-    return $form['settings']['block_form']['field_uiowa_collection_items']['widget'][$delta]['subform'];
+  // Check if the trigger element is a nested field.
+  if (isset($triggering_element['#field_parents']) && isset($triggering_element['#array_parents'])) {
+    // Create a reference
+    $parent = NestedArray::getValue($form, array_slice($triggering_element['#array_parents'], 0, -4));
+    $parent['field_unique_id']['widget'][0]['value']['#value'] = $unique_id;
+    return $parent;
   }
   else {
     $form['unique_id_wrapper']['unique_id']['#value'] = $unique_id;
     return $form['unique_id_wrapper'];
   }
+
 }

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -515,6 +515,7 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
         $accordion_paragraph = $paragraph->load($accordion_item->target_id);
         $body = $accordion_paragraph->get('field_accordion_item_body')->getValue()[0];
         $child_title = $accordion_paragraph->get('field_accordion_item_title')->getString();
+        $unique_id = $accordion_paragraph->get('field_uip_id')->getString();
         $child = $paragraph->create([
           'langcode' => 'en',
           'type' => 'uiowa_collection_item',
@@ -523,6 +524,7 @@ function sitenow_p2lb_process_paragraph($paragraph, $node) {
           'parent_field_name' => 'field_uiowa_collection_items',
           'field_collection_body' => $body,
           'field_collection_headline' => $child_title,
+          'field_unique_id' => $unique_id,
         ]);
         if ($child->save()) {
           $children[] = $child;

--- a/docroot/themes/custom/uids_base/templates/paragraphs/paragraph--uiowa-collection-item--accordion.html.twig
+++ b/docroot/themes/custom/uids_base/templates/paragraphs/paragraph--uiowa-collection-item--accordion.html.twig
@@ -47,6 +47,7 @@
   'accordion_item_label': content.field_collection_headline,
   'accordion_item_content': content.field_collection_body,
   'accordion_item_expanded': field_automatically_open,
+  'accordion_hash': content.field_unique_id.0,
   'attributes': attributes,
 } %}
 

--- a/docroot/themes/custom/uids_base/templates/paragraphs/paragraph--uiowa-collection-item--descriptive-list.html.twig
+++ b/docroot/themes/custom/uids_base/templates/paragraphs/paragraph--uiowa-collection-item--descriptive-list.html.twig
@@ -39,5 +39,12 @@
  */
 #}
 
-<dt>{{ content.field_collection_headline }}</dt>
+{% set unique_id = content.field_unique_id.0 %}
+{% if unique_id %}
+<dt id="{{ unique_id }}">
+{% else %}
+<dt>
+{% endif %}
+{{ content.field_collection_headline }}
+</dt>
 <dd>{{ content.field_collection_body }}</dd>

--- a/docroot/themes/custom/uids_base/templates/paragraphs/timeline/paragraph--uiowa-collection-item--tabs.html.twig
+++ b/docroot/themes/custom/uids_base/templates/paragraphs/timeline/paragraph--uiowa-collection-item--tabs.html.twig
@@ -47,6 +47,7 @@
   'accordion_item_label': content.field_collection_headline,
   'accordion_item_content': content.field_collection_body,
   'accordion_item_expanded': field_automatically_open,
+  'accordion_hash': content.field_unique_id.0,
   'attributes': attributes,
 } %}
 


### PR DESCRIPTION
# To Do

- ~~Make sure descriptive list and tabs are covered?~~
- ~~Streamline the ajax callback so it isn't so spelled out and specific?~~

# To Test

```
ddev blt ds --site brand.uiowa.edu && ddev drush @brand.local config-split:activate p2lb -y && ddev drush @brand.local uli admin/content/sitenow-converter
```
- Edit a page and add an accordion item with a unique id, save.
- Convert
- See the id in the new collection item field.
- edit the value with some spaces, tab or enter off the field. the ajax should update the value.
- edit the collection's unique id field. should be unaffected.
- change to description list and the id should still output if provided.
- edit a sections unique id field. should be unaffected.