### PR TITLE
Commencement venue

### DIFF
--- a/config/default/config_split.config_split.event.yml
+++ b/config/default/config_split.config_split.event.yml
@@ -10,9 +10,7 @@ stackable: true
 storage: folder
 folder: ../config/features/event
 module:
-  better_exposed_filters: 0
   fullcalendar_view: 0
-  geofield: 0
   jquery_ui: 0
   jquery_ui_datepicker: 0
   jquery_ui_slider: 0

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -50,6 +50,7 @@ module:
   focal_point: 0
   fontawesome: 0
   fragments: 0
+  geofield: 0
   google_analytics: 0
   google_tag: 0
   heading: 0

--- a/config/default/field.storage.node.field_geolocation.yml
+++ b/config/default/field.storage.node.field_geolocation.yml
@@ -1,0 +1,20 @@
+uuid: 24c6132a-e6b0-4738-a59f-776ea370b297
+langcode: en
+status: true
+dependencies:
+  module:
+    - geofield
+    - node
+id: node.field_geolocation
+field_name: field_geolocation
+entity_type: node
+type: geofield
+settings:
+  backend: geofield_backend_default
+module: geofield
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.node.field_location.yml
+++ b/config/default/field.storage.node.field_location.yml
@@ -1,0 +1,19 @@
+uuid: 23cb14d3-d0d4-4f6f-908b-2a8cb2318a1d
+langcode: en
+status: true
+dependencies:
+  module:
+    - address
+    - node
+id: node.field_location
+field_name: field_location
+entity_type: node
+type: address
+settings: {  }
+module: address
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sites/admissions.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/admissions.uiowa.edu/config_split.config_split.site.yml
@@ -13,7 +13,6 @@ module:
   better_exposed_filters: 0
   captcha: 0
   entity_print_views: 0
-  geofield: 0
   hcaptcha: 0
   jquery_ui: 0
   jquery_ui_datepicker: 0

--- a/config/sites/commencement.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/commencement.uiowa.edu/config_split.config_split.site.yml
@@ -9,7 +9,8 @@ weight: 70
 stackable: false
 storage: folder
 folder: ../config/sites/commencement.uiowa.edu
-module: {  }
+module:
+  commencement_core: 0
 theme: {  }
 complete_list:
   - config_split.config_split.site

--- a/config/sites/commencement.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/commencement.uiowa.edu/config_split.config_split.site.yml
@@ -23,6 +23,7 @@ complete_list:
   - taxonomy.vocabulary.celebrations
   - taxonomy.vocabulary.college
   - taxonomy.vocabulary.session
+  - views.view.events_by_venue
   - taxonomy.vocabulary.department
   - 'field.storage.node.field_event_*'
   - 'field.storage.node.field_venue_*'

--- a/config/sites/commencement.uiowa.edu/core.entity_form_display.node.event.default.yml
+++ b/config/sites/commencement.uiowa.edu/core.entity_form_display.node.event.default.yml
@@ -70,16 +70,17 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
-      closed_mode: summary
-      autocollapse: none
+      edit_mode: closed
+      closed_mode: preview
+      autocollapse: all
       closed_mode_threshold: 0
-      add_mode: dropdown
+      add_mode: button
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: uiowa_collection_item
       features:
-        collapse_edit_all: collapse_edit_all
-        duplicate: duplicate
+        add_above: '0'
+        collapse_edit_all: '0'
+        duplicate: '0'
     third_party_settings: {  }
   field_event_college:
     type: options_select
@@ -132,11 +133,11 @@ content:
       media_types: {  }
     third_party_settings: {  }
   field_event_livestream_caption:
-    type: text_textfield
-    weight: 26
+    type: text_textarea
+    weight: 30
     region: content
     settings:
-      size: 60
+      rows: 5
       placeholder: ''
     third_party_settings: {  }
   field_event_order_of_events:

--- a/config/sites/commencement.uiowa.edu/core.entity_form_display.node.venue.default.yml
+++ b/config/sites/commencement.uiowa.edu/core.entity_form_display.node.venue.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.venue.body
     - field.field.node.venue.field_geolocation
+    - field.field.node.venue.field_image
     - field.field.node.venue.field_location
     - field.field.node.venue.field_meta_tags
     - node.type.venue
@@ -13,6 +14,7 @@ dependencies:
     - address
     - content_moderation
     - geofield
+    - media_library
     - metatag
     - path
     - text
@@ -23,7 +25,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 121
+    weight: 4
     region: content
     settings:
       rows: 9
@@ -33,26 +35,33 @@ content:
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   field_geolocation:
     type: geofield_latlon
-    weight: 122
+    weight: 2
     region: content
     settings:
       html5_geolocation: false
     third_party_settings: {  }
+  field_image:
+    type: media_library_widget
+    weight: 1
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
   field_location:
     type: address_default
-    weight: 123
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   field_meta_tags:
     type: metatag_firehose
-    weight: 8
+    weight: 6
     region: content
     settings:
       sidebar: true
@@ -60,45 +69,45 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 15
+    weight: 9
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 120
+    weight: 14
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 16
+    weight: 10
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -115,7 +124,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 50
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sites/commencement.uiowa.edu/core.entity_form_display.node.venue.default.yml
+++ b/config/sites/commencement.uiowa.edu/core.entity_form_display.node.venue.default.yml
@@ -4,11 +4,13 @@ status: true
 dependencies:
   config:
     - field.field.node.venue.body
+    - field.field.node.venue.field_geolocation
     - field.field.node.venue.field_meta_tags
     - node.type.venue
     - workflows.workflow.editorial
   module:
     - content_moderation
+    - geofield
     - metatag
     - path
     - text
@@ -32,6 +34,13 @@ content:
     weight: 10
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_geolocation:
+    type: geofield_latlon
+    weight: 122
+    region: content
+    settings:
+      html5_geolocation: false
     third_party_settings: {  }
   field_meta_tags:
     type: metatag_firehose

--- a/config/sites/commencement.uiowa.edu/core.entity_form_display.node.venue.default.yml
+++ b/config/sites/commencement.uiowa.edu/core.entity_form_display.node.venue.default.yml
@@ -5,10 +5,12 @@ dependencies:
   config:
     - field.field.node.venue.body
     - field.field.node.venue.field_geolocation
+    - field.field.node.venue.field_location
     - field.field.node.venue.field_meta_tags
     - node.type.venue
     - workflows.workflow.editorial
   module:
+    - address
     - content_moderation
     - geofield
     - metatag
@@ -41,6 +43,12 @@ content:
     region: content
     settings:
       html5_geolocation: false
+    third_party_settings: {  }
+  field_location:
+    type: address_default
+    weight: 123
+    region: content
+    settings: {  }
     third_party_settings: {  }
   field_meta_tags:
     type: metatag_firehose

--- a/config/sites/commencement.uiowa.edu/core.entity_view_display.node.event.default.yml
+++ b/config/sites/commencement.uiowa.edu/core.entity_view_display.node.event.default.yml
@@ -118,7 +118,7 @@ content:
     region: content
   field_event_livestream_caption:
     type: text_default
-    label: visually_hidden
+    label: above
     settings: {  }
     third_party_settings: {  }
     weight: 16

--- a/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.default.yml
+++ b/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.default.yml
@@ -5,15 +5,207 @@ dependencies:
   config:
     - field.field.node.venue.body
     - field.field.node.venue.field_geolocation
+    - field.field.node.venue.field_image
     - field.field.node.venue.field_location
     - field.field.node.venue.field_meta_tags
     - node.type.venue
   module:
     - address
     - geofield
+    - layout_builder
     - metatag
+    - system
     - text
     - user
+  theme:
+    - uids_base
+third_party_settings:
+  layout_builder:
+    enabled: true
+    allow_custom: false
+    sections:
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: ''
+          context_mapping: {  }
+          layout_builder_styles_style:
+            - ''
+            - section_margin_fixed_width_container
+        components:
+          -
+            uuid: 8a266267-75c9-4697-b0de-3155e9b8b32d
+            region: content
+            configuration:
+              id: 'extra_field_block:node:venue:content_moderation_control'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+            weight: 0
+            additional: {  }
+            third_party_settings: {  }
+        third_party_settings: {  }
+      -
+        layout_id: layout_header
+        layout_settings:
+          label: Header
+          context_mapping: {  }
+          layout_builder_styles_style:
+            - ''
+            - section_margin_edge_to_edge
+        components:
+          -
+            uuid: a7049687-6bf7-427d-aeff-f2ba4255e9e4
+            region: background
+            configuration:
+              id: 'field_block:node:venue:field_image'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              formatter:
+                type: entity_reference_entity_view
+                label: visually_hidden
+                settings:
+                  view_mode: full__ultrawide
+                  link: false
+                third_party_settings: {  }
+            weight: 0
+            additional: {  }
+            third_party_settings: {  }
+          -
+            uuid: e9e8660a-7a58-4f82-a872-ef00a1d89a85
+            region: content
+            configuration:
+              id: 'field_block:node:venue:title'
+              label: null
+              label_display: null
+              provider: layout_builder
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+              formatter:
+                type: string
+                label: hidden
+                settings:
+                  link_to_entity: false
+                third_party_settings: {  }
+            weight: 1
+            additional:
+              layout_builder_styles_style: {  }
+            third_party_settings: {  }
+          -
+            uuid: fd1f990c-bb7c-4881-b3fc-706559a96230
+            region: content
+            configuration:
+              id: system_breadcrumb_block
+              label: null
+              label_display: null
+              provider: system
+              context_mapping: {  }
+            weight: 2
+            additional:
+              layout_builder_styles_style: {  }
+            third_party_settings: {  }
+        third_party_settings: {  }
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: ''
+        components:
+          -
+            uuid: 375f60ed-00a6-49f0-b575-fb85cde6299c
+            region: content
+            configuration:
+              id: 'field_block:node:venue:field_meta_tags'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              formatter:
+                type: metatag_empty_formatter
+                label: above
+                settings: {  }
+                third_party_settings: {  }
+            weight: 6
+            additional: {  }
+            third_party_settings: {  }
+          -
+            uuid: d4c7c685-921a-4c78-88e6-ddf09ac1c180
+            region: content
+            configuration:
+              id: 'field_block:node:venue:field_location'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              formatter:
+                type: address_default
+                label: above
+                settings: {  }
+                third_party_settings: {  }
+            weight: 7
+            additional: {  }
+            third_party_settings: {  }
+          -
+            uuid: a5a44d74-4189-4478-be28-b45b42195735
+            region: content
+            configuration:
+              id: 'field_block:node:venue:field_geolocation'
+              label: null
+              label_display: null
+              provider: layout_builder
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+              formatter:
+                type: geofield_latlon
+                label: visually_hidden
+                settings:
+                  output_format: decimal
+                third_party_settings: {  }
+            weight: 2
+            additional:
+              layout_builder_styles_style: {  }
+            third_party_settings: {  }
+          -
+            uuid: 8dc6c269-00b5-4cec-868e-193da8050f48
+            region: content
+            configuration:
+              id: 'field_block:node:venue:field_location'
+              label: null
+              label_display: null
+              provider: layout_builder
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+              formatter:
+                type: address_default
+                label: visually_hidden
+                settings: {  }
+                third_party_settings: {  }
+            weight: 8
+            additional:
+              layout_builder_styles_style: {  }
+            third_party_settings: {  }
+          -
+            uuid: 983d487f-a50f-4566-a260-6b6b273ad111
+            region: content
+            configuration:
+              id: 'field_block:node:venue:body'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              formatter:
+                type: text_default
+                label: hidden
+                settings: {  }
+                third_party_settings: {  }
+            weight: 5
+            additional: {  }
+            third_party_settings: {  }
+        third_party_settings:
+          layout_builder_limit:
+            limit:
+              scope: disabled
+              scope_update: 'Update scope'
 id: node.venue.default
 targetEntityType: node
 bundle: venue
@@ -39,6 +231,15 @@ content:
       output_escape: true
     third_party_settings: {  }
     weight: 103
+    region: content
+  field_image:
+    type: entity_reference_entity_view
+    label: visually_hidden
+    settings:
+      view_mode: full__ultrawide
+      link: false
+    third_party_settings: {  }
+    weight: 105
     region: content
   field_location:
     type: address_default

--- a/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.default.yml
+++ b/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.venue.field_location
     - field.field.node.venue.field_meta_tags
     - node.type.venue
+    - views.view.events_by_venue
   module:
     - address
     - geofield
@@ -17,6 +18,7 @@ dependencies:
     - system
     - text
     - user
+    - views
   theme:
     - uids_base
 third_party_settings:
@@ -125,7 +127,7 @@ third_party_settings:
                 label: above
                 settings: {  }
                 third_party_settings: {  }
-            weight: 6
+            weight: 5
             additional: {  }
             third_party_settings: {  }
           -
@@ -141,7 +143,7 @@ third_party_settings:
                 label: above
                 settings: {  }
                 third_party_settings: {  }
-            weight: 7
+            weight: 6
             additional: {  }
             third_party_settings: {  }
           -
@@ -161,27 +163,7 @@ third_party_settings:
                 settings:
                   output_format: decimal
                 third_party_settings: {  }
-            weight: 2
-            additional:
-              layout_builder_styles_style: {  }
-            third_party_settings: {  }
-          -
-            uuid: 8dc6c269-00b5-4cec-868e-193da8050f48
-            region: content
-            configuration:
-              id: 'field_block:node:venue:field_location'
-              label: null
-              label_display: null
-              provider: layout_builder
-              context_mapping:
-                entity: layout_builder.entity
-                view_mode: view_mode
-              formatter:
-                type: address_default
-                label: visually_hidden
-                settings: {  }
-                third_party_settings: {  }
-            weight: 8
+            weight: 3
             additional:
               layout_builder_styles_style: {  }
             third_party_settings: {  }
@@ -198,8 +180,55 @@ third_party_settings:
                 label: hidden
                 settings: {  }
                 third_party_settings: {  }
-            weight: 5
+            weight: 4
             additional: {  }
+            third_party_settings: {  }
+          -
+            uuid: ef33c557-3fc6-4c04-bd9d-c7d42ee2a0d0
+            region: content
+            configuration:
+              id: 'field_block:node:venue:field_image'
+              label: null
+              label_display: null
+              provider: layout_builder
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+              formatter:
+                type: entity_reference_entity_view
+                label: visually_hidden
+                settings:
+                  view_mode: full__ultrawide
+                third_party_settings: {  }
+            weight: 2
+            additional:
+              layout_builder_styles_style: {  }
+            third_party_settings: {  }
+          -
+            uuid: df838a8b-2375-4fe3-8ee8-b418d2def509
+            region: content
+            configuration:
+              id: 'views_block:events_by_venue-block_1'
+              label: null
+              label_display: null
+              provider: views
+              context_mapping: {  }
+              views_label: ''
+              items_per_page: none
+              pager: some
+              exposed: {  }
+              headline:
+                headline: 'Upcoming events'
+                hide_headline: 0
+                heading_size: h2
+                headline_style: default
+                headline_alignment: default
+                child_heading_size: h3
+              exposed_filter_values: null
+              layout_builder_styles: {  }
+            weight: 7
+            additional:
+              layout_builder_styles_style: {  }
             third_party_settings: {  }
         third_party_settings:
           layout_builder_limit:

--- a/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.default.yml
+++ b/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.default.yml
@@ -4,9 +4,11 @@ status: true
 dependencies:
   config:
     - field.field.node.venue.body
+    - field.field.node.venue.field_geolocation
     - field.field.node.venue.field_meta_tags
     - node.type.venue
   module:
+    - geofield
     - metatag
     - text
     - user
@@ -26,6 +28,15 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: -20
+    region: content
+  field_geolocation:
+    type: geofield_default
+    label: above
+    settings:
+      output_format: wkt
+      output_escape: true
+    third_party_settings: {  }
+    weight: 103
     region: content
   field_meta_tags:
     type: metatag_empty_formatter

--- a/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.default.yml
+++ b/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.default.yml
@@ -5,9 +5,11 @@ dependencies:
   config:
     - field.field.node.venue.body
     - field.field.node.venue.field_geolocation
+    - field.field.node.venue.field_location
     - field.field.node.venue.field_meta_tags
     - node.type.venue
   module:
+    - address
     - geofield
     - metatag
     - text
@@ -37,6 +39,13 @@ content:
       output_escape: true
     third_party_settings: {  }
     weight: 103
+    region: content
+  field_location:
+    type: address_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 104
     region: content
   field_meta_tags:
     type: metatag_empty_formatter

--- a/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.teaser.yml
+++ b/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.venue.body
     - field.field.node.venue.field_geolocation
+    - field.field.node.venue.field_location
     - field.field.node.venue.field_meta_tags
     - node.type.venue
   module:
@@ -39,5 +40,6 @@ hidden:
   entity_print_view_pdf: true
   entity_print_view_word_docx: true
   field_geolocation: true
+  field_location: true
   field_meta_tags: true
   search_api_excerpt: true

--- a/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.teaser.yml
+++ b/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.venue.body
+    - field.field.node.venue.field_geolocation
     - field.field.node.venue.field_meta_tags
     - node.type.venue
   module:
@@ -37,5 +38,6 @@ hidden:
   entity_print_view_epub: true
   entity_print_view_pdf: true
   entity_print_view_word_docx: true
+  field_geolocation: true
   field_meta_tags: true
   search_api_excerpt: true

--- a/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.token.yml
+++ b/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.token.yml
@@ -1,9 +1,9 @@
-uuid: 5defe24e-9a0f-4cf7-83f7-e448ecbe51a7
+uuid: 76d5957c-6dd4-47b6-bc59-152bd2c863a9
 langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.teaser
+    - core.entity_view_mode.node.token
     - field.field.node.venue.body
     - field.field.node.venue.field_geolocation
     - field.field.node.venue.field_image
@@ -11,21 +11,12 @@ dependencies:
     - field.field.node.venue.field_meta_tags
     - node.type.venue
   module:
-    - text
     - user
-id: node.venue.teaser
+id: node.venue.token
 targetEntityType: node
 bundle: venue
-mode: teaser
+mode: token
 content:
-  body:
-    type: text_summary_or_trimmed
-    label: hidden
-    settings:
-      trim_length: 600
-    third_party_settings: {  }
-    weight: 101
-    region: content
   content_moderation_control:
     settings: {  }
     third_party_settings: {  }
@@ -33,12 +24,12 @@ content:
     region: content
   field_image:
     type: entity_reference_entity_view
-    label: hidden
+    label: visually_hidden
     settings:
       view_mode: large__widescreen
       link: false
     third_party_settings: {  }
-    weight: 6
+    weight: 0
     region: content
   links:
     settings: {  }
@@ -46,6 +37,7 @@ content:
     weight: 100
     region: content
 hidden:
+  body: true
   entity_print_view_epub: true
   entity_print_view_pdf: true
   entity_print_view_word_docx: true

--- a/config/sites/commencement.uiowa.edu/field.field.node.event.field_event_livestream_caption.yml
+++ b/config/sites/commencement.uiowa.edu/field.field.node.event.field_event_livestream_caption.yml
@@ -1,4 +1,4 @@
-uuid: 5fd06e2b-fc58-42c3-9a25-e7ec5c464ad6
+uuid: c4d0b0f2-b623-4a59-9180-c0ced1e97924
 langcode: en
 status: true
 dependencies:
@@ -21,4 +21,4 @@ default_value_callback: ''
 settings:
   allowed_formats:
     - filtered_html
-field_type: text
+field_type: text_long

--- a/config/sites/commencement.uiowa.edu/field.field.node.venue.field_geolocation.yml
+++ b/config/sites/commencement.uiowa.edu/field.field.node.venue.field_geolocation.yml
@@ -1,0 +1,21 @@
+uuid: 1d7034f1-0d3b-4998-9c28-b654fde358bc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_geolocation
+    - node.type.venue
+  module:
+    - geofield
+id: node.venue.field_geolocation
+field_name: field_geolocation
+entity_type: node
+bundle: venue
+label: Geolocation
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: geofield

--- a/config/sites/commencement.uiowa.edu/field.field.node.venue.field_image.yml
+++ b/config/sites/commencement.uiowa.edu/field.field.node.venue.field_image.yml
@@ -1,0 +1,29 @@
+uuid: 81f09d2f-223b-498d-9f98-93032392b0ff
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_image
+    - media.type.image
+    - node.type.venue
+id: node.venue.field_image
+field_name: field_image
+entity_type: node
+bundle: venue
+label: 'Featured Image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: name
+      direction: ASC
+    auto_create: true
+    auto_create_bundle: image
+field_type: entity_reference

--- a/config/sites/commencement.uiowa.edu/field.field.node.venue.field_location.yml
+++ b/config/sites/commencement.uiowa.edu/field.field.node.venue.field_location.yml
@@ -1,0 +1,47 @@
+uuid: 8ff65b94-3261-4ed9-8653-46671a2a79e8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_location
+    - node.type.venue
+  module:
+    - address
+id: node.venue.field_location
+field_name: field_location
+entity_type: node
+bundle: venue
+label: Location
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    langcode: null
+    country_code: US
+    administrative_area: ''
+    locality: ''
+    dependent_locality: null
+    postal_code: ''
+    sorting_code: null
+    address_line1: ''
+    address_line2: ''
+    organization: ''
+    given_name: ''
+    additional_name: null
+    family_name: ''
+default_value_callback: ''
+settings:
+  available_countries: {  }
+  langcode_override: ''
+  field_overrides:
+    givenName:
+      override: hidden
+    additionalName:
+      override: hidden
+    familyName:
+      override: hidden
+    addressLine2:
+      override: optional
+  fields: {  }
+field_type: address

--- a/config/sites/commencement.uiowa.edu/field.storage.node.field_event_livestream_caption.yml
+++ b/config/sites/commencement.uiowa.edu/field.storage.node.field_event_livestream_caption.yml
@@ -1,4 +1,4 @@
-uuid: d6b7dbb2-ff8f-4e92-9174-1997aa8596ec
+uuid: 29473e96-b5a2-404b-be33-54cb91359552
 langcode: en
 status: true
 dependencies:
@@ -8,9 +8,8 @@ dependencies:
 id: node.field_event_livestream_caption
 field_name: field_event_livestream_caption
 entity_type: node
-type: text
-settings:
-  max_length: 255
+type: text_long
+settings: {  }
 module: text
 locked: false
 cardinality: 1

--- a/config/sites/commencement.uiowa.edu/views.view.events_by_venue.yml
+++ b/config/sites/commencement.uiowa.edu/views.view.events_by_venue.yml
@@ -109,7 +109,20 @@ display:
       cache:
         type: tag
         options: {  }
-      empty: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'There are currently no upcoming events for this venue.'
+            format: filtered_html
+          tokenize: false
       sorts: {  }
       arguments:
         nid:

--- a/config/sites/commencement.uiowa.edu/views.view.events_by_venue.yml
+++ b/config/sites/commencement.uiowa.edu/views.view.events_by_venue.yml
@@ -1,0 +1,232 @@
+uuid: e405a699-e301-4ef4-b498-afab402a568a
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.event
+  module:
+    - node
+    - user
+id: events_by_venue
+label: 'Events by venue'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Events by venue'
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 5
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: field_event_venue
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            event: event
+      style:
+        type: default
+        options:
+          row_class: ''
+          default_row_class: true
+          uses_fields: true
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        field_event_venue:
+          id: field_event_venue
+          table: node__field_event_venue
+          field: field_event_venue
+          relationship: none
+          group_type: group
+          admin_label: 'field_event_venue: Content'
+          plugin_id: standard
+          required: true
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_1:
+    id: block_1
+    display_title: Block
+    display_plugin: block
+    position: 1
+    display_options:
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/config/sites/pharmacy.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/pharmacy.uiowa.edu/config_split.config_split.site.yml
@@ -10,7 +10,6 @@ stackable: true
 storage: folder
 folder: ../config/sites/pharmacy.uiowa.edu
 module:
-  geofield: 0
   leaflet: 0
   pharmacy_core: 0
 theme: {  }

--- a/docroot/modules/custom/sitenow_events/sitenow_events.module
+++ b/docroot/modules/custom/sitenow_events/sitenow_events.module
@@ -24,7 +24,7 @@ use GuzzleHttp\Exception\RequestException;
  * Implements hook_entity_bundle_info_alter().
  */
 function sitenow_events_entity_bundle_info_alter(array &$bundles) {
-  if (isset($bundles['node']['event'])) {
+  if (\Drupal::config('config_split.config_split.event')->get('status') === TRUE && isset($bundles['node']['event'])) {
     $bundles['node']['event']['class'] = Event::class;
   }
 }

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/commencement_core.info.yml
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/commencement_core.info.yml
@@ -1,0 +1,6 @@
+name: Commencement
+type: module
+description: Custom functionality for commencement.uiowa.edu
+package: commencement.uiowa.edu
+core: 8.x
+core_version_requirement: ^8 || ^9 || ^10


### PR DESCRIPTION
Resolves #7574
Resolves #7576 

# How to test

```
ddev blt ds --site commencement.uiowa.edu && ddev drush @commencement.local uli node/add/venue
```
- Add a venue (reference: https://commencement.uiowa.edu/commencement-venues).
- Ensure title, image, lat/long, address can be added and display. Note if there appear to be any missing fields.
- Add an event and reference the venue: https://commencement.uiowa.ddev.site/node/add/event
- Observe that the venue shows as a link on the event. Click the link.
- Confirm that the event is listed on the venue now.

## Changes affecting other sites

- Set a breakpoint at line 28 of `sitenow_events.module`.
```
ddev blt ds --site admissions.uiowa.edu && ddev xdebug && ddev drush @admissions.local cr
```
- Confirm that breakpoint is triggered.
```
ddev xdebug off && ddev drush @admissions.local uli node/add/event
```
- Confirm that Geolocation field displays and there are no warnings/errors about it.