### PR TITLE
Hotfix: Update hook to fix incorrect class reference stored in tempstore

### DIFF
--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -3140,8 +3140,6 @@ function sitenow_update_10006() {
  * Fix block references that stored the wrong bundle class for pages.
  */
 function sitenow_update_10007() {
-
-  $block_plugin_ids = ['views_block:page_list_block-list_page'];
   $db = \Drupal::database();
 
   // Only continue with this section if we have a key_value_expire
@@ -3160,7 +3158,6 @@ function sitenow_update_10007() {
     \Drupal::messenger()
       ->addMessage(t('Tempstore records for layouts containing reference to incorrect page bundle class: @count',
         [
-          '@types' => implode(', ', $block_plugin_ids),
           '@count' => $count,
         ]));
 

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -3147,18 +3147,8 @@ function sitenow_update_10007() {
   // Only continue with this section if we have a key_value_expire
   // table to work with.
   if ($db->schema()->tableExists('key_value_expire')) {
-    // Check if we have a tempstore of this node.
-    // Temp store is saved in the db in the key_value_expire,
-    // And holds a serialized blob with the unsaved changes.
-    // Might be a better method of accessing this through the Layout
-    // Builder API and layoutTempstoreRepository, but have not found it yet.
+    // Directly accessing KVE record.
     $query = $db->select('key_value_expire', 'kve');
-
-    // Match against any record that has a block matching our $block_plugin_id.
-    $or_group = $query->orConditionGroup();
-    foreach ($block_plugin_ids as $block_plugin_id) {
-      $or_group = $or_group->condition('value', "%$block_plugin_id%", 'LIKE');
-    }
 
     $query = $query->condition('collection',
       'tempstore.shared.layout_builder.section_storage.overrides', '=')
@@ -3168,7 +3158,7 @@ function sitenow_update_10007() {
     $count = $query->countQuery()->execute()->fetchField();
 
     \Drupal::messenger()
-      ->addMessage(t('Tempstore records for sections with blocks of @types records found: @count',
+      ->addMessage(t('Tempstore records for layouts containing reference to incorrect page bundle class: @count',
         [
           '@types' => implode(', ', $block_plugin_ids),
           '@count' => $count,
@@ -3179,6 +3169,7 @@ function sitenow_update_10007() {
 
     foreach ($results as $record) {
 
+      // Directly manipulating the string because we can't serialize this because the class doesn't exist anymore.
       $record->value = str_replace('Drupal\uiowa_core\Entity\Page', 'Drupal\sitenow_pages\Entity\Page', $record->value);
 
       // Insert the updated tempstore.

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -3135,3 +3135,61 @@ function sitenow_update_10006() {
     ->set('uiowa_core.replicate_allowed', $replicate_allowed)
     ->save();
 }
+
+/**
+ * Fix block references that stored the wrong bundle class for pages.
+ */
+function sitenow_update_10007() {
+
+  $block_plugin_ids = ['views_block:page_list_block-list_page'];
+  $db = \Drupal::database();
+
+  // Only continue with this section if we have a key_value_expire
+  // table to work with.
+  if ($db->schema()->tableExists('key_value_expire')) {
+    // Check if we have a tempstore of this node.
+    // Temp store is saved in the db in the key_value_expire,
+    // And holds a serialized blob with the unsaved changes.
+    // Might be a better method of accessing this through the Layout
+    // Builder API and layoutTempstoreRepository, but have not found it yet.
+    $query = $db->select('key_value_expire', 'kve');
+
+    // Match against any record that has a block matching our $block_plugin_id.
+    $or_group = $query->orConditionGroup();
+    foreach ($block_plugin_ids as $block_plugin_id) {
+      $or_group = $or_group->condition('value', "%$block_plugin_id%", 'LIKE');
+    }
+
+    $query = $query->condition('collection',
+      'tempstore.shared.layout_builder.section_storage.overrides', '=')
+      ->condition('value', '%uiowa_core%', 'LIKE')
+      ->fields('kve');
+
+    $count = $query->countQuery()->execute()->fetchField();
+
+    \Drupal::messenger()
+      ->addMessage(t('Tempstore records for sections with blocks of @types records found: @count',
+        [
+          '@types' => implode(', ', $block_plugin_ids),
+          '@count' => $count,
+        ]));
+
+    $results = $query
+      ->execute();
+
+    foreach ($results as $record) {
+
+      $record->value = str_replace('Drupal\uiowa_core\Entity\Page', 'Drupal\sitenow_pages\Entity\Page', $record->value);
+
+      // Insert the updated tempstore.
+      $db->update('key_value_expire')
+        ->condition('name', $record->name, '=')
+        ->condition('expire', $record->expire, '=')
+        ->fields([
+          'value' => serialize($record->value),
+        ])
+        ->execute();
+    }
+  }
+
+}

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -3167,14 +3167,14 @@ function sitenow_update_10007() {
     foreach ($results as $record) {
 
       // Directly manipulating the string because we can't serialize this because the class doesn't exist anymore.
-      $record->value = str_replace('Drupal\uiowa_core\Entity\Page', 'Drupal\sitenow_pages\Entity\Page', $record->value);
+      $record->value = str_replace('O:29:"Drupal\uiowa_core\Entity\Page', 'O:32:"Drupal\sitenow_pages\Entity\Page', $record->value);
 
       // Insert the updated tempstore.
       $db->update('key_value_expire')
         ->condition('name', $record->name, '=')
         ->condition('expire', $record->expire, '=')
         ->fields([
-          'value' => serialize($record->value),
+          'value' => $record->value,
         ])
         ->execute();
     }


### PR DESCRIPTION
Resolves issue with being unable to load layout builder on pages that previously added a page list block but hadn't saved yet when our deployment ran.

# How to test

```
ddev blt ds --site writersworkshop.uiowa.edu && ddev drush @writersworkshop.local uli node/211/layout
```
- Confirm no WSOD/500 error.
