### PR TITLE
Update Drush User Commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -213,7 +213,7 @@
         "npm-asset/slick-carousel": "^1.8",
         "npm-asset/vanilla-icon-picker": "^1.2",
         "oomphinc/composer-installers-extender": "^2.0",
-        "richardbporter/drush-users-commands": "3.0.4",
+        "richardbporter/drush-users-commands": "3.2.1",
         "uiowa/block_content_template": "dev-master#ab06f7d5254b1d9a805c0717747e25f0ef508e59",
         "uiowa/uiowa_auth": "^2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "538d747a82b3617f828174feb4d23a28",
+    "content-hash": "5b3561692b8acbc05149dc08f6af173b",
     "packages": [
         {
             "name": "acquia/blt",
@@ -16020,28 +16020,31 @@
         },
         {
             "name": "richardbporter/drush-users-commands",
-            "version": "3.0.4",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/richardbporter/drush-users-commands.git",
-                "reference": "a1512218f6468741bb4319d4884f49790e8a6e39"
+                "reference": "bb7acd507970d4c87706dfb89fc3144c602cd2a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/richardbporter/drush-users-commands/zipball/a1512218f6468741bb4319d4884f49790e8a6e39",
-                "reference": "a1512218f6468741bb4319d4884f49790e8a6e39",
+                "url": "https://api.github.com/repos/richardbporter/drush-users-commands/zipball/bb7acd507970d4c87706dfb89fc3144c602cd2a0",
+                "reference": "bb7acd507970d4c87706dfb89fc3144c602cd2a0",
                 "shasum": ""
             },
             "require": {
                 "composer/installers": "^2.1",
                 "drush/drush": "^11.0.5",
-                "php": ">=7.4"
+                "php": ">=8.0"
             },
             "require-dev": {
-                "drupal/core-composer-scaffold": "^9.3",
-                "drupal/core-recommended": "^9.3",
+                "drupal/coder": "^8.3",
+                "drupal/core-composer-scaffold": "^9.3 || ^10.0",
+                "drupal/core-recommended": "^9.3 || ^10.0",
+                "mglaman/drupal-check": "^1.4",
                 "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "^3"
+                "squizlabs/php_codesniffer": "^3",
+                "symfony/phpunit-bridge": "^6.1"
             },
             "type": "drupal-drush",
             "extra": {
@@ -16095,7 +16098,7 @@
             "authors": [
                 {
                     "name": "Richard B. Porter",
-                    "homepage": "https://richardbporter.github.io"
+                    "homepage": "https://github.com/richardbporter"
                 }
             ],
             "description": "Drush commands to interact with multiple Drupal users.",
@@ -16107,9 +16110,9 @@
             ],
             "support": {
                 "issues": "https://github.com/richardbporter/drush-users-commands/issues",
-                "source": "https://github.com/richardbporter/drush-users-commands/tree/3.0.4"
+                "source": "https://github.com/richardbporter/drush-users-commands/tree/3.2.1"
             },
-            "time": "2022-04-13T20:45:31+00:00"
+            "time": "2023-03-05T20:22:07+00:00"
         },
         {
             "name": "robrichards/xmlseclibs",


### PR DESCRIPTION
# To Test

```
ddev composer install && ddev blt ds --site=sandbox.uiowa.edu
```

Confirm we have Drupal 10 coverage here: drush/Commands/contrib/UsersCommands/composer.json

`ddev drush @sandbox.local users:list --roles=administrator`

See only a list of administrator users.

`ddev drush @sandbox.local users:toggle`
`ddev drush @sandbox.local users:list`

See that all users are blocked.

`ddev drush @sandbox.local users:toggle`
`ddev drush @sandbox.local users:list`

See that all users are toggled back. Some users are still blocked because that was their status before the first toggle.
