### PR TITLE
Update drush info for uiowa07 part deux

### DIFF
--- a/drush/sites/uiowa07.site.yml
+++ b/drush/sites/uiowa07.site.yml
@@ -9,7 +9,7 @@ dev:
   root: /var/www/html/uiowa07.dev/docroot
   user: uiowa07.dev
 prod:
-  uri: uiowa07.prod.acquia-sites.com
+  uri: uiowa07prod.prod.acquia-sites.com
   host: uiowa07prod.ssh.prod.acquia-sites.com
   options: {  }
   paths: { dump-dir: /mnt/tmp }

--- a/drush/sites/uiowa07.site.yml
+++ b/drush/sites/uiowa07.site.yml
@@ -10,7 +10,7 @@ dev:
   user: uiowa07.dev
 prod:
   uri: uiowa07.prod.acquia-sites.com
-  host: uiowa07.ssh.prod.acquia-sites.com
+  host: uiowa07prod.ssh.prod.acquia-sites.com
   options: {  }
   paths: { dump-dir: /mnt/tmp }
   root: /var/www/html/uiowa07.prod/docroot


### PR DESCRIPTION
Essentially the same as https://github.com/uiowa/uiowa/pull/7148 but for PROD

# To Test
git pull
`ddev drush @uiowa07.prod ssh`
Assuming you have permissions (you should), you should be taken in to uiowa07.prod@sshd-56db667b45-th9ql or something weird like that. If you were to try this on main currently, you would not be able to get in compared to @uiowa07.dev