### PR TITLE
Hotfix - Webform Email Body Text Format

### DIFF
--- a/config/default/webform.settings.yml
+++ b/config/default/webform.settings.yml
@@ -198,7 +198,7 @@ element:
 html_editor:
   disabled: false
   element_format: filtered_html
-  mail_format: webform_default
+  mail_format: minimal_plus
   tidy: true
   make_unused_managed_files_temporary: true
 file:


### PR DESCRIPTION
# To Test

```
ddev composer install && ddev blt ds --site=default && ddev drush @default.local uli --name=webmaster admin/structure/webform/manage/contact/handlers
```

On `main` as a webmaster try to create an email handler with a custom body, see a disabled field.
On `hotfix_webform_email_body` as a webmaster try to create an email handler with a custom body, success!