### PR TITLE
Hotfix - Turning off v4 shim for font awesome for a temporary fix for "add component" button

### DIFF
--- a/config/default/fontawesome.settings.yml
+++ b/config/default/fontawesome.settings.yml
@@ -5,7 +5,7 @@ method: svg
 load_assets: true
 use_cdn: false
 external_svg_location: 'https://use.fontawesome.com/releases/v5.5.0/js/all.js'
-use_shim: true
+use_shim: false
 external_shim_location: 'https://use.fontawesome.com/releases/v5.5.0/js/v4-shims.js'
 allow_pseudo_elements: false
 use_solid_file: true


### PR DESCRIPTION
`ddev blt ds --site=uiowa.edu` and verify that brand fonts are loading in the footer.  Verify in the source that only the `all.min.js` is being loaded.   This will turn off font awesome 4 support which was replaced by version 5 in 2017. 

## future work

- Look to change the order of how lb_direct_add js is loaded so that something like siteimprove doesn’t slow load ahead of it