### PR TITLE
[ Oniowa ] Hotfix for duplicate date select options

### DIFF
--- a/docroot/sites/oniowa.uiowa.edu/modules/oniowa_core/oniowa_core.module
+++ b/docroot/sites/oniowa.uiowa.edu/modules/oniowa_core/oniowa_core.module
@@ -31,7 +31,7 @@ function oniowa_core_form_alter(&$form, FormStateInterface $form_state, $form_id
             ->fetchCol();
           foreach ($data as $date) {
             $day = date('l, F j Y', $date);
-            if (!isset($options[$date])) {
+            if (!in_array($day, $options)) {
               $options[$date] = $day;
             }
           }


### PR DESCRIPTION
On https://oniowa.uiowa.edu/events, there are currently duplicate date options in the date selector.

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
```
ddev blt ds --site=oniowa.uiowa.edu
```
Check https://oniowa.uiowa.ddev.site/events and see that there aren't duplicates