### PR TITLE
Hotfix: Added tabledrag patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -237,7 +237,8 @@
                 "Improve migration system performance: statically cache DrupalSqlBase::$systemData": "https://www.drupal.org/files/issues/2022-01-24/3154156-12.patch",
                 "Allow unpublished nodes in menu selection without bypass permisson": "https://www.drupal.org/files/issues/2023-03-22/2807629-89-d9.patch",
                 "layout_builder__layout_section column hitting database limit": "https://www.drupal.org/files/issues/2021-10-11/3030154-44.patch",
-                "Stable theme's off-canvas reset css causes incorrect box-sizing": "https://www.drupal.org/files/issues/2023-06-13/stable-theme-off-canvas-reset-3340931-15.patch"
+                "Stable theme's off-canvas reset css causes incorrect box-sizing": "https://www.drupal.org/files/issues/2023-06-13/stable-theme-off-canvas-reset-3340931-15.patch",
+                "Tabledrag is broken in layout builder sidebar": "https://www.drupal.org/files/issues/2023-03-23/3316720-tabledrag-broken-layout-builder-12.patch"
             },
             "drupal/default_content": {
                 "Add a Normalizer and Denormalizer to support Layout Builder": "https://www.drupal.org/files/issues/2021-04-07/3160146-37.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0e443564cdff3d4827b3a2b08cd5813",
+    "content-hash": "f03afaff8dc897c8a63ee71c398a807c",
     "packages": [
         {
             "name": "acquia/blt",


### PR DESCRIPTION
As reported by Mike Cranston, the tabledrag icons are broken. 

Drupal issue: https://www.drupal.org/project/drupal/issues/3316720. 

# How to test

```
ddev composer install && ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli /node/1746/layout
```


- Verify accordion block has drag handle
- Click "move" on a block and verify drag handle shows up in tray