### PR TITLE
[Bug fix] Alert style scoping fix for emergency.uiowa.edu

### DIFF
--- a/docroot/sites/emergency.uiowa.edu/modules/emergency_core/css/emergency-hawk-alerts.css
+++ b/docroot/sites/emergency.uiowa.edu/modules/emergency_core/css/emergency-hawk-alerts.css
@@ -1,0 +1,3 @@
+.view-hawk-alerts .alert__icon + div {
+  display: grid;
+}

--- a/docroot/sites/emergency.uiowa.edu/modules/emergency_core/emergency_core.libraries.yml
+++ b/docroot/sites/emergency.uiowa.edu/modules/emergency_core/emergency_core.libraries.yml
@@ -1,0 +1,4 @@
+emergency-hawk-alerts:
+  css:
+    component:
+      css/emergency-hawk-alerts.css: {}

--- a/docroot/sites/emergency.uiowa.edu/modules/emergency_core/emergency_core.module
+++ b/docroot/sites/emergency.uiowa.edu/modules/emergency_core/emergency_core.module
@@ -103,3 +103,16 @@ function emergency_core_import_alerts() {
   $message = t('Hawk alerts content sync completed. @created alerts were created and @skipped skipped. That is neat.', $arguments);
   return $message;
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function emergency_core_preprocess_block(&$variables) {
+  switch ($variables['elements']['#plugin_id']) {
+
+    case 'views_block:hawk_alerts-block_alerts':
+      $variables['#attached']['library'][] = 'emergency_core/emergency-hawk-alerts';
+      break;
+
+  }
+}

--- a/docroot/themes/custom/uids_base/scss/components/alert.scss
+++ b/docroot/themes/custom/uids_base/scss/components/alert.scss
@@ -67,5 +67,4 @@
 
 .alert__icon + div {
   width: 100%;
-  display: grid;
 }


### PR DESCRIPTION
In https://github.com/uiowa/uiowa/pull/7548, I added a CSS property that should have been scoped to only the hawk alert view.  This pr changes that. 

**Before:**
<img width="1371" alt="Screenshot 2024-04-18 at 9 17 01 AM" src="https://github.com/uiowa/uiowa/assets/1036433/3339871f-8727-43a2-a1c1-9a432e5a18d6">

**After:**
<img width="1394" alt="Screenshot 2024-04-18 at 9 16 45 AM" src="https://github.com/uiowa/uiowa/assets/1036433/b46eea66-e439-4522-8ede-5b79713d416d">


# How to test

```
 ddev blt frontend && ddev blt ds --site=emergency.uiowa.edu && ddev drush @emergency.local uli /node/31/edit
```

Add two situation updates and go to https://emergency.uiowa.ddev.site/ and confirm that both status updates are appearing in the alert. 