### PR TITLE
Uninstalls the `components` module

### DIFF
--- a/config/default/components.settings.yml
+++ b/config/default/components.settings.yml
@@ -1,3 +1,0 @@
-namespace_prefix: 0
-_core:
-  default_config_hash: ubgzimJBOnDVwucabHMNyh86hpBDgl1ytWQyexq4L6I

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -16,7 +16,6 @@ module:
   block_content_template: 0
   breakpoint: 0
   ckeditor: 0
-  components: 0
   config: 0
   config_ignore: 0
   config_split: 0

--- a/docroot/themes/custom/uids_base/uids_base.info.yml
+++ b/docroot/themes/custom/uids_base/uids_base.info.yml
@@ -30,10 +30,6 @@ regions:
   footer_first: 'Footer under logo'
   footer_second: 'Footer menus'
   page_bottom: 'Page bottom'
-# Components
-components:
-  namespaces:
-    uids: uids/components
 # Ckeditor styling for lead paragraphs and alerts
 ckeditor_stylesheets:
   - assets/css/components/video/video-utilities.css


### PR DESCRIPTION
Related to #6901 

I believe this module was originally introduced to allow us to setup a namespace to directly consume the templates from UIDS. However, we moved away from this practice a while ago and as far as I can tell, there are no instances of `'@uids/` in use in the code base. Which means we can remove it.

# How to test
```
ddev blt ds --site sandbox.uiowa.edu && ddev drush @sandbox.local uli /
```
- Check out the homepage and validate there are no issues.
- Click around the frontend of the site a little bit.