### PR TITLE
Config fixes for ITS/Facilities Alerts

### DIFF
--- a/config/features/sitenow_alerts/core.entity_form_display.node.alert.default.yml
+++ b/config/features/sitenow_alerts/core.entity_form_display.node.alert.default.yml
@@ -9,7 +9,6 @@ dependencies:
     - field.field.node.alert.field_meta_tags
     - field.field.node.alert.layout_builder__layout
     - node.type.alert
-    - workflows.workflow.editorial
   module:
     - content_moderation
     - metatag
@@ -64,10 +63,6 @@ content:
       show_extra: false
       hide_date: false
       separator: to
-    third_party_settings: {  }
-  field_alert_service_affected:
-    region: content
-    settings: {  }
     third_party_settings: {  }
   field_meta_tags:
     type: metatag_firehose

--- a/config/features/sitenow_alerts/core.entity_form_display.node.alert.default.yml
+++ b/config/features/sitenow_alerts/core.entity_form_display.node.alert.default.yml
@@ -66,6 +66,7 @@ content:
       separator: to
     third_party_settings: {  }
   field_alert_service_affected:
+    region: content
     settings: {  }
     third_party_settings: {  }
   field_meta_tags:

--- a/config/sites/its.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/its.uiowa.edu/config_split.config_split.site.yml
@@ -31,6 +31,8 @@ complete_list:
 partial_list:
   - core.entity_form_display.node.alert.default
   - core.entity_form_display.node.article.default
+  - core.entity_view_display.node.alert.default
+  - core.entity_view_display.node.alert.teaser
   - core.entity_view_display.node.article.teaser
   - core.entity_view_display.node.article.token
   - field.field.block_content.featured_content.field_featured_content_item

--- a/config/sites/its.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/its.uiowa.edu/config_split.config_split.site.yml
@@ -29,6 +29,7 @@ complete_list:
   - views.view.service_related_articles
   - 'field.storage.node.field_service_*'
 partial_list:
+  - core.entity_form_display.node.alert.default
   - core.entity_form_display.node.article.default
   - core.entity_view_display.node.article.teaser
   - core.entity_view_display.node.article.token

--- a/config/sites/its.uiowa.edu/config_split.patch.core.entity_form_display.node.alert.default.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.core.entity_form_display.node.alert.default.yml
@@ -12,6 +12,7 @@ adding:
         match_limit: 10
         size: 60
         placeholder: ''
+      third_party_settings: {  }
 removing:
   dependencies:
     config:

--- a/config/sites/its.uiowa.edu/config_split.patch.core.entity_form_display.node.alert.default.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.core.entity_form_display.node.alert.default.yml
@@ -2,6 +2,7 @@ adding:
   dependencies:
     config:
       - field.field.node.alert.field_alert_service_affected
+      - workflows.workflow.editorial
   content:
     field_alert_service_affected:
       type: entity_reference_autocomplete
@@ -13,7 +14,4 @@ adding:
         size: 60
         placeholder: ''
       third_party_settings: {  }
-removing:
-  dependencies:
-    config:
-      - workflows.workflow.editorial
+removing: {  }

--- a/config/sites/its.uiowa.edu/config_split.patch.core.entity_form_display.node.alert.default.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.core.entity_form_display.node.alert.default.yml
@@ -12,7 +12,6 @@ adding:
         match_limit: 10
         size: 60
         placeholder: ''
-      third_party_settings: {  }
 removing:
   dependencies:
     config:

--- a/config/sites/its.uiowa.edu/config_split.patch.core.entity_view_display.node.alert.default.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.core.entity_view_display.node.alert.default.yml
@@ -24,6 +24,17 @@ adding:
               weight: 0
               additional: {  }
               third_party_settings: {  }
+            config_split_sequence_ako1b5e48kom6han:
+              uuid: b04a7a65-26cb-40d7-a79d-5a6352bb237e
+              region: content
+              configuration:
+                id: 'extra_field_block:node:alert:content_moderation_control'
+                label_display: '0'
+                context_mapping:
+                  entity: layout_builder.entity
+              weight: 2
+              additional: {  }
+              third_party_settings: {  }
         -
           components:
             config_split_sequence_42vifq8g48vbludn:
@@ -49,6 +60,11 @@ adding:
               additional: {  }
               third_party_settings: {  }
   content:
+    content_moderation_control:
+      settings: {  }
+      third_party_settings: {  }
+      weight: -20
+      region: content
     field_alert_service_affected:
       type: entity_reference_label
       label: above

--- a/config/sites/its.uiowa.edu/config_split.patch.core.entity_view_display.node.alert.teaser.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.core.entity_view_display.node.alert.teaser.yml
@@ -7,7 +7,7 @@ adding:
 removing:
   content:
     content_moderation_control:
-      weight: -20
       settings: {  }
       third_party_settings: {  }
+      weight: -20
       region: content


### PR DESCRIPTION

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
```
ddev blt ds --site=its.uiowa.edu && ddev blt ds --site=facilities.uiowa.edu && ddev blt ds --site=default && ddev drush @default.local config-split:activate sitenow_alerts -y
```
Check that all syncs are clean and that default is able to enable the `sitenow_alerts` feature split