### PR TITLE
lb_direct_add config fix

### DIFF
--- a/config/default/lb_direct_add.settings.yml
+++ b/config/default/lb_direct_add.settings.yml
@@ -1,2 +1,2 @@
-use_label: '1'
+use_label: 1
 label: 'Add component'


### PR DESCRIPTION
# To Test

```
ddev blt ds --site=admissions.uiowa.edu
```

```
ddev blt ds --site=iowajpec.org
```

Both should be successful with config imports. On `main`, iowajpec.org has a config issue with lb_direct_add