### PR TITLE
Add label for reason for closure

### DIFF
--- a/config/sites/facilities.uiowa.edu/core.entity_view_display.node.alert.default.yml
+++ b/config/sites/facilities.uiowa.edu/core.entity_view_display.node.alert.default.yml
@@ -258,12 +258,15 @@ third_party_settings:
             region: content
             configuration:
               id: 'field_block:node:alert:body'
-              label_display: '0'
+              label: null
+              label_display: null
+              provider: layout_builder
               context_mapping:
                 entity: layout_builder.entity
+                view_mode: view_mode
               formatter:
                 type: text_default
-                label: hidden
+                label: inline
                 settings: {  }
                 third_party_settings: {  }
             weight: 8


### PR DESCRIPTION
Tracks https://github.com/uiowa/uiowa/issues/7066

## To test
1.  sync site
2. Observe that an alert now has a label on the "Reason for closure" field.
3. Did I export the right config?