### PR TITLE
Update drush info for uiowa07

### DIFF
--- a/drush/sites/uiowa07.site.yml
+++ b/drush/sites/uiowa07.site.yml
@@ -16,9 +16,9 @@ prod:
   root: /var/www/html/uiowa07.prod/docroot
   user: uiowa07.prod
 test:
-  uri: uiowa07stg.prod.acquia-sites.com
-  host: uiowa07stg.ssh.prod.acquia-sites.com
+  uri: uiowa07stage.prod.acquia-sites.com
+  host: uiowa07stage.ssh.prod.acquia-sites.com
   options: {  }
   paths: { dump-dir: /mnt/tmp }
-  root: /var/www/html/uiowa07.test/docroot
-  user: uiowa07.test
+  root: /var/www/html/uiowa07.stage/docroot
+  user: uiowa07.stage


### PR DESCRIPTION
# To Test

- git pull
- `ddev drush @uiowa07.test ssh`

Assuming you have permissions (you should), you should be taken in to `uiowa07.stage@sshd-685758d998-q2xrz` or something weird like that. If you were to try this on `main` currently, you would not be able to get in compared to `@uiowa07.dev`