### PR TITLE
Extend Linkit to other link fields

### DIFF
--- a/config/default/core.entity_form_display.block_content.uiowa_banner.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_banner.default.yml
@@ -12,7 +12,7 @@ dependencies:
     - field.field.block_content.uiowa_banner.field_uiowa_banner_title
   module:
     - heading
-    - link
+    - linkit
     - media_library
     - text
 _core:
@@ -45,12 +45,14 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_uiowa_banner_link:
-    type: link_default
+    type: linkit
     weight: 4
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      linkit_profile: default
+      linkit_auto_link_text: false
     third_party_settings: {  }
   field_uiowa_banner_pre_title:
     type: string_textfield

--- a/config/default/core.entity_form_display.block_content.uiowa_button.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_button.default.yml
@@ -6,19 +6,21 @@ dependencies:
     - block_content.type.uiowa_button
     - field.field.block_content.uiowa_button.field_uiowa_button_link
   module:
-    - link
+    - linkit
 id: block_content.uiowa_button.default
 targetEntityType: block_content
 bundle: uiowa_button
 mode: default
 content:
   field_uiowa_button_link:
-    type: link_default
+    type: linkit
     weight: 26
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      linkit_profile: default
+      linkit_auto_link_text: false
     third_party_settings: {  }
   info:
     type: string_textfield

--- a/config/default/core.entity_form_display.block_content.uiowa_card.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_card.default.yml
@@ -12,7 +12,7 @@ dependencies:
     - field.field.block_content.uiowa_card.field_uiowa_card_title
   module:
     - heading
-    - link
+    - linkit
     - media_library
     - text
 _core:
@@ -52,12 +52,14 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_uiowa_card_link:
-    type: link_default
+    type: linkit
     weight: 4
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      linkit_profile: default
+      linkit_auto_link_text: false
     third_party_settings: {  }
   field_uiowa_card_title:
     type: heading

--- a/config/default/core.entity_form_display.block_content.uiowa_cta.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_cta.default.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.block_content.uiowa_cta.field_uiowa_cta_title
   module:
     - heading
-    - link
+    - linkit
     - text
 _core:
   default_config_hash: C9SWoj32dA5WxftU5KLg_gWozCyQ0406EElZdchIyZo
@@ -19,12 +19,14 @@ bundle: uiowa_cta
 mode: default
 content:
   field_uiowa_cta_link:
-    type: link_default
+    type: linkit
     weight: 29
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      linkit_profile: default
+      linkit_auto_link_text: false
     third_party_settings: {  }
   field_uiowa_cta_summary:
     type: text_textarea

--- a/config/default/core.entity_form_display.block_content.uiowa_event.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_event.default.yml
@@ -14,7 +14,7 @@ dependencies:
     - datetime
     - fontawesome
     - heading
-    - link
+    - linkit
     - media_library
 id: block_content.uiowa_event.default
 targetEntityType: block_content
@@ -41,12 +41,14 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_uiowa_event_link:
-    type: link_default
+    type: linkit
     weight: 31
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      linkit_profile: default
+      linkit_auto_link_text: false
     third_party_settings: {  }
   field_uiowa_event_location:
     type: string_textfield

--- a/config/default/core.entity_form_display.block_content.uiowa_events.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_events.default.yml
@@ -20,7 +20,7 @@ dependencies:
     - field.field.block_content.uiowa_events.field_uiowa_headline
   module:
     - layout_builder_custom
-    - link
+    - linkit
     - smart_date
 id: block_content.uiowa_events.default
 targetEntityType: block_content
@@ -35,12 +35,14 @@ content:
       display_label: true
     third_party_settings: {  }
   field_collection_more_path:
-    type: link_default
+    type: linkit
     weight: 15
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      linkit_profile: default
+      linkit_auto_link_text: false
     third_party_settings: {  }
   field_collection_pager:
     type: boolean_checkbox
@@ -77,6 +79,7 @@ content:
         120|2 hours
         custom
       show_extra: false
+      separator: to
     third_party_settings: {  }
   field_uiowa_events_department:
     type: options_select

--- a/config/default/core.entity_form_display.block_content.uiowa_image.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_image.default.yml
@@ -7,7 +7,7 @@ dependencies:
     - field.field.block_content.uiowa_image.field_uiowa_image_image
     - field.field.block_content.uiowa_image.field_uiowa_image_link
   module:
-    - link
+    - linkit
     - media_library
 id: block_content.uiowa_image.default
 targetEntityType: block_content
@@ -22,12 +22,14 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_uiowa_image_link:
-    type: link_default
+    type: linkit
     weight: 2
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      linkit_profile: default
+      linkit_auto_link_text: false
     third_party_settings: {  }
   info:
     type: string_textfield

--- a/config/default/core.entity_form_display.block_content.uiowa_quote.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_quote.default.yml
@@ -10,7 +10,7 @@ dependencies:
     - field.field.block_content.uiowa_quote.field_uiowa_quote_image
   module:
     - allowed_formats
-    - link
+    - linkit
     - media_library
     - text
 id: block_content.uiowa_quote.default
@@ -19,12 +19,14 @@ bundle: uiowa_quote
 mode: default
 content:
   field_uiowa_quote_citation:
-    type: link_default
+    type: linkit
     weight: 28
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      linkit_profile: default
+      linkit_auto_link_text: false
     third_party_settings: {  }
   field_uiowa_quote_content:
     type: text_textarea

--- a/config/default/core.entity_form_display.paragraph.uiowa_slide.default.yml
+++ b/config/default/core.entity_form_display.paragraph.uiowa_slide.default.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.paragraph.uiowa_slide.field_uiowa_slide_link
     - paragraphs.paragraphs_type.uiowa_slide
   module:
-    - link
+    - linkit
     - media_library
     - text
 id: paragraph.uiowa_slide.default
@@ -41,12 +41,14 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_uiowa_slide_link:
-    type: link_default
+    type: linkit
     weight: 2
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      linkit_profile: default
+      linkit_auto_link_text: false
     third_party_settings: {  }
 hidden:
   created: true

--- a/config/default/core.entity_form_display.paragraph.uiowa_timeline_item.default.yml
+++ b/config/default/core.entity_form_display.paragraph.uiowa_timeline_item.default.yml
@@ -12,7 +12,7 @@ dependencies:
     - paragraphs.paragraphs_type.uiowa_timeline_item
   module:
     - fontawesome
-    - link
+    - linkit
     - media_library
     - text
 id: paragraph.uiowa_timeline_item.default
@@ -51,12 +51,14 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_timeline_link:
-    type: link_default
+    type: linkit
     weight: 4
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      linkit_profile: default
+      linkit_auto_link_text: false
     third_party_settings: {  }
   field_timeline_media:
     type: media_library_widget

--- a/docroot/modules/custom/layout_builder_custom/css/layout_builder_custom.overrides.css
+++ b/docroot/modules/custom/layout_builder_custom/css/layout_builder_custom.overrides.css
@@ -49,6 +49,11 @@
   width: 85%!important;
 }
 
+#drupal-off-canvas .ui-autocomplete.linkit-ui-autocomplete .linkit-result-line-wrapper.ui-menu-item-wrapper.ui-state-active,
+#drupal-off-canvas .ui-autocomplete.linkit-ui-autocomplete .linkit-result-line-wrapper.ui-menu-item-wrapper.ui-state-focus  {
+  background: #63666A;
+}
+
 /**
  * Reset first th and td to not be 150px.
  */

--- a/docroot/modules/custom/layout_builder_custom/css/layout_builder_custom.overrides.css
+++ b/docroot/modules/custom/layout_builder_custom/css/layout_builder_custom.overrides.css
@@ -34,6 +34,22 @@
 }
 
 /**
+ * Basic Linkit styles for Layout Builder settings tray.
+ */
+#drupal-off-canvas .ui-autocomplete.linkit-ui-autocomplete .linkit-result-line--group {
+  text-align: center;
+}
+
+#drupal-off-canvas .ui-autocomplete.linkit-ui-autocomplete span:first-child {
+  display: block;
+  font-weight: bold;
+}
+
+#drupal-off-canvas .ui-autocomplete.linkit-ui-autocomplete {
+  width: 85%!important;
+}
+
+/**
  * Reset first th and td to not be 150px.
  */
 #drupal-off-canvas th:first-child,

--- a/docroot/modules/custom/uiowa_core/css/claro-node-form.css
+++ b/docroot/modules/custom/uiowa_core/css/claro-node-form.css
@@ -13,3 +13,9 @@
     width: 35%;
   }
 }
+
+/* Adjust color contrast for linkit hover/focus background. */
+.ui-autocomplete .linkit-result-line-wrapper.ui-menu-item-wrapper.ui-state-active,
+.ui-autocomplete .linkit-result-line-wrapper.ui-menu-item-wrapper.ui-state-focus {
+  background: #63666A;
+}

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -879,6 +879,15 @@ function sitenow_preprocess_node(&$variables) {
  * @throws \Drupal\Core\TypedData\Exception\MissingDataException
  */
 function sitenow_form_menu_link_content_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+
+  // Use Linkit for menu links.
+  $form['#attached']['library'][] = 'linkit/linkit.autocomplete';
+  $form['link']['widget'][0]['#type'] = 'linkit';
+  $form['link']['widget'][0]['#autocomplete_route_name'] = 'linkit.autocomplete';
+  $form['link']['widget'][0]['#autocomplete_route_parameters'] = [
+    'linkit_profile_id' => 'default',
+  ];
+
   $form_object = $form_state->getFormObject();
   if ($form_object instanceof MenuLinkContentForm) {
     $menu_link = $form_object->getEntity();


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/4235

Menu link content support:

<img width="651" alt="258191224-a9b8c6aa-5b25-4f63-8856-c1caa200abdf" src="https://github.com/uiowa/uiowa/assets/4663676/c7558da1-62d1-4fa2-9d87-eddb88f79902">


Layout builder block and paragraphs support:

<img width="608" alt="Screenshot 2023-08-04 at 2 00 45 PM" src="https://github.com/uiowa/uiowa/assets/4663676/e6ea1349-7cca-4340-a9d9-a216b683e914">


# To Test

As an editor, I can get autocomplete content context (linkit) as I start typing for menu links administered through /admin/structure/menu as well as all of the default sitenow v3 block content types (e.g. card, banner, cta) and their nested paragraphs (e.g. timeline item) similar to when using the WYSIWYG.

The following link fields are supported as part of this PR:

menu_link_content link

field_collection_more_path (ui events)
field_uiowa_banner_link
field_uiowa_button_link
field_uiowa_card_link
field_uiowa_cta_link
field_uiowa_event_link
field_uiowa_image_link
field_uiowa_quote_citation (blockquote)
field_timeline_link
field_uiowa_slide_link
