### PR TITLE
[Hotfix] Added add an extra check to avoid preprocess error

### DIFF
--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -1085,11 +1085,15 @@ function uids_base_preprocess_form(&$variables) {
 /**
  * Implements hook_preprocess_image().
  */
-function theme_base_preprocess_image(&$variables) {
+function uids_base_preprocess_image(&$variables) {
   if (isset($variables['attributes']) && isset($variables['attributes']['loading'])) {
     $loading_attributes = $variables['attributes']['loading'];
     if ($loading_attributes === "lazy") {
-      $variables['attributes']['class'] = $variables['attributes']['class'] ?? [];
+      // Ensure $variables['attributes']['class'] is an array.
+      if (!isset($variables['attributes']['class']) || !is_array($variables['attributes']['class'])) {
+        $variables['attributes']['class'] = [];
+      }
+
       $variables['attributes']['class'][] = 'lazyload';
       $variables['#attached']['library'][] = 'uids_base/lazy-load-animation';
     }

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -1085,10 +1085,11 @@ function uids_base_preprocess_form(&$variables) {
 /**
  * Implements hook_preprocess_image().
  */
-function uids_base_preprocess_image(&$variables) {
+function theme_base_preprocess_image(&$variables) {
   if (isset($variables['attributes']) && isset($variables['attributes']['loading'])) {
     $loading_attributes = $variables['attributes']['loading'];
     if ($loading_attributes === "lazy") {
+      $variables['attributes']['class'] = $variables['attributes']['class'] ?? [];
       $variables['attributes']['class'][] = 'lazyload';
       $variables['#attached']['library'][] = 'uids_base/lazy-load-animation';
     }


### PR DESCRIPTION
Fixes `Error: [] operator not supported for strings in uids_base_preprocess_image() "`

# Sites to test so far:
```
ddev blt ds --site=classrooms.uiowa.edu && ddev drush @classrooms.local uli /abw-110
```

```
ddev blt ds --site=housing.uiowa.edu && ddev drush @housing.local uli /residence-halls/burge
```