### PR TITLE
Dompdf security fix

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -28,9 +28,6 @@ drush:
   aliases:
     ci: self
   default_alias: self
-disable-targets:
-  tests:
-    security-drupal: true
 tests:
   phpunit:
     - config: '${repo.root}'

--- a/composer.lock
+++ b/composer.lock
@@ -14337,16 +14337,16 @@
         },
         {
             "name": "phenx/php-svg-lib",
-            "version": "0.5.2",
+            "version": "0.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dompdf/php-svg-lib.git",
-                "reference": "732faa9fb4309221e2bd9b2fda5de44f947133aa"
+                "reference": "0e46722c154726a5f9ac218197ccc28adba16fcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/732faa9fb4309221e2bd9b2fda5de44f947133aa",
-                "reference": "732faa9fb4309221e2bd9b2fda5de44f947133aa",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/0e46722c154726a5f9ac218197ccc28adba16fcf",
+                "reference": "0e46722c154726a5f9ac218197ccc28adba16fcf",
                 "shasum": ""
             },
             "require": {
@@ -14365,7 +14365,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "LGPL-3.0"
+                "LGPL-3.0-or-later"
             ],
             "authors": [
                 {
@@ -14377,9 +14377,9 @@
             "homepage": "https://github.com/PhenX/php-svg-lib",
             "support": {
                 "issues": "https://github.com/dompdf/php-svg-lib/issues",
-                "source": "https://github.com/dompdf/php-svg-lib/tree/0.5.2"
+                "source": "https://github.com/dompdf/php-svg-lib/tree/0.5.3"
             },
-            "time": "2024-02-07T12:49:40+00:00"
+            "time": "2024-02-23T20:39:24+00:00"
         },
         {
             "name": "phootwork/collection",


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/7454

# To Test

- [See that blt/travis goes through security checks successfully](https://app.travis-ci.com/github/uiowa/uiowa/builds/269490965).
- Test admissions pdfs for noticeable issues:
  - `ddev blt ds --site=admissions.uiowa.edu && ddev drush @admissions.local uli print/pdf/node/2786`
  - Try a few more here admissions.uiowa.ddev.site/areas-of-study/print-links and compare with https://admissions.uiowa.edu/areas-of-study/print-links