### PR TITLE
Fix for buildings import

### DIFF
--- a/docroot/sites/facilities.uiowa.edu/modules/facilities_core/src/BuildingItemProcessor.php
+++ b/docroot/sites/facilities.uiowa.edu/modules/facilities_core/src/BuildingItemProcessor.php
@@ -36,24 +36,36 @@ class BuildingItemProcessor extends EntityItemProcessorBase {
    * Process the field_building_hours.
    */
   public static function process($entity, $record): bool {
-    $days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+    $updated = parent::process($entity, $record);
+
+    $days = [
+      'monday',
+      'tuesday',
+      'wednesday',
+      'thursday',
+      'friday',
+      'saturday',
+      'sunday',
+    ];
     $combined_hours = '';
 
     foreach ($days as $day) {
       $hours_property = $day . 'Hours';
       if (isset($record->{$hours_property})) {
-        $formatted_hours = "<strong>" . ucfirst($day) . "</strong>: " . $record->{$hours_property};
+        $formatted_hours = '<strong>' . ucfirst($day) . '</strong>: ' . $record->{$hours_property};
         $combined_hours .= $formatted_hours . '<br />';
       }
     }
+    if (!empty($combined_hours)) {
+      // Assign the combined hours as processed text.
+      $entity->set('field_building_hours', [
+        'value' => $combined_hours,
+        'format' => 'filtered_html',
+      ]);
+      $updated = TRUE;
+    }
 
-    // Assign the combined hours as processed text.
-    $entity->set('field_building_hours', [
-      'value' => $combined_hours,
-      'format' => 'filtered_html',
-    ]);
-
-    return TRUE;
+    return $updated;
   }
 
 }


### PR DESCRIPTION
Currently only building hours are being imported. If there are any new updates to other fields, those are being skipped over.

# To Test

If you haven't in a while, `ddev composer install && ddev blt ds --site=facilities.uiowa.edu`

On `main` set a breakpoint on \Drupal\uiowa_core\EntityItemProcessorBase::process and \Drupal\facilities_core\BuildingItemProcessor::process

Enable xdebug and run `ddev drush @facilities.local fm-buildings`

Note that only \Drupal\facilities_core\BuildingItemProcessor::process is triggered and hours are added to building nodes. Feel free to kill the import a couple nodes in.

Now checkout `fix_building_hours_import` and run fm-buildings again. Note that both run.

Referenced \Drupal\classrooms_core\RoomItemProcessor::process for this fix.