### PR TITLE
More Fontawesome: adjusted font awesome library usage

### DIFF
--- a/config/default/fontawesome.settings.yml
+++ b/config/default/fontawesome.settings.yml
@@ -8,10 +8,10 @@ external_svg_location: 'https://use.fontawesome.com/releases/v5.5.0/js/all.js'
 use_shim: false
 external_shim_location: 'https://use.fontawesome.com/releases/v5.5.0/js/v4-shims.js'
 allow_pseudo_elements: false
-use_solid_file: true
+use_solid_file: false
 use_regular_file: true
 use_light_file: false
-use_brands_file: true
+use_brands_file: false
 use_duotone_file: false
 use_thin_file: false
 external_svg_integrity: ''

--- a/config/default/fontawesome.settings.yml
+++ b/config/default/fontawesome.settings.yml
@@ -10,9 +10,9 @@ external_shim_location: 'https://use.fontawesome.com/releases/v5.5.0/js/v4-shims
 allow_pseudo_elements: false
 use_solid_file: true
 use_regular_file: true
-use_light_file: true
+use_light_file: false
 use_brands_file: true
-use_duotone_file: true
-use_thin_file: true
+use_duotone_file: false
+use_thin_file: false
 external_svg_integrity: ''
 bypass_validation: false


### PR DESCRIPTION
After seeing how much JavaScript we are loading in https://github.com/uiowa/uiowa/pull/6737, this pr reduces the amount of libraries being loaded for Fontawesome. 

Since we are fixed at 5.14 in https://github.com/uiowa/uiowa/blob/main/composer.json#L72, we can revisit these settings when we decide to move to 6. 


# How to test

```
ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli /icons
```
- Compare prod with local and verify that the icons remain the same. 