### PR TITLE
[Bug] Added fix for rss grid position overlapping with monthly archive sidebar

### DIFF
--- a/docroot/themes/custom/uids_base/scss/views/view-display-id-page_articles.scss
+++ b/docroot/themes/custom/uids_base/scss/views/view-display-id-page_articles.scss
@@ -24,7 +24,7 @@
   }
 
   .pager {
-    grid-area: 5 / 1 / 3 / 4;
+    grid-area: 5 / 1 / 3 / 3;
     @include breakpoint(sm) {
       margin-bottom: 4rem;
     }
@@ -44,7 +44,7 @@
 
   .feed-icons {
     @include breakpoint(sm) {
-      grid-area: 5 / 1 / 3 / 4;
+      grid-area: 5 / 1 / 3 / 3;
       margin-top: 6rem;
     }
   }


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/7069. 

# How to test

```
ddev blt frontend && ddev blt ds --site=cs.uiowa.edu && ddev drush @cs.local uli /news

```

- In multiple browsers, collapse browser window slowly and confirm that sidebar links are clickable at all breakpoints. 
- Adjust articles config page to try different layout options and confirm that the layout is working.