### PR TITLE
hotfix - classrooms - remove unnecessary access check that causes failure

### DIFF
--- a/docroot/modules/custom/ccom_migrate/src/Plugin/migrate/source/CcomArticle.php
+++ b/docroot/modules/custom/ccom_migrate/src/Plugin/migrate/source/CcomArticle.php
@@ -6,7 +6,6 @@ use Drupal\migrate\Row;
 use Drupal\sitenow_migrate\Plugin\migrate\source\BaseNodeSource;
 use Drupal\sitenow_migrate\Plugin\migrate\source\ProcessMediaTrait;
 use Drupal\taxonomy\Entity\Term;
-use function PHPUnit\Framework\isEmpty;
 
 /**
  * Migrate Source plugin.

--- a/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/src/RoomItemProcessor.php
+++ b/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/src/RoomItemProcessor.php
@@ -56,8 +56,7 @@ class RoomItemProcessor extends EntityItemProcessorBase {
       $query = \Drupal::entityQuery('taxonomy_term')->orConditionGroup()
         ->condition('vid', 'room_features')
         ->condition('vid', 'accessibility_features')
-        ->condition('vid', 'technology_features')
-        ->accessCheck();
+        ->condition('vid', 'technology_features');
 
       $tids = \Drupal::entityQuery('taxonomy_term')
         ->condition($query)

--- a/docroot/sites/its.uiowa.edu/modules/its_core/its_core.module
+++ b/docroot/sites/its.uiowa.edu/modules/its_core/its_core.module
@@ -5,9 +5,7 @@
  * Primary module hooks for ITS Core module.
  */
 
-use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\its_core\Entity\Service;
 
 /**


### PR DESCRIPTION
I got a little carried away with the d10 access checks.

# To Test

Before pulling this branch down, sync classrooms and try saving a room node.
```
ddev blt ds --site=classrooms.uiowa.edu && ddev drush @classrooms.local uli /node/1891/edit
```
Then again with this branch pulled down.