### PR TITLE
Move CAPTCHA to default, clean up Admissions

### DIFF
--- a/config/default/captcha.settings.yml
+++ b/config/default/captcha.settings.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: QDFjOXYIYVwCPQYHY4wAx4DUqOEkNaZokIx6DGApR9I
 enable_globally: 0
 enable_globally_on_admin_routes: false
-default_challenge: hcaptcha/hCaptcha
+default_challenge: captcha/Math
 description: ''
 title: ''
 administration_mode: false

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -15,6 +15,7 @@ module:
   block_content: 0
   block_content_template: 0
   breakpoint: 0
+  captcha: 0
   ckeditor5: 0
   config: 0
   config_ignore: 0

--- a/config/sites/admissions.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/admissions.uiowa.edu/config_split.config_split.site.yml
@@ -11,7 +11,6 @@ storage: folder
 folder: ../config/sites/admissions.uiowa.edu
 module:
   better_exposed_filters: 0
-  captcha: 0
   entity_print_views: 0
   hcaptcha: 0
   jquery_ui: 0
@@ -90,6 +89,7 @@ complete_list:
   - views.view.2_plus_2_majors
   - views.view.community_colleges_taxonomy_term
 partial_list:
+  - captcha.settings
   - core.entity_form_display.node.event.default
   - core.entity_view_display.block_content.uiowa_events.default
   - core.entity_view_display.node.event.default

--- a/config/sites/admissions.uiowa.edu/config_split.patch.captcha.settings.yml
+++ b/config/sites/admissions.uiowa.edu/config_split.patch.captcha.settings.yml
@@ -1,0 +1,4 @@
+adding:
+  default_challenge: hcaptcha/hCaptcha
+removing:
+  default_challenge: captcha/Math

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
@@ -257,12 +257,6 @@ function admissions_core_form_alter(&$form, FormStateInterface $form_state, $for
       ];
       break;
 
-    case 'webform_ui_element_form':
-      // Disable captcha type field as it should always be the default
-      // (hcaptcha) at this time.
-      $form['properties']['captcha']['captcha_type']['#disabled'] = TRUE;
-      $form['properties']['captcha']['captcha_container']['#disabled'] = TRUE;
-      break;
   }
 }
 


### PR DESCRIPTION
Resolves #7657

<img width="629" alt="Screenshot 2024-05-13 at 11 38 57 AM" src="https://github.com/uiowa/uiowa/assets/4663676/515c1a11-8d9b-4e67-b42c-12f7414c3e86">

# Test

- As a webmaster, I can add a math challenge captcha to my webform and have it show up for an anonymous session.
- As an admissions webmaster, I can add a math or hcaptcha challenge to my webform and that my default challenge type is set to hcaptcha (anonymous session) assuming I have the api keys necessary for it to work. DM Joe for keys or grab from the secrets file off of one of the remotes.

# Review

https://sitenow.uiowa.edu/documentation/webforms/handling-webform-spam-submissions