### PR TITLE
Hotfix for unstyled unauthorized page in SiteNow Intranet

### DIFF
--- a/docroot/modules/custom/sitenow_intranet/src/EventSubscriber/SitenowIntranetSubscriber.php
+++ b/docroot/modules/custom/sitenow_intranet/src/EventSubscriber/SitenowIntranetSubscriber.php
@@ -59,6 +59,8 @@ class SitenowIntranetSubscriber implements EventSubscriberInterface {
           'samlauth.saml_controller_login',
           'user.login',
           'user.reset.login',
+          'system.css_asset',
+          'system.js_asset',
         ])) {
           throw new UnauthorizedHttpException('Login, yo!');
         }


### PR DESCRIPTION
# How to test

```
ddev blt ds --site intranet.shl.uiowa.edu
```
- Change `FALSE` to `TRUE` in line `62` of `docroot/sites/intranet.shl.uiowa.edu/settings/local.settings.php`
- Visit https://shlintranet.uiowa.ddev.site and confirm that the page is not unstyled.