### PR TITLE
Rollback Linkit Expansion

### DIFF
--- a/config/default/core.entity_form_display.block_content.uiowa_banner.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_banner.default.yml
@@ -45,7 +45,7 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_uiowa_banner_link:
-    type: link
+    type: link_default
     weight: 4
     region: content
     settings:

--- a/config/default/core.entity_form_display.block_content.uiowa_banner.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_banner.default.yml
@@ -12,7 +12,7 @@ dependencies:
     - field.field.block_content.uiowa_banner.field_uiowa_banner_title
   module:
     - heading
-    - linkit
+    - link
     - media_library
     - text
 _core:
@@ -45,14 +45,12 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_uiowa_banner_link:
-    type: linkit
+    type: link
     weight: 4
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
-      linkit_auto_link_text: false
     third_party_settings: {  }
   field_uiowa_banner_pre_title:
     type: string_textfield

--- a/config/default/core.entity_form_display.block_content.uiowa_button.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_button.default.yml
@@ -6,21 +6,19 @@ dependencies:
     - block_content.type.uiowa_button
     - field.field.block_content.uiowa_button.field_uiowa_button_link
   module:
-    - linkit
+    - link
 id: block_content.uiowa_button.default
 targetEntityType: block_content
 bundle: uiowa_button
 mode: default
 content:
   field_uiowa_button_link:
-    type: linkit
+    type: link
     weight: 26
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
-      linkit_auto_link_text: false
     third_party_settings: {  }
   info:
     type: string_textfield

--- a/config/default/core.entity_form_display.block_content.uiowa_button.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_button.default.yml
@@ -13,7 +13,7 @@ bundle: uiowa_button
 mode: default
 content:
   field_uiowa_button_link:
-    type: link
+    type: link_default
     weight: 26
     region: content
     settings:

--- a/config/default/core.entity_form_display.block_content.uiowa_card.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_card.default.yml
@@ -12,7 +12,7 @@ dependencies:
     - field.field.block_content.uiowa_card.field_uiowa_card_title
   module:
     - heading
-    - linkit
+    - link
     - media_library
     - text
 _core:
@@ -52,14 +52,12 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_uiowa_card_link:
-    type: linkit
+    type: link
     weight: 4
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
-      linkit_auto_link_text: false
     third_party_settings: {  }
   field_uiowa_card_title:
     type: heading

--- a/config/default/core.entity_form_display.block_content.uiowa_card.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_card.default.yml
@@ -52,7 +52,7 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_uiowa_card_link:
-    type: link
+    type: link_default
     weight: 4
     region: content
     settings:

--- a/config/default/core.entity_form_display.block_content.uiowa_cta.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_cta.default.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.block_content.uiowa_cta.field_uiowa_cta_title
   module:
     - heading
-    - linkit
+    - link
     - text
 _core:
   default_config_hash: C9SWoj32dA5WxftU5KLg_gWozCyQ0406EElZdchIyZo
@@ -19,14 +19,12 @@ bundle: uiowa_cta
 mode: default
 content:
   field_uiowa_cta_link:
-    type: linkit
+    type: link
     weight: 29
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
-      linkit_auto_link_text: false
     third_party_settings: {  }
   field_uiowa_cta_summary:
     type: text_textarea

--- a/config/default/core.entity_form_display.block_content.uiowa_cta.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_cta.default.yml
@@ -19,7 +19,7 @@ bundle: uiowa_cta
 mode: default
 content:
   field_uiowa_cta_link:
-    type: link
+    type: link_default
     weight: 29
     region: content
     settings:

--- a/config/default/core.entity_form_display.block_content.uiowa_event.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_event.default.yml
@@ -14,7 +14,7 @@ dependencies:
     - datetime
     - fontawesome
     - heading
-    - linkit
+    - link
     - media_library
 id: block_content.uiowa_event.default
 targetEntityType: block_content
@@ -41,14 +41,12 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_uiowa_event_link:
-    type: linkit
+    type: link
     weight: 31
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
-      linkit_auto_link_text: false
     third_party_settings: {  }
   field_uiowa_event_location:
     type: string_textfield

--- a/config/default/core.entity_form_display.block_content.uiowa_event.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_event.default.yml
@@ -41,7 +41,7 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_uiowa_event_link:
-    type: link
+    type: link_default
     weight: 31
     region: content
     settings:

--- a/config/default/core.entity_form_display.block_content.uiowa_events.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_events.default.yml
@@ -35,7 +35,7 @@ content:
       display_label: true
     third_party_settings: {  }
   field_collection_more_path:
-    type: link
+    type: link_default
     weight: 15
     region: content
     settings:

--- a/config/default/core.entity_form_display.block_content.uiowa_events.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_events.default.yml
@@ -20,7 +20,7 @@ dependencies:
     - field.field.block_content.uiowa_events.field_uiowa_headline
   module:
     - layout_builder_custom
-    - linkit
+    - link
     - smart_date
 id: block_content.uiowa_events.default
 targetEntityType: block_content
@@ -35,14 +35,12 @@ content:
       display_label: true
     third_party_settings: {  }
   field_collection_more_path:
-    type: linkit
+    type: link
     weight: 15
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
-      linkit_auto_link_text: false
     third_party_settings: {  }
   field_collection_pager:
     type: boolean_checkbox

--- a/config/default/core.entity_form_display.block_content.uiowa_image.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_image.default.yml
@@ -22,7 +22,7 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_uiowa_image_link:
-    type: link
+    type: link_default
     weight: 2
     region: content
     settings:

--- a/config/default/core.entity_form_display.block_content.uiowa_image.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_image.default.yml
@@ -7,7 +7,7 @@ dependencies:
     - field.field.block_content.uiowa_image.field_uiowa_image_image
     - field.field.block_content.uiowa_image.field_uiowa_image_link
   module:
-    - linkit
+    - link
     - media_library
 id: block_content.uiowa_image.default
 targetEntityType: block_content
@@ -22,14 +22,12 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_uiowa_image_link:
-    type: linkit
+    type: link
     weight: 2
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
-      linkit_auto_link_text: false
     third_party_settings: {  }
   info:
     type: string_textfield

--- a/config/default/core.entity_form_display.block_content.uiowa_quote.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_quote.default.yml
@@ -19,7 +19,7 @@ bundle: uiowa_quote
 mode: default
 content:
   field_uiowa_quote_citation:
-    type: link
+    type: link_default
     weight: 28
     region: content
     settings:

--- a/config/default/core.entity_form_display.block_content.uiowa_quote.default.yml
+++ b/config/default/core.entity_form_display.block_content.uiowa_quote.default.yml
@@ -10,7 +10,7 @@ dependencies:
     - field.field.block_content.uiowa_quote.field_uiowa_quote_image
   module:
     - allowed_formats
-    - linkit
+    - link
     - media_library
     - text
 id: block_content.uiowa_quote.default
@@ -19,14 +19,12 @@ bundle: uiowa_quote
 mode: default
 content:
   field_uiowa_quote_citation:
-    type: linkit
+    type: link
     weight: 28
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
-      linkit_auto_link_text: false
     third_party_settings: {  }
   field_uiowa_quote_content:
     type: text_textarea

--- a/config/default/core.entity_form_display.paragraph.uiowa_slide.default.yml
+++ b/config/default/core.entity_form_display.paragraph.uiowa_slide.default.yml
@@ -41,7 +41,7 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_uiowa_slide_link:
-    type: link
+    type: link_default
     weight: 2
     region: content
     settings:

--- a/config/default/core.entity_form_display.paragraph.uiowa_slide.default.yml
+++ b/config/default/core.entity_form_display.paragraph.uiowa_slide.default.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.paragraph.uiowa_slide.field_uiowa_slide_link
     - paragraphs.paragraphs_type.uiowa_slide
   module:
-    - linkit
+    - link
     - media_library
     - text
 id: paragraph.uiowa_slide.default
@@ -41,14 +41,12 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_uiowa_slide_link:
-    type: linkit
+    type: link
     weight: 2
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
-      linkit_auto_link_text: false
     third_party_settings: {  }
 hidden:
   created: true

--- a/config/default/core.entity_form_display.paragraph.uiowa_timeline_item.default.yml
+++ b/config/default/core.entity_form_display.paragraph.uiowa_timeline_item.default.yml
@@ -51,7 +51,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_timeline_link:
-    type: link
+    type: link_default
     weight: 4
     region: content
     settings:

--- a/config/default/core.entity_form_display.paragraph.uiowa_timeline_item.default.yml
+++ b/config/default/core.entity_form_display.paragraph.uiowa_timeline_item.default.yml
@@ -12,7 +12,7 @@ dependencies:
     - paragraphs.paragraphs_type.uiowa_timeline_item
   module:
     - fontawesome
-    - linkit
+    - link
     - media_library
     - text
 id: paragraph.uiowa_timeline_item.default
@@ -51,14 +51,12 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_timeline_link:
-    type: linkit
+    type: link
     weight: 4
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
-      linkit_profile: default
-      linkit_auto_link_text: false
     third_party_settings: {  }
   field_timeline_media:
     type: media_library_widget

--- a/docroot/modules/custom/layout_builder_custom/css/layout_builder_custom.overrides.css
+++ b/docroot/modules/custom/layout_builder_custom/css/layout_builder_custom.overrides.css
@@ -34,27 +34,6 @@
 }
 
 /**
- * Basic Linkit styles for Layout Builder settings tray.
- */
-#drupal-off-canvas .ui-autocomplete.linkit-ui-autocomplete .linkit-result-line--group {
-  text-align: center;
-}
-
-#drupal-off-canvas .ui-autocomplete.linkit-ui-autocomplete span:first-child {
-  display: block;
-  font-weight: bold;
-}
-
-#drupal-off-canvas .ui-autocomplete.linkit-ui-autocomplete {
-  width: 85%!important;
-}
-
-#drupal-off-canvas .ui-autocomplete.linkit-ui-autocomplete .linkit-result-line-wrapper.ui-menu-item-wrapper.ui-state-active,
-#drupal-off-canvas .ui-autocomplete.linkit-ui-autocomplete .linkit-result-line-wrapper.ui-menu-item-wrapper.ui-state-focus  {
-  background: #63666A;
-}
-
-/**
  * Reset first th and td to not be 150px.
  */
 #drupal-off-canvas th:first-child,

--- a/docroot/modules/custom/uiowa_core/css/claro-node-form.css
+++ b/docroot/modules/custom/uiowa_core/css/claro-node-form.css
@@ -13,9 +13,3 @@
     width: 35%;
   }
 }
-
-/* Adjust color contrast for linkit hover/focus background. */
-.ui-autocomplete .linkit-result-line-wrapper.ui-menu-item-wrapper.ui-state-active,
-.ui-autocomplete .linkit-result-line-wrapper.ui-menu-item-wrapper.ui-state-focus {
-  background: #63666A;
-}

--- a/docroot/profiles/custom/sitenow/sitenow.profile
+++ b/docroot/profiles/custom/sitenow/sitenow.profile
@@ -879,15 +879,6 @@ function sitenow_preprocess_node(&$variables) {
  * @throws \Drupal\Core\TypedData\Exception\MissingDataException
  */
 function sitenow_form_menu_link_content_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
-
-  // Use Linkit for menu links.
-  $form['#attached']['library'][] = 'linkit/linkit.autocomplete';
-  $form['link']['widget'][0]['#type'] = 'linkit';
-  $form['link']['widget'][0]['#autocomplete_route_name'] = 'linkit.autocomplete';
-  $form['link']['widget'][0]['#autocomplete_route_parameters'] = [
-    'linkit_profile_id' => 'default',
-  ];
-
   $form_object = $form_state->getFormObject();
   if ($form_object instanceof MenuLinkContentForm) {
     $menu_link = $form_object->getEntity();


### PR DESCRIPTION
Mirrored removal of https://github.com/uiowa/uiowa/pull/6742 (minus a few general config updates)

# To Test

As an editor, I everything related to menu links and block type/paragraph link fields is working as it has been and that I can create `<nolink>` `<front>` links with no issue.