### PR TITLE
Update `google_tag` to 8.x-1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -128,7 +128,7 @@
         "drupal/fullcalendar_view": "^5.0",
         "drupal/geofield": "^1.53",
         "drupal/google_analytics": "^4.0",
-        "drupal/google_tag": "^1.3",
+        "drupal/google_tag": "^1.6",
         "drupal/heading": "^1.4",
         "drupal/honeypot": "^2.1",
         "drupal/iframe_title_filter": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a0c25ba0558760350f66d70d46221f33",
+    "content-hash": "102104bd4e9f7e7d7edf974186fd081d",
     "packages": [
         {
             "name": "acquia/blt",
@@ -6197,26 +6197,26 @@
         },
         {
             "name": "drupal/google_tag",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/google_tag.git",
-                "reference": "8.x-1.5"
+                "reference": "8.x-1.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/google_tag-8.x-1.5.zip",
-                "reference": "8.x-1.5",
-                "shasum": "b2929a517cc86bb3e54dded127556f18236a8628"
+                "url": "https://ftp.drupal.org/files/projects/google_tag-8.x-1.6.zip",
+                "reference": "8.x-1.6",
+                "shasum": "d084315e54c2e561b8b64eef86081c2634d054cd"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9"
+                "drupal/core": "^8.8 || ^9 || ^10"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.5",
-                    "datestamp": "1648569365",
+                    "version": "8.x-1.6",
+                    "datestamp": "1671145853",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/config/default/google_tag.settings.yml
+++ b/config/default/google_tag.settings.yml
@@ -23,13 +23,19 @@ _default_container:
   environment_token: ''
   path_toggle: 'exclude listed'
   path_list: |-
-    /admin*
-    /batch*
+    /admin
+    /admin/*
+    /batch
+    /batch/*
     /node/add*
     /node/*/edit
     /node/*/delete
+    /node/*/layout
+    /taxonomy/term/*/edit
+    /taxonomy/term/*/layout
     /user/*/edit*
     /user/*/cancel*
+    /user/*/layout
   role_toggle: 'exclude listed'
   role_list: {  }
   status_toggle: 'exclude listed'


### PR DESCRIPTION
Resolves #6900 and updates `google_tag` to a D10 compatible version without going to the most recent update.

# How to test

Code review is sufficient. I have tested the update.
