### PR TITLE
hotfix - restore block content permissions

### DIFF
--- a/config/default/user.role.editor.yml
+++ b/config/default/user.role.editor.yml
@@ -3,7 +3,22 @@ langcode: en
 status: true
 dependencies:
   config:
+    - block_content.type.featured_content
+    - block_content.type.uiowa_aggregator
+    - block_content.type.uiowa_banner
+    - block_content.type.uiowa_button
+    - block_content.type.uiowa_card
+    - block_content.type.uiowa_collection
+    - block_content.type.uiowa_cta
+    - block_content.type.uiowa_event
+    - block_content.type.uiowa_events
+    - block_content.type.uiowa_image
+    - block_content.type.uiowa_image_gallery
+    - block_content.type.uiowa_quote
+    - block_content.type.uiowa_slider
+    - block_content.type.uiowa_statistic
     - block_content.type.uiowa_text_area
+    - block_content.type.uiowa_timeline
     - core.entity_view_display.fragment.region_item.default
     - core.entity_view_display.fragment.region_item_after_content.default
     - core.entity_view_display.node.page.default
@@ -112,6 +127,7 @@ permissions:
   - 'create article content'
   - 'create audio media'
   - 'create facebook media'
+  - 'create featured_content block content'
   - 'create file media'
   - 'create image media'
   - 'create instagram media'
@@ -125,8 +141,24 @@ permissions:
   - 'create terms in research_areas'
   - 'create terms in tags'
   - 'create twitter media'
+  - 'create uiowa_aggregator block content'
+  - 'create uiowa_banner block content'
+  - 'create uiowa_button block content'
+  - 'create uiowa_card block content'
+  - 'create uiowa_collection block content'
+  - 'create uiowa_cta block content'
+  - 'create uiowa_event block content'
+  - 'create uiowa_events block content'
+  - 'create uiowa_image block content'
+  - 'create uiowa_image_gallery block content'
+  - 'create uiowa_quote block content'
+  - 'create uiowa_slider block content'
+  - 'create uiowa_statistic block content'
+  - 'create uiowa_text_area block content'
+  - 'create uiowa_timeline block content'
   - 'delete any audio media'
   - 'delete any facebook media'
+  - 'delete any featured_content block content'
   - 'delete any file media'
   - 'delete any image media'
   - 'delete any instagram media'
@@ -134,6 +166,21 @@ permissions:
   - 'delete any remote_video media'
   - 'delete any static_map media'
   - 'delete any twitter media'
+  - 'delete any uiowa_aggregator block content'
+  - 'delete any uiowa_banner block content'
+  - 'delete any uiowa_button block content'
+  - 'delete any uiowa_card block content'
+  - 'delete any uiowa_collection block content'
+  - 'delete any uiowa_cta block content'
+  - 'delete any uiowa_event block content'
+  - 'delete any uiowa_events block content'
+  - 'delete any uiowa_image block content'
+  - 'delete any uiowa_image_gallery block content'
+  - 'delete any uiowa_quote block content'
+  - 'delete any uiowa_slider block content'
+  - 'delete any uiowa_statistic block content'
+  - 'delete any uiowa_text_area block content'
+  - 'delete any uiowa_timeline block content'
   - 'delete article revisions'
   - 'delete own article content'
   - 'delete own audio media'
@@ -153,6 +200,7 @@ permissions:
   - 'edit any article content'
   - 'edit any audio media'
   - 'edit any facebook media'
+  - 'edit any featured_content block content'
   - 'edit any file media'
   - 'edit any image media'
   - 'edit any instagram media'
@@ -162,7 +210,21 @@ permissions:
   - 'edit any remote_video media'
   - 'edit any static_map media'
   - 'edit any twitter media'
+  - 'edit any uiowa_aggregator block content'
+  - 'edit any uiowa_banner block content'
+  - 'edit any uiowa_button block content'
+  - 'edit any uiowa_card block content'
+  - 'edit any uiowa_collection block content'
+  - 'edit any uiowa_cta block content'
+  - 'edit any uiowa_event block content'
+  - 'edit any uiowa_events block content'
+  - 'edit any uiowa_image block content'
+  - 'edit any uiowa_image_gallery block content'
+  - 'edit any uiowa_quote block content'
+  - 'edit any uiowa_slider block content'
+  - 'edit any uiowa_statistic block content'
   - 'edit any uiowa_text_area block content'
+  - 'edit any uiowa_timeline block content'
   - 'edit own article content'
   - 'edit own audio media'
   - 'edit own facebook media'

--- a/config/default/user.role.webmaster.yml
+++ b/config/default/user.role.webmaster.yml
@@ -3,7 +3,25 @@ langcode: en
 status: true
 dependencies:
   config:
+    - block_content.type.featured_content
+    - block_content.type.uiowa_aggregator
+    - block_content.type.uiowa_banner
+    - block_content.type.uiowa_button
+    - block_content.type.uiowa_card
+    - block_content.type.uiowa_collection
+    - block_content.type.uiowa_cta
+    - block_content.type.uiowa_event
+    - block_content.type.uiowa_events
+    - block_content.type.uiowa_hero
+    - block_content.type.uiowa_image
+    - block_content.type.uiowa_image_gallery
+    - block_content.type.uiowa_page_title_hero
+    - block_content.type.uiowa_quote
+    - block_content.type.uiowa_slider
+    - block_content.type.uiowa_spacer_separator
+    - block_content.type.uiowa_statistic
     - block_content.type.uiowa_text_area
+    - block_content.type.uiowa_timeline
     - core.entity_view_display.fragment.region_item.default
     - core.entity_view_display.node.page.default
     - filter.format.basic
@@ -172,6 +190,7 @@ permissions:
   - 'create article content'
   - 'create audio media'
   - 'create facebook media'
+  - 'create featured_content block content'
   - 'create file media'
   - 'create image media'
   - 'create instagram media'
@@ -185,6 +204,21 @@ permissions:
   - 'create terms in research_areas'
   - 'create terms in tags'
   - 'create twitter media'
+  - 'create uiowa_aggregator block content'
+  - 'create uiowa_banner block content'
+  - 'create uiowa_button block content'
+  - 'create uiowa_card block content'
+  - 'create uiowa_collection block content'
+  - 'create uiowa_cta block content'
+  - 'create uiowa_event block content'
+  - 'create uiowa_events block content'
+  - 'create uiowa_image block content'
+  - 'create uiowa_image_gallery block content'
+  - 'create uiowa_quote block content'
+  - 'create uiowa_slider block content'
+  - 'create uiowa_statistic block content'
+  - 'create uiowa_text_area block content'
+  - 'create uiowa_timeline block content'
   - 'create url aliases'
   - 'create users'
   - 'create video media'
@@ -192,6 +226,7 @@ permissions:
   - 'delete any article content'
   - 'delete any audio media'
   - 'delete any facebook media'
+  - 'delete any featured_content block content'
   - 'delete any file media'
   - 'delete any image media'
   - 'delete any instagram media'
@@ -201,6 +236,24 @@ permissions:
   - 'delete any remote_video media'
   - 'delete any static_map media'
   - 'delete any twitter media'
+  - 'delete any uiowa_aggregator block content'
+  - 'delete any uiowa_banner block content'
+  - 'delete any uiowa_button block content'
+  - 'delete any uiowa_card block content'
+  - 'delete any uiowa_collection block content'
+  - 'delete any uiowa_cta block content'
+  - 'delete any uiowa_event block content'
+  - 'delete any uiowa_events block content'
+  - 'delete any uiowa_hero block content'
+  - 'delete any uiowa_image block content'
+  - 'delete any uiowa_image_gallery block content'
+  - 'delete any uiowa_page_title_hero block content'
+  - 'delete any uiowa_quote block content'
+  - 'delete any uiowa_slider block content'
+  - 'delete any uiowa_spacer_separator block content'
+  - 'delete any uiowa_statistic block content'
+  - 'delete any uiowa_text_area block content'
+  - 'delete any uiowa_timeline block content'
   - 'delete any video media'
   - 'delete any webform'
   - 'delete any webform submission'
@@ -232,6 +285,7 @@ permissions:
   - 'edit any article content'
   - 'edit any audio media'
   - 'edit any facebook media'
+  - 'edit any featured_content block content'
   - 'edit any file media'
   - 'edit any image media'
   - 'edit any instagram media'
@@ -241,7 +295,24 @@ permissions:
   - 'edit any remote_video media'
   - 'edit any static_map media'
   - 'edit any twitter media'
+  - 'edit any uiowa_aggregator block content'
+  - 'edit any uiowa_banner block content'
+  - 'edit any uiowa_button block content'
+  - 'edit any uiowa_card block content'
+  - 'edit any uiowa_collection block content'
+  - 'edit any uiowa_cta block content'
+  - 'edit any uiowa_event block content'
+  - 'edit any uiowa_events block content'
+  - 'edit any uiowa_hero block content'
+  - 'edit any uiowa_image block content'
+  - 'edit any uiowa_image_gallery block content'
+  - 'edit any uiowa_page_title_hero block content'
+  - 'edit any uiowa_quote block content'
+  - 'edit any uiowa_slider block content'
+  - 'edit any uiowa_spacer_separator block content'
+  - 'edit any uiowa_statistic block content'
   - 'edit any uiowa_text_area block content'
+  - 'edit any uiowa_timeline block content'
   - 'edit any video media'
   - 'edit any webform'
   - 'edit any webform submission'

--- a/config/sites/uiowa.edu/config_split.patch.user.role.webmaster.yml
+++ b/config/sites/uiowa.edu/config_split.patch.user.role.webmaster.yml
@@ -1,10 +1,14 @@
 adding:
   dependencies:
     config:
+      - block_content.type.uiowa_vertical_video
       - taxonomy.vocabulary.a_z_list
   permissions:
     - 'administer search-links menu items'
     - 'create terms in a_z_list'
+    - 'create uiowa_vertical_video block content'
+    - 'delete any uiowa_vertical_video block content'
     - 'delete terms in a_z_list'
+    - 'edit any uiowa_vertical_video block content'
     - 'edit terms in a_z_list'
 removing: {  }


### PR DESCRIPTION
gave webmaster the ability to edit/delete hero, page title hero, separator as these are still blocks that may still exist. we don't want folks to create new instances.

based on https://iowaweb.slack.com/archives/C0164FNN1PV/p1701709721548589

# To Test

As a webmaster, I can create a new card block with a media reference item and not get an error.
As a webmaster on uiowa.edu, I can edit the vertical video blocks on the homepage.
Note: Publisher did not have these permissions. Stacked from editor role: https://github.com/uiowa/uiowa/pull/7098/files#diff-248671d07e9077b908e8debaa71eb3571cf6683c152e2b110b24a88306af8e66

```
ddev drush @home.local sql-drop -y && ddev drush @home.local cr && ddev blt ds --site=uiowa.edu
```