### PR TITLE
ITS - Site Split and Service Content Type

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -42,6 +42,8 @@ Deploy the code changes to each environment per the normal process and import
 the configuration from the split manually.
 ```drush @mysite.dev config:import --source ../config/sites/mysite.uiowa.edu --partial```
 
+You may have to run `cim` and `cr` after the partial import for certain config like a moderation_control block to register.
+
 ## Caveats
 **DO NOT** split core.extension for your site. This will only lead to problems.
 You can complete-split individual modules that your site needs and Config

--- a/config/sites/its.uiowa.edu/.htaccess
+++ b/config/sites/its.uiowa.edu/.htaccess
@@ -1,0 +1,27 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>
+<IfModule mod_php.c>
+  php_flag engine off
+</IfModule>

--- a/config/sites/its.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/its.uiowa.edu/config_split.config_split.site.yml
@@ -1,0 +1,25 @@
+uuid: 8ff40ace-a53a-4a73-a2bd-f9a086b7d9e1
+langcode: en
+status: true
+dependencies: {  }
+id: site
+label: Site
+description: 'The its.uiowa.edu site split.'
+weight: 70
+stackable: true
+storage: folder
+folder: ../config/sites/its.uiowa.edu
+module: {  }
+theme: {  }
+complete_list:
+  - config_split.config_split.site
+  - metatag.metatag_defaults.node__service
+  - node.type.service
+  - schemadotorg.schemadotorg_mapping.node.service
+  - simple_sitemap.bundle_settings.default.node.service
+  - 'core.entity_view_display.node.service.*'
+  - 'core.entity_form_display.node.service.*'
+partial_list:
+  - metatag.settings
+  - workflows.workflow.editorial
+  - 'user.role.*'

--- a/config/sites/its.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/its.uiowa.edu/config_split.config_split.site.yml
@@ -15,6 +15,7 @@ complete_list:
   - config_split.config_split.site
   - metatag.metatag_defaults.node__service
   - node.type.service
+  - pathauto.pattern.service
   - schemadotorg.schemadotorg_mapping.node.service
   - simple_sitemap.bundle_settings.default.node.service
   - 'core.entity_view_display.node.service.*'

--- a/config/sites/its.uiowa.edu/config_split.patch.metatag.settings.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.metatag.settings.yml
@@ -1,0 +1,10 @@
+adding:
+  entity_type_groups:
+    node:
+      service:
+        basic: basic
+        advanced: advanced
+        open_graph: open_graph
+        twitter_cards: twitter_cards
+  tag_scroll_max_height: ''
+removing: {  }

--- a/config/sites/its.uiowa.edu/config_split.patch.user.role.editor.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.user.role.editor.yml
@@ -1,0 +1,15 @@
+adding:
+  dependencies:
+    config:
+      - node.type.service
+  permissions:
+    - 'create service content'
+    - 'delete own service content'
+    - 'delete service revisions'
+    - 'edit any service content'
+    - 'edit own service content'
+    - 'enter service revision log entry'
+    - 'override service published option'
+    - 'revert service revisions'
+    - 'view service revisions'
+removing: {  }

--- a/config/sites/its.uiowa.edu/config_split.patch.user.role.publisher.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.user.role.publisher.yml
@@ -1,0 +1,16 @@
+adding:
+  dependencies:
+    config:
+      - node.type.service
+  permissions:
+    - 'create service content'
+    - 'delete any service content'
+    - 'delete own service content'
+    - 'delete service revisions'
+    - 'edit any service content'
+    - 'edit own service content'
+    - 'enter service revision log entry'
+    - 'override service published option'
+    - 'revert service revisions'
+    - 'view service revisions'
+removing: {  }

--- a/config/sites/its.uiowa.edu/config_split.patch.user.role.viewer.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.user.role.viewer.yml
@@ -1,0 +1,8 @@
+adding:
+  dependencies:
+    config:
+      - node.type.service
+  permissions:
+    - 'enter service revision log entry'
+    - 'view service revisions'
+removing: {  }

--- a/config/sites/its.uiowa.edu/config_split.patch.user.role.webmaster.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.user.role.webmaster.yml
@@ -1,0 +1,19 @@
+adding:
+  dependencies:
+    config:
+      - node.type.service
+  permissions:
+    - 'create service content'
+    - 'delete any service content'
+    - 'delete own service content'
+    - 'delete service revisions'
+    - 'edit any service content'
+    - 'edit own service content'
+    - 'enter service revision log entry'
+    - 'override service authored by option'
+    - 'override service authored on option'
+    - 'override service published option'
+    - 'override service revision option'
+    - 'revert service revisions'
+    - 'view service revisions'
+removing: {  }

--- a/config/sites/its.uiowa.edu/config_split.patch.workflows.workflow.editorial.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.workflows.workflow.editorial.yml
@@ -1,0 +1,9 @@
+adding:
+  dependencies:
+    config:
+      - node.type.service
+  type_settings:
+    entity_types:
+      node:
+        - service
+removing: {  }

--- a/config/sites/its.uiowa.edu/core.base_field_override.node.service.promote.yml
+++ b/config/sites/its.uiowa.edu/core.base_field_override.node.service.promote.yml
@@ -1,0 +1,22 @@
+uuid: 346a95d9-7274-4444-a8e0-5dad47d55675
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.service
+id: node.service.promote
+field_name: promote
+entity_type: node
+bundle: service
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sites/its.uiowa.edu/core.entity_form_display.node.service.default.yml
+++ b/config/sites/its.uiowa.edu/core.entity_form_display.node.service.default.yml
@@ -1,0 +1,104 @@
+uuid: 2199903d-9f18-4d5a-802b-a6f88167e8cd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.service.body
+    - field.field.node.service.field_meta_tags
+    - node.type.service
+  module:
+    - content_moderation
+    - metatag
+    - path
+    - text
+id: node.service.default
+targetEntityType: node
+bundle: service
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 4
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_meta_tags:
+    type: metatag_firehose
+    weight: 121
+    region: content
+    settings:
+      sidebar: true
+      use_details: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 15
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 120
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 16
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sites/its.uiowa.edu/core.entity_view_display.node.service.default.yml
+++ b/config/sites/its.uiowa.edu/core.entity_view_display.node.service.default.yml
@@ -1,0 +1,75 @@
+uuid: 7a8827b9-1ccc-48a9-bb1c-bcc35afadfa6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.service.body
+    - field.field.node.service.field_meta_tags
+    - node.type.service
+  module:
+    - layout_builder
+    - text
+    - user
+  theme:
+    - uids_base
+third_party_settings:
+  layout_builder:
+    enabled: true
+    allow_custom: false
+    sections:
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: ''
+        components:
+          -
+            uuid: 935aa0ea-f15f-4e36-871f-f06b5f7eaa4c
+            region: content
+            configuration:
+              id: 'field_block:node:service:body'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              formatter:
+                type: text_default
+                label: above
+                settings: {  }
+                third_party_settings: {  }
+            weight: 0
+            additional: {  }
+            third_party_settings: {  }
+          -
+            uuid: 233ef287-9669-4d88-9b5e-571ab5262e61
+            region: content
+            configuration:
+              id: 'extra_field_block:node:service:links'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+            weight: 1
+            additional: {  }
+            third_party_settings: {  }
+        third_party_settings: {  }
+id: node.service.default
+targetEntityType: node
+bundle: service
+mode: default
+content:
+  body:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
+  field_meta_tags: true
+  search_api_excerpt: true

--- a/config/sites/its.uiowa.edu/core.entity_view_display.node.service.default.yml
+++ b/config/sites/its.uiowa.edu/core.entity_view_display.node.service.default.yml
@@ -20,6 +20,63 @@ third_party_settings:
       -
         layout_id: layout_onecol
         layout_settings:
+          label: 'Moderation control'
+          context_mapping: {  }
+          layout_builder_styles_style:
+            0: ''
+            1: section_container_narrow
+            section_margin_remove_default_margins: section_margin_remove_default_margins
+        components:
+          -
+            uuid: 44d64f4f-f5cb-414c-9668-f1bd67427663
+            region: content
+            configuration:
+              id: 'extra_field_block:node:service:content_moderation_control'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+            weight: 2
+            additional: {  }
+            third_party_settings: {  }
+        third_party_settings:
+          layout_builder_lock:
+            lock: {  }
+      -
+        layout_id: layout_header
+        layout_settings:
+          label: Header
+          context_mapping: {  }
+          layout_builder_styles_style:
+            0: ''
+            1: section_margin_edge_to_edge
+            remove_default_bottom_padding: remove_default_bottom_padding
+        components:
+          -
+            uuid: 6eced04f-8ad2-4f0b-8c74-39dc9d58709b
+            region: content
+            configuration:
+              id: 'field_block:node:service:title'
+              label: null
+              label_display: null
+              provider: layout_builder
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+              formatter:
+                type: string
+                label: hidden
+                settings:
+                  link_to_entity: false
+                third_party_settings: {  }
+            weight: -2
+            additional: {  }
+            third_party_settings: {  }
+        third_party_settings:
+          layout_builder_lock:
+            lock: {  }
+      -
+        layout_id: layout_onecol
+        layout_settings:
           label: ''
         components:
           -
@@ -38,17 +95,6 @@ third_party_settings:
             weight: 0
             additional: {  }
             third_party_settings: {  }
-          -
-            uuid: 233ef287-9669-4d88-9b5e-571ab5262e61
-            region: content
-            configuration:
-              id: 'extra_field_block:node:service:links'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-            weight: 1
-            additional: {  }
-            third_party_settings: {  }
         third_party_settings: {  }
 id: node.service.default
 targetEntityType: node
@@ -61,6 +107,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 0
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
     region: content
   links:
     settings: {  }

--- a/config/sites/its.uiowa.edu/core.entity_view_display.node.service.teaser.yml
+++ b/config/sites/its.uiowa.edu/core.entity_view_display.node.service.teaser.yml
@@ -1,0 +1,36 @@
+uuid: 030a3554-f3e0-42dd-b034-76c791293ff3
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.service.body
+    - field.field.node.service.field_meta_tags
+    - node.type.service
+  module:
+    - text
+    - user
+id: node.service.teaser
+targetEntityType: node
+bundle: service
+mode: teaser
+content:
+  body:
+    type: text_summary_or_trimmed
+    label: hidden
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
+  field_meta_tags: true
+  search_api_excerpt: true

--- a/config/sites/its.uiowa.edu/field.field.node.service.body.yml
+++ b/config/sites/its.uiowa.edu/field.field.node.service.body.yml
@@ -1,0 +1,23 @@
+uuid: 55341e5b-e53a-4496-ab7e-2a9883ae5044
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.service
+  module:
+    - text
+id: node.service.body
+field_name: body
+entity_type: node
+bundle: service
+label: Description
+description: 'A description of the item.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/config/sites/its.uiowa.edu/field.field.node.service.body.yml
+++ b/config/sites/its.uiowa.edu/field.field.node.service.body.yml
@@ -6,7 +6,11 @@ dependencies:
     - field.storage.node.body
     - node.type.service
   module:
+    - allowed_formats
     - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats: {  }
 id: node.service.body
 field_name: body
 entity_type: node
@@ -18,6 +22,6 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  display_summary: false
+  display_summary: true
   required_summary: false
 field_type: text_with_summary

--- a/config/sites/its.uiowa.edu/field.field.node.service.field_meta_tags.yml
+++ b/config/sites/its.uiowa.edu/field.field.node.service.field_meta_tags.yml
@@ -1,0 +1,21 @@
+uuid: 0c28ce35-28e4-40e7-99fa-681a5bc49721
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.service
+  module:
+    - metatag
+id: node.service.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: service
+label: 'SEO Settings'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/config/sites/its.uiowa.edu/metatag.metatag_defaults.node__service.yml
+++ b/config/sites/its.uiowa.edu/metatag.metatag_defaults.node__service.yml
@@ -7,3 +7,4 @@ label: 'Content: Service'
 tags:
   description: '[node:summary]'
   og_description: '[node:summary]'
+  twitter_cards_description: '[node:summary]'

--- a/config/sites/its.uiowa.edu/metatag.metatag_defaults.node__service.yml
+++ b/config/sites/its.uiowa.edu/metatag.metatag_defaults.node__service.yml
@@ -1,0 +1,9 @@
+uuid: 626e08fd-e415-4cc7-9d2f-b7bc3a2f0e3c
+langcode: en
+status: true
+dependencies: {  }
+id: node__service
+label: 'Content: Service'
+tags:
+  description: '[node:body]'
+  og_description: '[node:body]'

--- a/config/sites/its.uiowa.edu/metatag.metatag_defaults.node__service.yml
+++ b/config/sites/its.uiowa.edu/metatag.metatag_defaults.node__service.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: node__service
 label: 'Content: Service'
 tags:
-  description: '[node:body]'
-  og_description: '[node:body]'
+  description: '[node:summary]'
+  og_description: '[node:summary]'

--- a/config/sites/its.uiowa.edu/node.type.service.yml
+++ b/config/sites/its.uiowa.edu/node.type.service.yml
@@ -1,0 +1,31 @@
+uuid: bc8ff14f-aeae-42a9-adc8-8a81d527bf4c
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+    - node_revision_delete
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+  node_revision_delete:
+    amount:
+      status: true
+      settings:
+        amount: 10
+    created:
+      status: false
+      settings:
+        age: 1
+    drafts:
+      status: false
+      settings:
+        age: 1
+name: Service
+type: service
+description: 'Use <em>service</em> to provide information about ITS services, e.g. UI Wireless, HawkID, etc.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/config/sites/its.uiowa.edu/pathauto.pattern.service.yml
+++ b/config/sites/its.uiowa.edu/pathauto.pattern.service.yml
@@ -1,0 +1,22 @@
+uuid: 81efbe26-4c86-4e4e-bddb-839bb6bf0e15
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: service
+label: Service
+type: 'canonical_entities:node'
+pattern: 'services/[node:title]'
+selection_criteria:
+  c91a1e78-e6be-45b2-ac2a-ff6170259e4f:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: c91a1e78-e6be-45b2-ac2a-ff6170259e4f
+    context_mapping:
+      node: node
+    bundles:
+      service: service
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/config/sites/its.uiowa.edu/rabbit_hole.behavior_settings.node_type_service.yml
+++ b/config/sites/its.uiowa.edu/rabbit_hole.behavior_settings.node_type_service.yml
@@ -1,0 +1,14 @@
+uuid: 41f8b6c4-edfd-4756-8dac-9b9ad4ead7c6
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.service
+id: node_type_service
+entity_type_id: node_type
+entity_id: service
+action: display_page
+allow_override: 1
+redirect: ''
+redirect_code: 301
+redirect_fallback_action: access_denied

--- a/config/sites/its.uiowa.edu/schemadotorg.schemadotorg_mapping.node.service.yml
+++ b/config/sites/its.uiowa.edu/schemadotorg.schemadotorg_mapping.node.service.yml
@@ -1,0 +1,14 @@
+uuid: 125da24a-f4db-42e2-91a5-b618bd84eaac
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.service.body
+    - node.type.service
+id: node.service
+target_entity_type_id: node
+target_bundle: service
+schema_type: Service
+schema_properties:
+  body: description
+  title: name

--- a/config/sites/its.uiowa.edu/simple_sitemap.bundle_settings.default.node.service.yml
+++ b/config/sites/its.uiowa.edu/simple_sitemap.bundle_settings.default.node.service.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/6666

# To Test

```
ddev blt ds --site=its.uiowa.edu && ddev drush @its.local config:import --source ../config/sites/its.uiowa.edu --partial && ddev drush @its.local cim && ddev drush @its.local cr && ddev drush @its.local uli admin/structure/types/manage/service/display/default/layout
```

- Upon `uli`, you should see the moderation control block within the layout builder display settings without errors.
- As an editor/publisher/webmaster, you can add/edit any service.
- As a publisher/webmaster, you can delete a service. As an editor, you can delete your own service.
- Basic metatag and schema.org ([Service](https://schema.org/Service)) output should be present in the DOM.
- Alias should match the /services/[node:title] pattern as discussed here: https://github.com/uiowa/uiowa/pull/6801#issuecomment-1686991745
