### PR TITLE
Update FontAwesome

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "acquia/blt-travis": "^1.1.0",
         "acquia/memcache-settings": "^1.1",
         "bower-asset/chosen": "^1.8",
-        "bower-asset/fontawesome": "^6.x-dev#d02961b",
+        "bower-asset/fontawesome": "6.x-dev#f0c25837a3fe0e03783b939559e088abcbfb3c4b",
         "bower-asset/lazysizes": "^5.2",
         "bower-asset/photoswipe": "^4.1",
         "cweagans/composer-patches": "^1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "daf7f5ee18464df338e109560acea71c",
+    "content-hash": "24a01eb3a97b8132303a463cc4cc4495",
     "packages": [
         {
             "name": "acquia/blt",
@@ -590,7 +590,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FortAwesome/Font-Awesome/zipball/d02961b",
+                "url": "https://api.github.com/repos/FortAwesome/Font-Awesome/zipball/d02961b018153506364077343b0edcde0a39d27e",
                 "reference": "d02961b018153506364077343b0edcde0a39d27e"
             },
             "type": "bower-asset"

--- a/composer.lock
+++ b/composer.lock
@@ -586,12 +586,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:FortAwesome/Font-Awesome.git",
-                "reference": "d02961b018153506364077343b0edcde0a39d27e"
+                "reference": "f0c25837a3fe0e03783b939559e088abcbfb3c4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FortAwesome/Font-Awesome/zipball/d02961b018153506364077343b0edcde0a39d27e",
-                "reference": "d02961b018153506364077343b0edcde0a39d27e"
+                "url": "https://api.github.com/repos/FortAwesome/Font-Awesome/zipball/f0c25837a3fe0e03783b939559e088abcbfb3c4b",
+                "reference": "f0c25837a3fe0e03783b939559e088abcbfb3c4b"
             },
             "type": "bower-asset"
         },


### PR DESCRIPTION
# To Test

```
ddev composer install && ddev blt frontend && ddev drush @sandbox.local sql-drop -y && ddev drush @sandbox.local cr && ddev blt ds --site=sandbox.uiowa.edu
```

Visit https://sandbox.uiowa.ddev.site/ and you may need to open up inspector and do a refresh with hard cache reload... to see the twitter (new) in the social media menu within the footer.

Similar to when we updated this before, these assets seem to cache differently and don't get a cache break. We had to clear site and varnish caches in prod after the update.