### PR TITLE
[ P2LB ] Clear tempstore on con/revert

### DIFF
--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -1534,11 +1534,11 @@ function sitenow_p2lb_clear_tempstore(string $nid): bool {
   $temp_store_repository = \Drupal::service('layout_builder.tempstore_repository');
   $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
   $node_context = EntityContext::fromEntity($node);
-  $plugin = \Drupal::service('plugin.manager.layout_builder.section_storage')
+  $overrides_section_storage = \Drupal::service('plugin.manager.layout_builder.section_storage')
     ->load('overrides', ['entity' => $node_context]);
   // If it exists, clear it out.
-  if ($temp_store_repository->has($plugin)) {
-    $temp_store_repository->delete($plugin);
+  if ($temp_store_repository->has($overrides_section_storage)) {
+    $temp_store_repository->delete($overrides_section_storage);
     return TRUE;
   }
   return FALSE;

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -1478,6 +1478,7 @@ function sitenow_p2lb_block_definition($type, array $fields) {
  * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
  */
 function sitenow_p2lb_get_protected_revision_id(string $nid) {
+
   // Guard against the node id being null.
   if (!$nid) {
     return NULL;
@@ -1510,8 +1511,10 @@ function sitenow_p2lb_get_protected_revision_id(string $nid) {
  * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
  */
 function sitenow_p2lb_get_protected_revision(string $nid): ?RevisionableInterface {
+
   // Get the protected revision id.
   $protected_revision_id = sitenow_p2lb_get_protected_revision_id($nid);
+
   // Return the protected revision or NULL.
   /** @var \Drupal\Core\Entity\RevisionableInterface $revision */
   $revision = \Drupal::entityTypeManager()
@@ -1524,22 +1527,29 @@ function sitenow_p2lb_get_protected_revision(string $nid): ?RevisionableInterfac
 /**
  * Helper function to clear a node's layout builder tempstore.
  *
- * @param string $nid
+ * @param ContentEntityInterface $entity
  *   The id of the node that needs its tempstore cleared.
  *
  * @return bool
  *   Whether there was a tempstore that needed clearing or not.
  */
-function sitenow_p2lb_clear_tempstore(string $nid): bool {
+function sitenow_p2lb_clear_tempstore(ContentEntityInterface $entity): bool {
+
+  // Got hints for how to do this from here.
+  // https://www.drupal.org/node/3012353
   $temp_store_repository = \Drupal::service('layout_builder.tempstore_repository');
-  $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
-  $node_context = EntityContext::fromEntity($node);
+  $entity_context = EntityContext::fromEntity($entity);
+
+  // Our 'plugin' is 'overrides', or the 'unsaved changes' of a node.
   $overrides_section_storage = \Drupal::service('plugin.manager.layout_builder.section_storage')
-    ->load('overrides', ['entity' => $node_context]);
+    ->load('overrides', ['entity' => $entity_context]);
+
   // If it exists, clear it out.
   if ($temp_store_repository->has($overrides_section_storage)) {
     $temp_store_repository->delete($overrides_section_storage);
     return TRUE;
   }
+
+  // Else, return false, signifying no need to clear tempstore.
   return FALSE;
 }

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\RevisionableInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Plugin\Context\EntityContext;
 use Drupal\Core\Url;
 use Drupal\layout_builder\Field\LayoutSectionItemList;
 use Drupal\layout_builder\InlineBlockUsage;
@@ -1530,12 +1531,14 @@ function sitenow_p2lb_get_protected_revision(string $nid): ?RevisionableInterfac
  *   Whether there was a tempstore that needed clearing or not.
  */
 function sitenow_p2lb_clear_tempstore(string $nid): bool {
-  /** @var @var Drupal\Core\KeyValueStore\DatabaseStorageExpirable $data_storage_expirable */
-  $data_storage_expirable = \Drupal::keyValueExpirable('tempstore.shared.layout_builder.section_storage.overrides');
-  $node_string = "node.{$nid}.default.en";
-  // if it exists, clear it out.
-  if ($data_storage_expirable->has($node_string)) {
-    $data_storage_expirable->delete($node_string);
+  $temp_store_repository = \Drupal::service('layout_builder.tempstore_repository');
+  $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
+  $node_context = EntityContext::fromEntity($node);
+  $plugin = \Drupal::service('plugin.manager.layout_builder.section_storage')
+    ->load('overrides', ['entity' => $node_context]);
+  // If it exists, clear it out.
+  if ($temp_store_repository->has($plugin)) {
+    $temp_store_repository->delete($plugin);
     return TRUE;
   }
   return FALSE;

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -1519,3 +1519,24 @@ function sitenow_p2lb_get_protected_revision(string $nid): ?RevisionableInterfac
 
   return $revision;
 }
+
+/**
+ * Helper function to clear a node's layout builder tempstore.
+ *
+ * @param string $nid
+ *   The id of the node that needs its tempstore cleared.
+ *
+ * @return bool
+ *   Whether there was a tempstore that needed clearing or not.
+ */
+function sitenow_p2lb_clear_tempstore(string $nid): bool {
+  /** @var @var Drupal\Core\KeyValueStore\DatabaseStorageExpirable $data_storage_expirable */
+  $data_storage_expirable = \Drupal::keyValueExpirable('tempstore.shared.layout_builder.section_storage.overrides');
+  $node_string = "node.{$nid}.default.en";
+  // if it exists, clear it out.
+  if ($data_storage_expirable->has($node_string)) {
+    $data_storage_expirable->delete($node_string);
+    return TRUE;
+  }
+  return FALSE;
+}

--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -1527,7 +1527,7 @@ function sitenow_p2lb_get_protected_revision(string $nid): ?RevisionableInterfac
 /**
  * Helper function to clear a node's layout builder tempstore.
  *
- * @param ContentEntityInterface $entity
+ * @param \Drupal\Core\Entity\ContentEntityInterface $entity
  *   The id of the node that needs its tempstore cleared.
  *
  * @return bool

--- a/docroot/modules/custom/sitenow_p2lb/src/Plugin/Action/ConvertParagraphsToLayoutBuilder.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/Plugin/Action/ConvertParagraphsToLayoutBuilder.php
@@ -34,6 +34,9 @@ class ConvertParagraphsToLayoutBuilder extends ActionBase {
    */
   public function execute(ContentEntityInterface $entity = NULL) {
     sitenow_p2lb_node_p2lb($entity);
+
+    // Finally, clear the tempstore.
+    sitenow_p2lb_clear_tempstore($entity);
   }
 
 }

--- a/docroot/modules/custom/sitenow_p2lb/src/Plugin/Action/RevertToParagraphs.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/Plugin/Action/RevertToParagraphs.php
@@ -75,6 +75,9 @@ class RevertToParagraphs extends ActionBase {
 
     // Save the new revision.
     $new_revision->save();
+
+    // Finally, clear the tempstore.
+    sitenow_p2lb_clear_tempstore($entity);
   }
 
 }

--- a/docroot/modules/custom/sitenow_p2lb/src/Plugin/Action/RevertToParagraphs.php
+++ b/docroot/modules/custom/sitenow_p2lb/src/Plugin/Action/RevertToParagraphs.php
@@ -77,7 +77,7 @@ class RevertToParagraphs extends ActionBase {
     $new_revision->save();
 
     // Finally, clear the tempstore.
-    sitenow_p2lb_clear_tempstore($entity);
+    sitenow_p2lb_clear_tempstore($new_revision);
   }
 
 }


### PR DESCRIPTION

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt ds --site hawkeyemarchingband.uiowa.edu && ddev drush @hawkeyemarchingband.local config-split:activate p2lb -y && ddev drush @hawkeyemarchingband.local cim -y && ddev drush @hawkeyemarchingband.local uli
```

1. Sync down a v2 site of your choice, we used hawkeyemarchingband
2. Enable p2lb
4. Change the layout on two pages
3. Convert those two pages
13. Neither of them should have the "You have unsaved changes" message on the LB page. 
5. on the first page  
    a. publish it
    b make a change
8. On the second page. 
    a. leave it draft
    b. make a change 
11. they should both say "You have unsaved changes" on the LB page
12. Revert them both
13. Neither of them should have the "You have unsaved changes" message on the LB page. 
