### PR TITLE
Fixes featured content headline bug

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -1189,18 +1189,10 @@ function layout_builder_custom_preprocess_block__inline_block__featured_content(
     if ($target) {
       $entity = $target->getEntity();
 
-      // Associate the block's cache tags with each entity so that the
-      // appropriate render cache ID is cleared when the block changes.
-      $cache_tags = $block->getCacheTags();
-      $entity->addCacheTags($cache_tags);
-      // Grab a fresh copy of the node.
-      $id = $entity->id();
-      Cache::invalidateTags(['node:' . $id]);
-
       // Construct the entity teaser markup manually to pass in the heading
       // size variable for the template and append it to the block content.
       $build = \Drupal::entityTypeManager()->getViewBuilder($entity->getEntityTypeId())->view($entity, 'teaser');
-      $build['#heading_size'] = $heading_size;
+      $build['#title_heading_size'] = $heading_size;
       $render = \Drupal::service('renderer')->render($build);
 
       $variables['content']['referenced_items'][] = [


### PR DESCRIPTION
Resolves #6792 

# How to test
```
ddev blt ds --site sandbox.uiowa.edu && ddev drush @sandbox.local uli featured-content
```
- Confirm that existing featured content block items use the appropriate h tag (one level below the headline)
- Add a new block, update existing blocks, anything else you can think of to ensure that this works across the board

## Removal of logic from #3715
- Review #3715 and https://github.com/uiowa/uiowa/issues/3558#issuecomment-868700956
- Test by creating/editing multiple pages that use article lists, people lists, and featured content that include the same nodes with settings that cause the headline to be a different size.
- Confirm that all node item headlines in each type of list display the correct size headline in all instances and across updates and additions of new blocks.