### PR TITLE
[Hotfix] Switched to auto-fill to fix Safari bug

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/page-layouts.scss
+++ b/docroot/themes/custom/uids_base/scss/components/page-layouts.scss
@@ -82,11 +82,11 @@ main {
 
 .grid--3-2 .layout__region {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(50%, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(50%, 1fr));
 
 
   @include breakpoint(sm) {
-    grid-template-columns: repeat(auto-fit, minmax(33.3%, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(33.3%, 1fr));
   }
 }
 
@@ -114,11 +114,11 @@ main {
   }
 
   @include breakpoint(sm) {
-    grid-template-columns: repeat(auto-fit, minmax(50%, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(50%, 1fr));
   }
 
   @include breakpoint(page-container) {
-    grid-template-columns: repeat(auto-fit, minmax(33.3%, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(33.3%, 1fr));
   }
 }
 


### PR DESCRIPTION
This pr fixes the display for the stat grid on the home page. 

<img width="1095" alt="Screenshot 2024-04-15 at 11 05 43 AM" src="https://github.com/uiowa/uiowa/assets/1036433/fcc26318-e6b2-4c8c-bf45-4ead256f2c3b">

# How to test

```
ddev blt frontend && ddev blt ds --site=uiowa.edu && ddev drush @home.local uli 
```
