### PR TITLE
Hotfix: Fix article/people path auto settings.

### DIFF
--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -2933,3 +2933,26 @@ function sitenow_update_9075() {
 function sitenow_update_9076() {
   drupal_flush_all_caches();
 }
+
+/**
+ * Update node type conditions from node_type to entity_bundle.
+ */
+function sitenow_update_10001() {
+  // Load all pattern configuration entities.
+  foreach (\Drupal::configFactory()->listAll('pathauto.pattern.') as $pattern_config_name) {
+    $pattern_config = \Drupal::configFactory()->getEditable($pattern_config_name);
+
+    // Loop patterns and swap the node_type plugin by the entity_bundle:node
+    // plugin.
+    if ($pattern_config->get('type') === 'canonical_entities:node') {
+      $selection_criteria = $pattern_config->get('selection_criteria');
+      foreach ($selection_criteria as $uuid => $condition) {
+        if ($condition['id'] === 'node_type') {
+          $pattern_config->set("selection_criteria.$uuid.id", 'entity_bundle:node');
+          $pattern_config->save();
+          break;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hotfix for errors seen in production after 10.0 deployment.

# How to test

- Sync a site
- Visit path auto settings page and ensure it loads
- Check config export via UI
