### PR TITLE
[Bug fix] Added grid class fix for related article content

### DIFF
--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -841,7 +841,7 @@ function uiowa_core_preprocess_block(&$variables) {
       if (!isset($variables['attributes']['class'])) {
         $variables['attributes']['class'] = [];
       }
-      $variables['attributes']['class'][] = 'block--bg-container grid--threecol--33-34-33 bg--gray block-padding__bottom block-padding__top';
+      $variables['attributes']['class'][] = 'block--bg-container bg--gray block-padding__bottom block-padding__top';
       break;
 
     case 'views_block:related_content-block_related_headings_lists':
@@ -933,6 +933,17 @@ function uiowa_core_tokens($type, $tokens, array $data, array $options, Bubbleab
     }
   }
   return $replacements;
+}
+
+/**
+ * Implements template_preprocess_views_view().
+ */
+function uiowa_core_preprocess_views_view(&$variables) {
+  // Check if the current view has a specific ID or display ID.
+  if ($variables['view']->id() == 'related_manually_referenced_content') {
+    // Attach the grid class.
+    $variables['attributes']['class'][] = 'grid--threecol--33-34-33';
+  }
 }
 
 /**


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/6916

# How to test

```
ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli /news/2023/08/museum-natural-history-muse-mfa-grad-student-mariceliz-pagan-gomez
```

Confirm that grid items are even and do not have extra spacing on top like in https://sandbox.prod.drupal.uiowa.edu/news/2023/08/museum-natural-history-muse-mfa-grad-student-mariceliz-pagan-gomez.