### PR TITLE
Hotfix - Added lb_direct_add patch for popover

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -268,6 +268,9 @@
                 "Section dependency on layout plugin configuration form": "https://www.drupal.org/files/issues/2019-08-23/layout_builder_styles-3062261-%2310.patch",
                 "Some styles get added multiple times": "https://www.drupal.org/files/issues/2023-02-14/3341740-3.patch"
             },
+            "drupal/lb_direct_add": {
+                "Popover menu doesn't work without a refresh": "https://www.drupal.org/files/issues/2023-03-28/lb_direct_add-3350807-4.patch"
+            },
             "drupal/linkit": {
                 "Add Webform Matcher": "https://www.drupal.org/files/issues/2023-06-13/linkit-webform-matcher-2946234-36.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ccc13744da806c8ec9396669152d26ac",
+    "content-hash": "e0e443564cdff3d4827b3a2b08cd5813",
     "packages": [
         {
             "name": "acquia/blt",
@@ -9583,6 +9583,10 @@
                     "homepage": "https://www.drupal.org/user/291091"
                 },
                 {
+                    "name": "dinazaur",
+                    "homepage": "https://www.drupal.org/user/3637512"
+                },
+                {
                     "name": "Grevil",
                     "homepage": "https://www.drupal.org/user/3668491"
                 },
@@ -9637,7 +9641,7 @@
                     "datestamp": "1624384412",
                     "security-coverage": {
                         "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
+                        "message": "RC releases are not covered by Drupal security advisories."
                     }
                 }
             },
@@ -10404,6 +10408,7 @@
                 "drupal/config_rewrite": "*",
                 "drupal/custom_field": "*",
                 "drupal/devel": "*",
+                "drupal/entity_reference_override": "~2.0",
                 "drupal/entity_reference_revisions": "*",
                 "drupal/entity_usage": "~2.0",
                 "drupal/existing_values_autocomplete_widget": "*",
@@ -10448,8 +10453,8 @@
                     "dev-1.0.x": "1.0.x-dev"
                 },
                 "drupal": {
-                    "version": "1.0.0-alpha3+59-dev",
-                    "datestamp": "1689693474",
+                    "version": "1.0.0-alpha3+60-dev",
+                    "datestamp": "1690854716",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -11078,6 +11083,10 @@
                     "name": "mehrpadin",
                     "homepage": "https://www.drupal.org/u/mehrpadin",
                     "role": "Maintainer"
+                },
+                {
+                    "name": "LOBsTerr",
+                    "homepage": "https://www.drupal.org/user/645020"
                 },
                 {
                     "name": "mehrpadin",


### PR DESCRIPTION
```
ddev composer install && ddev blt ds --site=education.uiowa.edu && ddev drush @education.local uli /private-sector-partnerships-strengthen-higher-education
```

Test that the popover still closes when you click outside of the button.  That is our one concern here before pushing this out. 