### PR TITLE
[Bug] UIowa Hours fix

### DIFF
--- a/docroot/themes/custom/uids_base/uids_base.libraries.yml
+++ b/docroot/themes/custom/uids_base/uids_base.libraries.yml
@@ -214,8 +214,6 @@ stat:
   css:
     component:
       assets/css/components/stat.css: { preprocess: false }
-  js:
-    uids3/components/stat/stat.js: { preprocess: false }
 timeline:
   css:
     component:


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/7194. 

# How to test

1. Change line 63 of local.settings.php for recserv.uiowa.edu to `$config['system.performance']['js']['preprocess'] = TRUE;`
2. Confirm logged-in home page hours block and https://recserv.uiowa.ddev.site/hours works
2. Confirm anonymous https://recserv.uiowa.ddev.site/hours and front page home page hours block works

```
ddev blt ds --site=recserv.uiowa.edu && ddev drush @recserv.local uli /
```


