### PR TITLE
Update Search to use homepage

### DIFF
--- a/docroot/modules/custom/uiowa_search/src/Controller/UiowaSearchResultsController.php
+++ b/docroot/modules/custom/uiowa_search/src/Controller/UiowaSearchResultsController.php
@@ -24,27 +24,13 @@ class UiowaSearchResultsController extends ControllerBase {
     $config = $this->config('uiowa_search.settings')->get('uiowa_search');
     $search_terms = $request->get('terms');
 
-    $search_params = [
-      'q' => $search_terms,
-      'client' => 'our_frontend',
-      'btnG' => 'Search',
-      'output' => 'xml_no_dtd',
-      'proxystylesheet' => 'our_frontend',
-      'sort' => 'date',
-      'entqr' => '0',
-      'oe' => 'UTF-8',
-      'ie' => 'UTF-8',
-      'ud' => '1',
-      'site' => 'default_collection',
-    ];
-
     $display_search_all_uiowa = $config['display_search_all_uiowa'] ?? TRUE;
 
     if ($display_search_all_uiowa) {
       $build['search'] = [
         '#type' => 'link',
         '#title' => $this->t('Search all University of Iowa for @terms', ['@terms' => $search_terms]),
-        '#url' => Url::fromUri('https://search.uiowa.edu', ['query' => $search_params]),
+        '#url' => Url::fromUri('https://uiowa.edu/search', ['query' => ['terms' => $search_terms]]),
         '#attributes' => [
           'target' => '_blank',
         ],


### PR DESCRIPTION
Relates to #7398, but does not close.

# To Test

```
ddev blt ds --site=sandbox.uiowa.edu
```

Go to https://sandbox.uiowa.ddev.site/search?terms=sitenow and click on the "Search all Univ..." link. It should properly take you to uiowa.edu/search and return results. Note while you are there that the homepage (prod) does not have the link visible.

Based on the discussion on the issue, the old parameters are not necessary for this solution anymore.
