### PR TITLE
Alert Categories Rabbit Hole

### DIFF
--- a/config/default/config_split.config_split.sitenow_alerts.yml
+++ b/config/default/config_split.config_split.sitenow_alerts.yml
@@ -10,6 +10,7 @@ stackable: true
 storage: folder
 folder: ../config/features/sitenow_alerts
 module:
+  rh_taxonomy: 0
   scheduler: 0
   sitenow_alerts: 0
 theme: {  }

--- a/config/features/sitenow_alerts/config_split.patch.user.role.editor.yml
+++ b/config/features/sitenow_alerts/config_split.patch.user.role.editor.yml
@@ -1,0 +1,4 @@
+adding:
+  permissions:
+    - 'rabbit hole bypass taxonomy_term'
+removing: {  }

--- a/config/features/sitenow_alerts/config_split.patch.user.role.publisher.yml
+++ b/config/features/sitenow_alerts/config_split.patch.user.role.publisher.yml
@@ -15,6 +15,7 @@ adding:
     - 'edit own alert content'
     - 'edit terms in alert_categories'
     - 'override alert published option'
+    - 'rabbit hole bypass taxonomy_term'
     - 'schedule publishing of nodes'
     - 'view alert revisions'
 removing: {  }

--- a/config/features/sitenow_alerts/config_split.patch.user.role.webmaster.yml
+++ b/config/features/sitenow_alerts/config_split.patch.user.role.webmaster.yml
@@ -16,6 +16,7 @@ adding:
     - 'edit own alert content'
     - 'edit terms in alert_categories'
     - 'override alert published option'
+    - 'rabbit hole bypass taxonomy_term'
     - 'revert alert revisions'
     - 'schedule publishing of nodes'
     - 'view alert revisions'

--- a/config/features/sitenow_alerts/core.entity_form_display.taxonomy_term.alert_categories.default.yml
+++ b/config/features/sitenow_alerts/core.entity_form_display.taxonomy_term.alert_categories.default.yml
@@ -1,0 +1,51 @@
+uuid: f364a91d-b65f-402e-8b56-3f7eb44c70ab
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.alert_categories
+  module:
+    - path
+    - text
+id: taxonomy_term.alert_categories.default
+targetEntityType: taxonomy_term
+bundle: alert_categories
+mode: default
+content:
+  description:
+    type: text_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 100
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden:
+  publish_on: true
+  unpublish_on: true

--- a/config/features/sitenow_alerts/core.entity_view_display.node.alert.teaser.yml
+++ b/config/features/sitenow_alerts/core.entity_view_display.node.alert.teaser.yml
@@ -29,15 +29,15 @@ content:
       trim_suffix: ...
       wrap_output: false
       wrap_class: trimmed
-      more_link: false
-      more_class: more-link
-      more_text: More
-      more_aria_label: 'Read more about [node:title]'
       summary_handler: full
       trim_options:
         text: false
         trim_zero: false
         replace_tokens: false
+      more_link: false
+      more_class: more-link
+      more_text: More
+      more_aria_label: 'Read more about [node:title]'
     third_party_settings: {  }
     weight: 0
     region: content

--- a/config/features/sitenow_alerts/rabbit_hole.behavior_settings.taxonomy_vocabulary_alert_categories.yml
+++ b/config/features/sitenow_alerts/rabbit_hole.behavior_settings.taxonomy_vocabulary_alert_categories.yml
@@ -1,0 +1,14 @@
+uuid: 53772a31-6ee2-42bb-89b2-62fae45d4ad5
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.alert_categories
+id: taxonomy_vocabulary_alert_categories
+entity_type_id: taxonomy_vocabulary
+entity_id: alert_categories
+action: access_denied
+allow_override: 0
+redirect: ''
+redirect_code: 301
+redirect_fallback_action: access_denied

--- a/config/features/sitenow_alerts/taxonomy.vocabulary.alert_categories.yml
+++ b/config/features/sitenow_alerts/taxonomy.vocabulary.alert_categories.yml
@@ -1,7 +1,23 @@
 uuid: 3896a99a-862b-4e32-9bbd-e61f3e4b264f
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - scheduler
+third_party_settings:
+  scheduler:
+    expand_fieldset: null
+    fields_display_mode: null
+    publish_enable: false
+    publish_past_date: null
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: false
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: 'Alert categories'
 vid: alert_categories
 description: 'For use with the alert content type'


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/6677

# To Test

```
ddev blt di --site=default && ddev drush @default.local config-split:activate sitenow_alerts
```

Go to admin/structure/taxonomy/manage/alert_categories/add and add "Test" then try and go to https://default.uiowa.ddev.site/alert-categories/test as an anonymous user.

```
ddev blt ds --site=facilities.uiowa.edu
```
Confirm there are no sync issues and that the functionality works there as well.

Disregard the config updates for smart trim and scheduler. They are harmless.
