### PR TITLE
Updated status command hooks implementations for Drush 12

### DIFF
--- a/drush/Commands/UiowaCommands.php
+++ b/drush/Commands/UiowaCommands.php
@@ -55,16 +55,13 @@ class UiowaCommands extends DrushCommands implements SiteAliasManagerAwareInterf
    * @hook init core:status
    */
   public function initStatus(InputInterface $input, AnnotationData $annotationData) {
-    $fields = explode(',', $input->getOption('fields'));
-    $defaults = $annotationData->getList('default-fields');
+    $field_labels = $annotationData->getList('field-labels');
+    $field_labels['application'] = 'Application';
+    $annotationData->set('field-labels', $field_labels);
 
-    // If no specific fields were requested, add ours to the defaults.
-    if ($fields == $defaults) {
-      $annotationData->append('field-labels', "\n application: Application");
-      array_unshift($defaults, 'application');
-      $annotationData->set('default-fields', $defaults);
-      $input->setOption('fields', $defaults);
-    }
+    $defaults = $annotationData->getList('default-table-fields');
+    array_unshift($defaults, 'application');
+    $annotationData->set('default-table-fields', $defaults);
   }
 
   /**


### PR DESCRIPTION
Resolves #7380 

# How to test

## First, test that this works as expected under normal local conditions:
```
ddev drush @default.local status
```
Output should not include a line with `Application      : `.
```
ddev drush @default.local status --fields application
```
There should be no output.
```
ddev drush @default.local status --field application
```
Should output a blank line.

## Next, test this as if we were in production:
Add the following snippet in `.ddev/config.yaml` after the `disable_settings_management: true` line:
```yaml
web_environment:
  - AH_SITE_GROUP=uiowa20
```
And run `ddev restart`
```
ddev drush @default.local status
```
Output should include `Application      : uiowa20`.
```
ddev drush @default.local status --fields application
```
Output should be
```
Application : uiowa20 
```
```
ddev drush @default.local status --field application
```
Output should be
```
uiowa20
```

## After you're done testing
```
git reset --hard && ddev restart
```
should restore your local environment to not reporting an application.