### PR TITLE
Hotfix: Default more link for page list block

### DIFF
--- a/config/default/views.view.page_list_block.yml
+++ b/config/default/views.view.page_list_block.yml
@@ -520,6 +520,8 @@ display:
           query_tags: {  }
       relationships: {  }
       use_ajax: true
+      link_display: custom_url
+      link_url: '<front>'
       header: {  }
       footer: {  }
       display_extenders: {  }
@@ -560,7 +562,7 @@ display:
         use_more: use_more
         configure_filters_custom: 0
       general_help_text: '<a href="/admin/content?title=&type=page&status=1" target="_blank" rel="noopener">Manage existing pages on this site</a> or <a href="/node/add/page" target="_blank" rel="noopener">add a page here</a>.'
-      more_link_help_text: ''
+      more_link_help_text: "Check to include a 'display more' link. By default this will link to the front page of the website. Alternatively, a custom URL path can be provided in the ‘Path’ text box below."
       restrict_fields:
         title: title
         field_image: 0


### PR DESCRIPTION
Resolves issue seen on Writer's Workshop site that caused WSOD.

# How to test
```
ddev blt ds --site writersworkshop.uiowa.edu && ddev drush @writersworkshop.local uli node/66/revisions/12386/revert
```
- Revert the revision
- Visit https://writersworkshop.uiowa.ddev.site/publications and confirm that the page loads.
- Test that you can set a custom more URL.
- Test that the default more link (`<front>`) works if no custom path is set.