### PR TITLE
[Migration] Public files path option

### DIFF
--- a/docroot/modules/custom/sitenow_migrate/src/Form/MigrateSettingsForm.php
+++ b/docroot/modules/custom/sitenow_migrate/src/Form/MigrateSettingsForm.php
@@ -161,6 +161,13 @@ class MigrateSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('shared_configuration.source.constants.source_base_path'),
     ];
 
+    $form['constants']['public_file_path'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Public Files Path'),
+      '#description' => $this->t('The public files system path, if not set as <em>file_public_path</em> in the database <em>variables</em> table. Eg. <em>sites/default/files</em>'),
+      '#default_value' => $config->get('shared_configuration.source.constants.public_file_path'),
+    ];
+
     return $form;
   }
 
@@ -173,6 +180,7 @@ class MigrateSettingsForm extends ConfigFormBase {
         'key' => 'drupal_7',
         'constants' => [
           'source_base_path' => $form_state->getValue('source_base_path'),
+          'public_file_path' => $form_state->getValue('public_file_path'),
           'drupal_file_directory' => 'public://' . date('Y-m'),
         ],
         'database' => [

--- a/docroot/modules/custom/sitenow_migrate/src/Plugin/migrate/source/Files.php
+++ b/docroot/modules/custom/sitenow_migrate/src/Plugin/migrate/source/Files.php
@@ -6,6 +6,7 @@ use Drupal\Core\Database\Database;
 use Drupal\file\Plugin\migrate\source\d7\File;
 use Drupal\migrate\Event\MigrateRollbackEvent;
 use Drupal\migrate\Row;
+use Drupal\migrate_drupal\Plugin\migrate\source\DrupalSqlBase;
 
 /**
  * Basic implementation of the source plugin.
@@ -86,6 +87,22 @@ class Files extends File {
       ->getStorage('media');
     $mediaEntities = $entityManager->loadMultiple($results);
     $entityManager->delete($mediaEntities);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function initializeIterator() {
+    $this->privatePath = $this->variableGet('file_private_path', NULL);
+    $publicPath = $this->variableGet('file_public_path', NULL);
+    if (is_null($publicPath)) {
+      $publicPath = \Drupal::config('migrate_plus.migration_group.sitenow_migrate')
+        ->get('shared_configuration.source.constants.public_file_path');
+    }
+    $this->publicPath = $publicPath;
+    // We need to skip over the direct parent and go directly
+    // to its parent to avoid re-setting the publicPath.
+    return DrupalSqlBase::initializeIterator();
   }
 
 }


### PR DESCRIPTION
Relates to #6868 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

Sync a CCOM site locally using DevDesktop. (if you have just gotten access to the CCOM application, in DevDesktop you may need to click More > Refresh Acquia Cloud Sites in order to get it to appear)

<!-- Include detailed steps for how to test this PR. -->

```
ddev blt ds --site=default && ddev drush @default.local config-split:activate sitenow_migrate -y && ddev drush @default.local uli /admin/config/sitenow/sitenow-migrate 
```

Complete the config page using the help text.
For the new "Public Files Path", it should be something like "sites/**medicine.uiowa.edu.internalmedicine**/files" where the bolded should match the multisite designation in devdesktop. (You can also log into the site and visit `/admin/config/media/file-system` to check)

```
ddev drush @default.local ms
```
Check that migrations, particularly the `d7_file` migration, are registered.

```
ddev drush @default.local mim d7_file --limit=10
```
Feel free to adjust the `limit`, or remove it to import all files.

Check for no errors
Check the https://default.uiowa.ddev.site/admin/content/media, and see that media entities have been created for the imported files

Try syncing a uiowa70x site and hooking up, running the files migration _without_ filling in the public files path, and see that it works (a code review may also be sufficient, and that the logic should in that case match `initializeIterator` in https://api.drupal.org/api/drupal/core%21modules%21file%21src%21Plugin%21migrate%21source%21d7%21File.php/class/File/8.9.x)