### PR TITLE
[Bug] V2 events spacing

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/event.scss
+++ b/docroot/themes/custom/uids_base/scss/components/event.scss
@@ -85,6 +85,7 @@
   .paragraph--type--events.grid & {
     .card {
       &__row {
+        margin-top: 0!important;
         display: inline-block;
         padding: 1.5rem;
         margin: 0;
@@ -109,6 +110,7 @@
   .paragraph--type--events.masonry & {
     .card {
       &__row {
+        margin-top: 0!important;
         display: inline-block;
         padding: 1.5rem;
         border: none;

--- a/docroot/themes/custom/uids_base/templates/paragraphs/paragraph--events--default.html.twig
+++ b/docroot/themes/custom/uids_base/templates/paragraphs/paragraph--events--default.html.twig
@@ -44,7 +44,8 @@
     'paragraph--type--' ~ paragraph.bundle|clean_class,
     view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
     not paragraph.isPublished() ? 'paragraph--unpublished',
-    'list-container'
+    'list-container',
+    'list-container--list',
   ]
 %}
 


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/7430

# How to test

```
blt frontend && ddev blt ds --site=law.uiowa.edu && ddev drush @law.local uli /events
```

- Confirm that list has spacing
- Confirm that masonry and grid options do not have top margin spacing