### PR TITLE
[Bug] exposedFormEnhancements bug fix

### DIFF
--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -722,18 +722,6 @@ function uiowa_core_form_alter(&$form, FormStateInterface $form_state, $form_id)
     case 'node_person_form':
       $form['field_person_types']['#attributes']['class'][] = 'multi--column';
       break;
-
-    case 'views_exposed_form':
-      $form['#attached']['library'][] = 'uiowa_core/exposedFormEnhancements';
-
-      // Fixes a bug with BEF, details here:
-      // https://www.drupal.org/project/better_exposed_filters/issues/3264403#comment-14803047
-      foreach ($form as $k => $v) {
-        if (str_contains($k, '_collapsible')) {
-          $form[$k]['#open'] = FALSE;
-        }
-      }
-      break;
   }
 }
 

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -53,6 +53,15 @@ function uids_base_form_views_exposed_form_alter(&$form, $form_state, $form_id) 
   // For all views with exposed filters.
   if ($form_id === 'views_exposed_form') {
     $form['#attributes']['class'][] = 'uids-content bg--gray';
+    $form['#attached']['library'][] = 'uiowa_core/exposedFormEnhancements';
+
+    // Fixes a bug with BEF, details here:
+    // https://www.drupal.org/project/better_exposed_filters/issues/3264403#comment-14803047
+    foreach ($form as $k => $v) {
+      if (str_contains($k, '_collapsible')) {
+        $form[$k]['#open'] = FALSE;
+      }
+    }
   }
   // For these views specifically.
   $view_ids = ['book_toc', 'book_search'];


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/7162

```
ddev blt ds --site=classrooms.uiowa.edu && ddev drush @classrooms.local uli /spaces/find-university-classroom
```
### Confirm select list selected items have `brand-secondary` inline style on them. 

<img width="291" alt="Screenshot 2023-12-12 at 8 37 29 AM" src="https://github.com/uiowa/uiowa/assets/1036433/fa4084d0-3c8b-4f61-b136-9306ca5279c1">


### Confirm action items select is visible.
<img width="771" alt="Screenshot 2023-12-12 at 8 36 46 AM" src="https://github.com/uiowa/uiowa/assets/1036433/c1e7d8f1-5988-4ea7-a91f-7c685368af24">


