### PR TITLE
Facilities Dispatch Conditionals Fix

### DIFF
--- a/docroot/sites/facilities.uiowa.edu/modules/facilities_core/src/Form/NodeAlertDispatchForm.php
+++ b/docroot/sites/facilities.uiowa.edu/modules/facilities_core/src/Form/NodeAlertDispatchForm.php
@@ -307,6 +307,9 @@ class NodeAlertDispatchForm extends FormBase {
       }
     }
 
+    // Filter out blank but not empty array items.
+    $placeholders = array_filter($placeholders);
+
     return $placeholders;
   }
 


### PR DESCRIPTION
Relates to https://github.com/uiowa/uiowa/issues/6880

Blank but not empty values (`render()` doing what it does) were being sent over which dispatch considered a value to print. 

<img width="327" alt="Screenshot 2023-09-28 at 12 00 30 PM" src="https://github.com/uiowa/uiowa/assets/4663676/b21be7a8-c717-475a-a5a8-043a76c021b4">


`array_filter()` in php 7.4+ handles `!is_null($value) && $value !== ''`

https://github.com/uiowa/uiowa/issues/6880#issuecomment-1739524380

<img width="801" alt="Screenshot 2023-09-28 at 12 18 52 PM" src="https://github.com/uiowa/uiowa/assets/4663676/44cc35ee-34f0-4229-b376-8b97314db791">

# To Test

```
ddev composer install && ddev blt ds --site=facilities.uiowa.edu && ddev drush @facilities.local uli 
```

Add the dispatch key from facilities.uiowa.edu. Try scheduling a message. I will receive it unless you change the communication details: https://apps.its.uiowa.edu/dispatch/communications/1238605612/edit

Only values you have supplied will be included in the message.
