### PR TITLE
OnIowa show all events

### DIFF
--- a/config/sites/oniowa.uiowa.edu/config_split.patch.views.view.events.yml
+++ b/config/sites/oniowa.uiowa.edu/config_split.patch.views.view.events.yml
@@ -2,6 +2,9 @@ adding:
   display:
     default:
       display_options:
+        pager:
+          options:
+            items_per_page: 0
         style:
           options:
             grouping:
@@ -64,4 +67,10 @@ adding:
             date_format: medium
             custom_date_format: ''
             timezone: ''
-removing: {  }
+removing:
+  display:
+    default:
+      display_options:
+        pager:
+          options:
+            items_per_page: 10


### PR DESCRIPTION
Based on standup, we decided to remove the pager/limit from the upcoming events view page for OnIowa.

# To Test

- See that all 180+ events display at once.