### PR TITLE
rollback memory limit for now

### DIFF
--- a/.ddev/php/memory_limit.ini
+++ b/.ddev/php/memory_limit.ini
@@ -1,2 +1,0 @@
-[PHP]
-memory_limit = 128M


### PR DESCRIPTION
Folks are having issues syncing sites locally with this limit in place. Rolling back for now. Sean thought maybe we could have different limits based on CLI vs Web