### PR TITLE
Brand - fix service being called for this email

### DIFF
--- a/docroot/sites/brand.uiowa.edu/modules/brand_core/brand_core.module
+++ b/docroot/sites/brand.uiowa.edu/modules/brand_core/brand_core.module
@@ -433,7 +433,7 @@ function brand_core_lockup_digest(): string {
     ];
 
     $login_url = Url::fromUri($base_url . '/saml/login', $url_options)->toString();
-    $email = \Drupal::service('plugin.manager.mail')->sendTypedEmail('brand_core', 'lockup_review_digest', $lockups, $label, $results, $login_url);
+    $email = \Drupal::service('email_factory')->sendTypedEmail('brand_core', 'lockup_review_digest', $lockups, $label, $results, $login_url);
 
     if ($email->getError()) {
       $message = t('Lockup Review Digest not sent. Error: @error');


### PR DESCRIPTION
Sondra said they haven't been getting emails for a while. Locally, I was getting this error:

```
Call to undefined method Drupal\symfony_mailer\MailManagerReplacement::sendTypedEmail() in brand_core_lockup_digest() (line 436 of /var/www/html/docroot/sites/brand.uiowa.edu/modules/brand_core/brand_core.module)
```

Looks like we missed it in https://github.com/uiowa/uiowa/pull/7472. ITS was fixed but not brand.

# To Test

On `main` run `ddev blt ds --site=brand.uiowa.edu`, go in an create a lockup and submit it for review.
Run `ddev drush @brand.local brand-ld` and see the error.
Checkout `brand_email_hotfix` and rerun the drush command. Run `ddev launch -m` to see the email.
