### PR TITLE
Fixed use strict in lazy load.

### DIFF
--- a/docroot/themes/custom/uids_base/assets/js/lazy_load_animation.js
+++ b/docroot/themes/custom/uids_base/assets/js/lazy_load_animation.js
@@ -1,7 +1,5 @@
-'use strict';
-
 (function ($, Drupal) {
-
+  'use strict';
   Drupal.behaviors.nativeLazyLoadAnimation = {
     attach: function (context) {
       $(once('lazy-load-animation','img.lazyload')).on('load', function () {


### PR DESCRIPTION
use strict was being globally scoped, breaking other JS

## To test
1. before checking out this branch, Sync engineering
2. Go to `/me`
3. observe no secondary menu dropdown arrows
4. open console
5. observe js error for 'loadjs not declared'
6. checkout this branch
7. clear cache
8. observe the above is not true.