### PR TITLE
[Commencement] Display map on venue

### DIFF
--- a/config/sites/commencement.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/commencement.uiowa.edu/config_split.config_split.site.yml
@@ -11,6 +11,7 @@ storage: folder
 folder: ../config/sites/commencement.uiowa.edu
 module:
   commencement_core: 0
+  leaflet: 0
   schema_event: 0
   schema_place: 0
 theme: {  }

--- a/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.default.yml
+++ b/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.default.yml
@@ -160,10 +160,75 @@ third_party_settings:
                 entity: layout_builder.entity
                 view_mode: view_mode
               formatter:
-                type: geofield_latlon
+                type: leaflet_formatter_default
                 label: visually_hidden
                 settings:
-                  output_format: decimal
+                  multiple_map: false
+                  leaflet_map: 'OSM Mapnik'
+                  height: 400
+                  height_unit: px
+                  hide_empty_map: true
+                  disable_wheel: false
+                  gesture_handling: false
+                  fitbounds_options: '{"padding":[0,0]}'
+                  reset_map:
+                    control: false
+                    options: '{"position":"topleft","title":"Reset View"}'
+                  map_scale:
+                    control: false
+                    options: '{"position":"bottomright","maxWidth":100,"metric":true,"imperial":false,"updateWhenIdle":false}'
+                  locate:
+                    control: false
+                    options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
+                    automatic: false
+                  leaflet_tooltip:
+                    value: ''
+                    options: '{"permanent":false,"direction":"center"}'
+                  leaflet_popup:
+                    control: '0'
+                    content: ''
+                    options: '{"maxWidth":"300","minWidth":"50","autoPan":true}'
+                  map_position:
+                    force: false
+                    center:
+                      lat: 0.0
+                      lon: 0.0
+                    zoomControlPosition: topleft
+                    zoom: 17
+                    minZoom: 1
+                    maxZoom: 19
+                    zoomFiner: 0
+                  icon:
+                    iconType: marker
+                    iconUrl: ''
+                    shadowUrl: ''
+                    className: ''
+                    iconSize:
+                      x: ''
+                      'y': ''
+                    iconAnchor:
+                      x: ''
+                      'y': ''
+                    shadowSize:
+                      x: ''
+                      'y': ''
+                    shadowAnchor:
+                      x: ''
+                      'y': ''
+                    popupAnchor:
+                      x: ''
+                      'y': ''
+                    html: '<div></div>'
+                    html_class: leaflet-map-divicon
+                    circle_marker_options: '{"radius":100,"color":"red","fillColor":"#f03","fillOpacity":0.5}'
+                  fullscreen:
+                    control: false
+                    options: '{"position":"topleft","pseudoFullscreen":false}'
+                  path: '{"color":"#3388ff","opacity":"1.0","stroke":true,"weight":3,"fill":"depends","fillColor":"*","fillOpacity":"0.2","radius":"6"}'
+                  feature_properties:
+                    values: ''
+                  map_lazy_load:
+                    lazy_load: true
                 third_party_settings: {  }
             weight: 3
             additional:


### PR DESCRIPTION
# How to test

- `ddev blt ds --site=commencement.uiowa.edu && ddev drush @commencement.local uli`
- go to https://commencement.uiowa.ddev.site/admin/content and check a few venues, the lat/long values should now be rendered as a map. ~~Note: some values are off and need updating, the important thing is that a map is there. Carver-Hawkeye Arena is accurate.~~ Lat/long values are updated, the IMU is no longer showing as in the Iowa River. :)
- Do we like the current Zoom level?