### PR TITLE
Classrooms - reduce revisions related to imported content

### DIFF
--- a/config/sites/classrooms.uiowa.edu/node.type.room.yml
+++ b/config/sites/classrooms.uiowa.edu/node.type.room.yml
@@ -5,6 +5,7 @@ dependencies:
   module:
     - menu_ui
     - node_revision_delete
+    - scheduler
 third_party_settings:
   menu_ui:
     available_menus: {  }
@@ -13,7 +14,7 @@ third_party_settings:
     amount:
       status: true
       settings:
-        amount: 10
+        amount: 3
     created:
       status: false
       settings:
@@ -22,6 +23,19 @@ third_party_settings:
       status: false
       settings:
         age: 1
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: Room
 type: room
 description: 'Use <em>room</em> to provide MAUI room information and overrides.'


### PR DESCRIPTION
Fresh off https://github.com/uiowa/uiowa/issues/7623, this is a small change that could greatly reduce the size of Classrooms' database based on the number of related taxonomy terms per node and the amount of entity usage tracking that happens with revisions.

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

Compare with other import-based content types:

https://github.com/uiowa/uiowa/blob/main/config/sites/facilities.uiowa.edu/node.type.building.yml#L16
https://github.com/uiowa/uiowa/blob/main/config/sites/facilities.uiowa.edu/node.type.project.yml#L16

Scheduler stuff is just added default config. Not enabled.
