### PR TITLE
[ITS] Service content type permission updates

### DIFF
--- a/config/sites/its.uiowa.edu/config_split.patch.user.role.editor.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.user.role.editor.yml
@@ -3,8 +3,6 @@ adding:
     config:
       - node.type.service
   permissions:
-    - 'create service content'
-    - 'delete own service content'
     - 'delete service revisions'
     - 'edit any service content'
     - 'edit own service content'

--- a/config/sites/its.uiowa.edu/config_split.patch.user.role.publisher.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.user.role.publisher.yml
@@ -3,9 +3,6 @@ adding:
     config:
       - node.type.service
   permissions:
-    - 'create service content'
-    - 'delete any service content'
-    - 'delete own service content'
     - 'delete service revisions'
     - 'edit any service content'
     - 'edit own service content'


### PR DESCRIPTION
Resolves #6890 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
`ddev blt ds --site=its.uiowa.edu`

```
git restore config/sites/its.uiowa.edu/schemadotorg.schemadotorg_mapping.node.service.yml && rm config/sites/its.uiowa.edu/schemadotorg.schemadotorg_mapping.node.service.yml && ddev blt ds --site=its.uiowa.edu && ddev drush @its.local config:import --source ../config/sites/its.uiowa.edu --partial -y && ddev drush @its.local cim -y && git restore config/ && ddev drush @its.local cim -y && ddev drush @its.local cr && ddev drush @its.local uli /node/add/service
```

Masquerade as webmaster, editor, and publisher
Editor should be able to edit, but not create/delete/publish Service content type
Publisher should be able to edit/publish, but not create/delete Service content type
Webmaster should be able to create/edit/publish/delete Service content type