### PR TITLE
Re-exported schemadotorg config

### DIFF
--- a/config/default/schemadotorg.schemadotorg_mapping_type.block_content.yml
+++ b/config/default/schemadotorg.schemadotorg_mapping_type.block_content.yml
@@ -17,7 +17,6 @@ recommended_schema_types:
 default_schema_types:
   basic: WebContent
 default_schema_type_properties: {  }
-default_schema_type_view_displays: {  }
 default_base_fields:
   uuid: {  }
   info:
@@ -29,5 +28,3 @@ default_base_fields:
     - dateModified
   langcode:
     - inLanguage
-default_component_weights:
-  langcode: 200

--- a/config/default/schemadotorg.schemadotorg_mapping_type.media.yml
+++ b/config/default/schemadotorg.schemadotorg_mapping_type.media.yml
@@ -25,7 +25,6 @@ default_schema_type_properties:
   MediaObject:
     - dateCreated
     - dateModified
-default_schema_type_view_displays: {  }
 default_base_fields:
   path: {  }
   revision_created: {  }
@@ -55,14 +54,3 @@ default_base_fields:
   field_media_video_file:
     - video
     - contentUrl
-default_component_weights:
-  field_media_audio_file: 0
-  field_media_document: 0
-  field_media_image: 0
-  field_media_oembed_video: 0
-  field_media_video_file: 0
-  langcode: 200
-  created: 200
-  uid: 200
-  status: 200
-  path: 210

--- a/config/default/schemadotorg.schemadotorg_mapping_type.node.yml
+++ b/config/default/schemadotorg.schemadotorg_mapping_type.node.yml
@@ -103,38 +103,6 @@ default_schema_type_properties:
     - '-name'
     - '-text'
     - articleBody
-default_schema_type_view_displays:
-  teaser:
-    Thing:
-      - description
-    Event:
-      - eventSchedule
-      - startDate
-      - endDate
-    Person:
-      - image
-    Place:
-      - image
-      - address
-    LocalBusiness:
-      - openingHours
-    Episode:
-      - duration
-      - episodeNumber
-    Hospital:
-      - availableService
-    MedicalOrganization:
-      - medicalSpecialty
-    MedicalClinic:
-      - availableService
-    Physician:
-      - availableService
-      - medicalSpecialty
-    JobPosting:
-      - datePosted
-    Recipe:
-      - image
-      - cookTime
 default_base_fields:
   uuid: {  }
   revision_uid: {  }
@@ -158,18 +126,3 @@ default_base_fields:
     - dateModified
   field_tags:
     - keywords
-default_component_weights:
-  langcode: 200
-  links: 200
-  uid: 200
-  created: 200
-  promote: 210
-  sticky: 210
-  publish_on: 210
-  publish_state: 210
-  unpublish_on: 210
-  unpublish_state: 210
-  moderation_state: 210
-  simple_sitemap: 220
-  path: 220
-  status: 220

--- a/config/default/schemadotorg.schemadotorg_mapping_type.user.yml
+++ b/config/default/schemadotorg.schemadotorg_mapping_type.user.yml
@@ -11,7 +11,6 @@ recommended_schema_types: {  }
 default_schema_types:
   user: Person
 default_schema_type_properties: {  }
-default_schema_type_view_displays: {  }
 default_base_fields:
   uuid: {  }
   langcode:
@@ -22,7 +21,3 @@ default_base_fields:
     - email
   user_picture:
     - image
-default_component_weights:
-  user_picture: 0
-  langcode: 200
-  member_for: 200

--- a/config/default/schemadotorg.settings.yml
+++ b/config/default/schemadotorg.settings.yml
@@ -1,21 +1,7 @@
 _core:
   default_config_hash: kVLaNV10JOymh1CXy3n1pxRP-ccd3Vcd-ndShhRpDag
 field_prefix: field_
-field_prefix_ui: false
 schema_types:
-  default_types:
-    WebPage:
-      name: page
-      label: Page
-    FAQPage:
-      name: faq
-      label: FAQ
-    QAPage:
-      name: qa
-      label: 'Q&A'
-    MedicalClinic:
-      name: clinic
-      label: Clinic
   main_properties:
     AudioObject: null
     Comment: text
@@ -689,6 +675,19 @@ schema_types:
       - text
       - text_long
       - text_with_summary
+  default_types:
+    WebPage:
+      name: page
+      label: Page
+    FAQPage:
+      name: faq
+      label: FAQ
+    QAPage:
+      name: qa
+      label: 'Q&A'
+    MedicalClinic:
+      name: clinic
+      label: Clinic
 schema_properties:
   range_includes:
     FAQPage--mainEntity:
@@ -1222,7 +1221,6 @@ schema_properties:
     nsn:
       label: 'NATO Stock Number (NSN)'
       max_length: 13
-  default_field_types: {  }
   default_field_weights:
     - subtype
     - name
@@ -1313,3 +1311,5 @@ schema_properties:
     - relatedLink
     - hasPart
     - mainEntity
+  default_field_types: {  }
+field_prefix_ui: false


### PR DESCRIPTION
I noticed a config status warning when syncing a site. It led me to re-exporting config, which is what this update includes.

# How to test

```
ddev blt ds
```
- Ensure no config status errors.