### PR TITLE
[Hotfix] Added fix for card styles option missing

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -223,15 +223,6 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
             $form['#attached']['library'][] = 'layout_builder_custom/quote-block-form';
             break;
 
-          case 'inline_block:uiowa_text_area':
-          case 'webform_block':
-
-            $form['layout_builder_style_padding']['#empty_option'] = 'None';
-            break;
-
-          case 'inline_block:uiowa_card':
-            $form['#attached']['library'][] = 'layout_builder_custom/card-block-form';
-
           case 'inline_block:uiowa_image_gallery':
             $form['#attached']['library'][] = 'layout_builder_custom/image-block-form';
 
@@ -246,6 +237,16 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
                 ],
               ],
             ];
+            break;
+
+          case 'inline_block:uiowa_text_area':
+          case 'webform_block':
+
+            $form['layout_builder_style_padding']['#empty_option'] = 'None';
+            break;
+
+          case 'inline_block:uiowa_card':
+            $form['#attached']['library'][] = 'layout_builder_custom/card-block-form';
 
           case 'inline_block:uiowa_aggregator':
           case 'inline_block:uiowa_events':

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -241,7 +241,6 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
 
           case 'inline_block:uiowa_text_area':
           case 'webform_block':
-
             $form['layout_builder_style_padding']['#empty_option'] = 'None';
             break;
 


### PR DESCRIPTION
In https://github.com/uiowa/uiowa/pull/6881/files, I put my `#states` code in the wrong place.  This issue fixes that. 

```
ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli /node/21/layout
```

- Edit/add a card and confirm that "Styles" option exists and "Align button" option exists
- Edit/add an Image gallery and confirm that "Styles" option exists if "No crop" option is selected
- Edit/add a text area block and confirm that text area padding option has `None` as the default option