### PR TITLE
IWP - Writer Bio Updates

### DIFF
--- a/config/sites/iwp.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/iwp.uiowa.edu/config_split.config_split.site.yml
@@ -16,6 +16,7 @@ theme: {  }
 complete_list:
   - config_split.config_split.site
   - core.entity_form_display.node.writer_bio.default
+  - iwp_core.settings
   - metatag.metatag_defaults.node__writer_bio
   - node.type.writer_bio
   - pathauto.pattern.writer_bio
@@ -25,6 +26,7 @@ complete_list:
   - 'field.storage.node.field_writer_bio_*'
   - 'taxonomy.vocabulary.writer_bio_*'
 partial_list:
+  - config_ignore.settings
   - metatag.settings
   - workflows.workflow.editorial
   - 'user.role.*'

--- a/config/sites/iwp.uiowa.edu/config_split.patch.config_ignore.settings.yml
+++ b/config/sites/iwp.uiowa.edu/config_split.patch.config_ignore.settings.yml
@@ -1,0 +1,4 @@
+adding:
+  ignored_config_entities:
+    - iwp_core.settings
+removing: {  }

--- a/config/sites/iwp.uiowa.edu/core.entity_form_display.node.writer_bio.default.yml
+++ b/config/sites/iwp.uiowa.edu/core.entity_form_display.node.writer_bio.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.writer_bio.field_writer_bio_family_name
     - field.field.node.writer_bio.field_writer_bio_given_name
     - field.field.node.writer_bio.field_writer_bio_languages
+    - field.field.node.writer_bio.field_writer_bio_media_link
     - field.field.node.writer_bio.field_writer_bio_photo_credit
     - field.field.node.writer_bio.field_writer_bio_sample
     - field.field.node.writer_bio.field_writer_bio_sample_original
@@ -19,6 +20,7 @@ dependencies:
   module:
     - allowed_formats
     - content_moderation
+    - link
     - media_library
     - metatag
     - path
@@ -89,6 +91,14 @@ content:
     weight: 14
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_writer_bio_media_link:
+    type: link_default
+    weight: 26
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
     third_party_settings: {  }
   field_writer_bio_photo_credit:
     type: string_textfield

--- a/config/sites/iwp.uiowa.edu/core.entity_form_display.node.writer_bio.minimal.yml
+++ b/config/sites/iwp.uiowa.edu/core.entity_form_display.node.writer_bio.minimal.yml
@@ -11,11 +11,13 @@ dependencies:
     - field.field.node.writer_bio.field_writer_bio_family_name
     - field.field.node.writer_bio.field_writer_bio_given_name
     - field.field.node.writer_bio.field_writer_bio_languages
+    - field.field.node.writer_bio.field_writer_bio_media_link
     - field.field.node.writer_bio.field_writer_bio_photo_credit
     - field.field.node.writer_bio.field_writer_bio_sample
     - field.field.node.writer_bio.field_writer_bio_sample_original
     - field.field.node.writer_bio.field_writer_bio_session_status
     - node.type.writer_bio
+    - workflows.workflow.editorial
   module:
     - content_moderation
     - path
@@ -99,6 +101,7 @@ hidden:
   field_writer_bio_family_name: true
   field_writer_bio_given_name: true
   field_writer_bio_languages: true
+  field_writer_bio_media_link: true
   field_writer_bio_photo_credit: true
   field_writer_bio_sample: true
   field_writer_bio_sample_original: true

--- a/config/sites/iwp.uiowa.edu/core.entity_view_display.node.writer_bio.default.yml
+++ b/config/sites/iwp.uiowa.edu/core.entity_view_display.node.writer_bio.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.writer_bio.field_writer_bio_family_name
     - field.field.node.writer_bio.field_writer_bio_given_name
     - field.field.node.writer_bio.field_writer_bio_languages
+    - field.field.node.writer_bio.field_writer_bio_media_link
     - field.field.node.writer_bio.field_writer_bio_photo_credit
     - field.field.node.writer_bio.field_writer_bio_sample
     - field.field.node.writer_bio.field_writer_bio_sample_original
@@ -17,6 +18,7 @@ dependencies:
     - node.type.writer_bio
   module:
     - layout_builder
+    - link
     - metatag
     - system
     - text
@@ -263,7 +265,7 @@ third_party_settings:
                 settings:
                   link_to_entity: false
                 third_party_settings: {  }
-            weight: 11
+            weight: 12
             additional: {  }
             third_party_settings: {  }
           -
@@ -286,6 +288,27 @@ third_party_settings:
             weight: 4
             additional:
               layout_builder_styles_style: {  }
+            third_party_settings: {  }
+          -
+            uuid: f32aa559-5a7c-4447-93d5-86e3e344887f
+            region: main
+            configuration:
+              id: 'field_block:node:writer_bio:field_writer_bio_media_link'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              formatter:
+                type: link
+                label: above
+                settings:
+                  trim_length: 80
+                  url_only: false
+                  url_plain: false
+                  rel: ''
+                  target: ''
+                third_party_settings: {  }
+            weight: 11
+            additional: {  }
             third_party_settings: {  }
         third_party_settings:
           layout_builder_limit:
@@ -358,6 +381,18 @@ content:
       link: true
     third_party_settings: {  }
     weight: 110
+    region: content
+  field_writer_bio_media_link:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 112
     region: content
   field_writer_bio_photo_credit:
     type: string

--- a/config/sites/iwp.uiowa.edu/core.entity_view_display.node.writer_bio.default.yml
+++ b/config/sites/iwp.uiowa.edu/core.entity_view_display.node.writer_bio.default.yml
@@ -110,7 +110,7 @@ third_party_settings:
             0: ''
             1: section_margin_fixed_width_container
             2: section_card_media_size_medium
-            3: section_card_media_format_circle
+            3: section_card_media_format_square
             section_no_border: section_no_border
             section_alignment_start: section_alignment_start
         components:

--- a/config/sites/iwp.uiowa.edu/core.entity_view_display.node.writer_bio.teaser.yml
+++ b/config/sites/iwp.uiowa.edu/core.entity_view_display.node.writer_bio.teaser.yml
@@ -11,12 +11,15 @@ dependencies:
     - field.field.node.writer_bio.field_writer_bio_family_name
     - field.field.node.writer_bio.field_writer_bio_given_name
     - field.field.node.writer_bio.field_writer_bio_languages
+    - field.field.node.writer_bio.field_writer_bio_media_link
     - field.field.node.writer_bio.field_writer_bio_photo_credit
     - field.field.node.writer_bio.field_writer_bio_sample
     - field.field.node.writer_bio.field_writer_bio_sample_original
     - field.field.node.writer_bio.field_writer_bio_session_status
     - node.type.writer_bio
   module:
+    - field_delimiter
+    - link
     - text
     - user
 id: node.writer_bio.teaser
@@ -64,6 +67,20 @@ content:
       field_delimiter:
         delimiter: ','
     weight: 7
+    region: content
+  field_writer_bio_media_link:
+    type: link
+    label: visually_hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings:
+      field_delimiter:
+        delimiter: ','
+    weight: 9
     region: content
   field_writer_bio_sample:
     type: entity_reference_label

--- a/config/sites/iwp.uiowa.edu/core.entity_view_display.node.writer_bio.token.yml
+++ b/config/sites/iwp.uiowa.edu/core.entity_view_display.node.writer_bio.token.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.writer_bio.field_writer_bio_family_name
     - field.field.node.writer_bio.field_writer_bio_given_name
     - field.field.node.writer_bio.field_writer_bio_languages
+    - field.field.node.writer_bio.field_writer_bio_media_link
     - field.field.node.writer_bio.field_writer_bio_photo_credit
     - field.field.node.writer_bio.field_writer_bio_sample
     - field.field.node.writer_bio.field_writer_bio_sample_original
@@ -23,6 +24,11 @@ targetEntityType: node
 bundle: writer_bio
 mode: token
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   field_image:
     type: entity_reference_entity_view
     label: visually_hidden
@@ -47,6 +53,7 @@ hidden:
   field_writer_bio_family_name: true
   field_writer_bio_given_name: true
   field_writer_bio_languages: true
+  field_writer_bio_media_link: true
   field_writer_bio_photo_credit: true
   field_writer_bio_sample: true
   field_writer_bio_sample_original: true

--- a/config/sites/iwp.uiowa.edu/field.field.node.writer_bio.field_writer_bio_media_link.yml
+++ b/config/sites/iwp.uiowa.edu/field.field.node.writer_bio.field_writer_bio_media_link.yml
@@ -1,0 +1,23 @@
+uuid: 93e1757e-7342-4af9-9290-6c20dd7b5674
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_writer_bio_media_link
+    - node.type.writer_bio
+  module:
+    - link
+id: node.writer_bio.field_writer_bio_media_link
+field_name: field_writer_bio_media_link
+entity_type: node
+bundle: writer_bio
+label: Media
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 17
+field_type: link

--- a/config/sites/iwp.uiowa.edu/field.field.node.writer_bio.field_writer_bio_session_status.yml
+++ b/config/sites/iwp.uiowa.edu/field.field.node.writer_bio.field_writer_bio_session_status.yml
@@ -10,7 +10,7 @@ id: node.writer_bio.field_writer_bio_session_status
 field_name: field_writer_bio_session_status
 entity_type: node
 bundle: writer_bio
-label: Session/Status
+label: Session
 description: ''
 required: true
 translatable: false

--- a/config/sites/iwp.uiowa.edu/field.storage.node.field_writer_bio_media_link.yml
+++ b/config/sites/iwp.uiowa.edu/field.storage.node.field_writer_bio_media_link.yml
@@ -1,0 +1,19 @@
+uuid: 806dde3d-d0bf-4f17-8998-f7c658cdfb48
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_writer_bio_media_link
+field_name: field_writer_bio_media_link
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sites/iwp.uiowa.edu/taxonomy.vocabulary.writer_bio_session_status.yml
+++ b/config/sites/iwp.uiowa.edu/taxonomy.vocabulary.writer_bio_session_status.yml
@@ -18,7 +18,7 @@ third_party_settings:
     unpublish_enable: false
     unpublish_required: false
     unpublish_revision: false
-name: Session/Status
+name: Session
 vid: writer_bio_session_status
 description: ''
 weight: 0

--- a/config/sites/iwp.uiowa.edu/views.view.writer_bio.yml
+++ b/config/sites/iwp.uiowa.edu/views.view.writer_bio.yml
@@ -176,7 +176,7 @@ display:
           exposed: true
           expose:
             operator_id: field_writer_bio_session_status_target_id_op
-            label: Session/Status
+            label: Session
             description: ''
             use_operator: false
             operator: field_writer_bio_session_status_target_id_op

--- a/docroot/sites/iwp.uiowa.edu/modules/iwp_core/iwp_core.module
+++ b/docroot/sites/iwp.uiowa.edu/modules/iwp_core/iwp_core.module
@@ -5,10 +5,12 @@
  * Custom functionality the IWP website.
  */
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\iwp_core\Entity\WriterBio;
+use Drupal\views\ViewExecutable;
 
 /**
  * Implements hook_entity_bundle_info_alter().
@@ -31,7 +33,39 @@ function iwp_core_form_alter(&$form, FormStateInterface $form_state, $form_id) {
         // Set field_writer_bio_photo_credit to node_image group.
         $form['field_writer_bio_photo_credit']['#group'] = 'node_image';
       }
+      break;
 
+    case 'taxonomy_term_writer_bio_session_status_form':
+      $term_id = $form_state->getFormObject()->getEntity()->id();
+      $config = \Drupal::config('iwp_core.settings');
+      $default_session = $config->get('default_session');
+      $form['default_session'] = [
+        '#type' => 'checkbox',
+        '#title' => t('Default session'),
+        '#description' => t('Check this box to make this session the default session for the site.'),
+        // Set the default value based on whether it matches the term ID.
+        '#default_value' => $default_session == $term_id,
+      ];
+
+      // Add a submit handler for processing the default session.
+      $form['actions']['submit']['#submit'][] = 'iwp_core_taxonomy_term_session_form_submit';
+      break;
+  }
+}
+
+/**
+ * Custom submit handler for the taxonomy_term_session_form form.
+ */
+function iwp_core_taxonomy_term_session_form_submit($form, FormStateInterface $form_state) {
+  $is_default = $form_state->getValue('default_session');
+  // If a value was set for default session, update the configuration.
+  if ($is_default) {
+    $config = \Drupal::service('config.factory')->getEditable('iwp_core.settings');
+    // Set the term ID as the default session.
+    $term_id = $form_state->getFormObject()->getEntity()->id();
+    $config->set('default_session', $term_id)->save();
+    // Invalidate the views cache for the ceremonies view.
+    Cache::invalidateTags(['config:views.view.writer_bio']);
   }
 }
 
@@ -67,7 +101,8 @@ function iwp_core_preprocess_field(&$variables) {
       $node = $variables["element"]["#object"];
       $file_entity = NULL;
       $field_to_check = ($field_name === 'field_writer_bio_sample') ? 'field_writer_bio_sample' : 'field_writer_bio_sample_original';
-      $link_text = ($field_name === 'field_writer_bio_sample') ? 'Writing Sample' : 'Writing Sample Original Language';
+      $link_text = $node->label() . "'s ";
+      $link_text .= ($field_name === 'field_writer_bio_sample') ? 'Writing Sample' : 'Writing Sample Original Language';
 
       // Check if the field has a file.
       if (!empty($node->$field_to_check->entity) && !empty($node->$field_to_check->entity->field_media_file->entity)) {
@@ -80,5 +115,19 @@ function iwp_core_preprocess_field(&$variables) {
         $variables['items'][0]['content'] = $link->toString();
       }
       break;
+  }
+}
+
+/**
+ * Implements hook_views_pre_build().
+ */
+function iwp_core_views_pre_build(ViewExecutable $view) {
+  if ($view->id() == 'writer_bio') {
+    $config = \Drupal::config('iwp_core.settings');
+    $default_session = $config->get('default_session');
+    if ($default_session) {
+      $filter = $view->display_handler->getHandler('filter', 'field_writer_bio_session_status_target_id');
+      $filter->value['value'] = $default_session;
+    }
   }
 }

--- a/docroot/sites/iwp.uiowa.edu/modules/iwp_core/src/Entity/WriterBio.php
+++ b/docroot/sites/iwp.uiowa.edu/modules/iwp_core/src/Entity/WriterBio.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\iwp_core\Entity;
 
+use Drupal\Core\Link;
+use Drupal\Core\Url;
 use Drupal\uiowa_core\Entity\NodeBundleBase;
 use Drupal\uiowa_core\Entity\RendersAsCardInterface;
 
@@ -22,9 +24,6 @@ class WriterBio extends NodeBundleBase implements RendersAsCardInterface {
         'field_writer_bio_languages',
         'field_writer_bio_countries',
       ],
-      '#content' => [
-        'field_writer_bio_media_link',
-      ],
     ]);
 
     // Combine fields into an unordered list.
@@ -32,10 +31,20 @@ class WriterBio extends NodeBundleBase implements RendersAsCardInterface {
     $list_fields = [
       'field_writer_bio_sample',
       'field_writer_bio_sample_original',
+      'field_writer_bio_media_link',
     ];
     foreach ($list_fields as $field) {
       if ($this->hasField($field) && !$this->$field->isEmpty()) {
-        $items[] = $this->$field->view('teaser');
+        if ($field === 'field_writer_bio_media_link') {
+          $links = $this->get($field)->getValue();
+          foreach ($links as $link) {
+            $items[] = Link::fromTextAndUrl($link['title'], Url::fromUri($link['uri']));
+          }
+        }
+        else {
+          $items[] = $this->$field->view('teaser');
+        }
+
       }
     }
     if (!empty($items)) {

--- a/docroot/sites/iwp.uiowa.edu/modules/iwp_core/src/Entity/WriterBio.php
+++ b/docroot/sites/iwp.uiowa.edu/modules/iwp_core/src/Entity/WriterBio.php
@@ -36,7 +36,7 @@ class WriterBio extends NodeBundleBase implements RendersAsCardInterface {
   public function getDefaultCardStyles(): array {
     return [
       ...parent::getDefaultCardStyles(),
-      'media_format' => 'media--circle media--border',
+      'media_format' => 'media--square media--border',
       'border' => 'borderless',
     ];
   }

--- a/docroot/sites/iwp.uiowa.edu/modules/iwp_core/src/Entity/WriterBio.php
+++ b/docroot/sites/iwp.uiowa.edu/modules/iwp_core/src/Entity/WriterBio.php
@@ -48,7 +48,7 @@ class WriterBio extends NodeBundleBase implements RendersAsCardInterface {
       }
     }
     if (!empty($items)) {
-      $build['#content']['samples'] = [
+      $build['#content']['related_links'] = [
         '#theme' => 'item_list',
         '#type' => 'ul',
         '#items' => $items,

--- a/docroot/sites/iwp.uiowa.edu/modules/iwp_core/src/Entity/WriterBio.php
+++ b/docroot/sites/iwp.uiowa.edu/modules/iwp_core/src/Entity/WriterBio.php
@@ -23,10 +23,29 @@ class WriterBio extends NodeBundleBase implements RendersAsCardInterface {
         'field_writer_bio_countries',
       ],
       '#content' => [
-        'field_writer_bio_sample',
-        'field_writer_bio_sample_original',
+        'field_writer_bio_media_link',
       ],
     ]);
+
+    // Combine fields into an unordered list.
+    $items = [];
+    $list_fields = [
+      'field_writer_bio_sample',
+      'field_writer_bio_sample_original',
+    ];
+    foreach ($list_fields as $field) {
+      if ($this->hasField($field) && !$this->$field->isEmpty()) {
+        $items[] = $this->$field->view('teaser');
+      }
+    }
+    if (!empty($items)) {
+      $build['#content']['samples'] = [
+        '#theme' => 'item_list',
+        '#type' => 'ul',
+        '#items' => $items,
+        '#weight' => 3,
+      ];
+    }
 
   }
 


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/7653
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt ds --site=iwp.uiowa.edu
```

- On https://iwp.uiowa.ddev.site/node/add/writer_bio see that the Session label no longer has /Status and that there is a new multiple title/link field at the bottom of the form. Add a couple links.
- See on the full node render that the Media field is rendered similar to other fields below the writing samples. Also see the same label treatment is extended for Session.
- Go to https://iwp.uiowa.ddev.site/admin/structure/taxonomy/manage/writer_bio_session_status/overview and edit a term or pick a new term. See the default session checkbox and check it. Notice except for the machine name, all mentions of Session have the same label treatment.
- Go to https://iwp.uiowa.ddev.site/residency/participants and see that the term you selected is loaded by default and that the filter label is "Session." Open this page in an anonymous window. In your authenticated window, go back and choose a different term to serve as default. Check the box. Save. Inspect the old term and see that it is no longer checked. Leave without saving. Refresh the anonymous window and see that the view updates with your new default term.
- If you have stage_file_proxy set for iwp.prod.drupal.uiowa.edu, you should see square images for the full node and teaser.
- On the teasers you should see a bulleted list of samples (name prepended) and media links together.
- `ddev drush @iwp.local cim` does not remove your default session config.
