### PR TITLE
Emergency website - Hawk Alert set default value for complete field

### DIFF
--- a/config/sites/emergency.uiowa.edu/field.field.node.hawk_alert.field_hawk_alert_complete.yml
+++ b/config/sites/emergency.uiowa.edu/field.field.node.hawk_alert.field_hawk_alert_complete.yml
@@ -13,7 +13,9 @@ label: Complete
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    value: 0
 default_value_callback: ''
 settings:
   on_label: 'On'

--- a/config/sites/emergency.uiowa.edu/views.view.hawk_alerts.yml
+++ b/config/sites/emergency.uiowa.edu/views.view.hawk_alerts.yml
@@ -535,6 +535,20 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'There are no results.'
+            format: full_html
+          tokenize: false
       filters:
         status:
           id: status
@@ -607,6 +621,7 @@ display:
           relationship: none
           view_mode: teaser
       defaults:
+        empty: false
         title: false
         pager: false
         style: false


### PR DESCRIPTION
# To Test

- `ddev blt ds --site=emergency.uiowa.edu`
- Add the active view to a page. Open that view in an anonymous browser, caching it.
- Run the `ddev drush @emergency.local rave-alerts` command and see one item is imported.
- Refresh the anonymous browser to see the alert.