### PR TITLE
[Commencement] Venue only displays events in default session

### DIFF
--- a/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.default.yml
+++ b/config/sites/commencement.uiowa.edu/core.entity_view_display.node.venue.default.yml
@@ -309,7 +309,7 @@ third_party_settings:
               pager: some
               exposed: {  }
               headline:
-                headline: 'Upcoming events'
+                headline: Events
                 hide_headline: 0
                 heading_size: h2
                 headline_style: headline_bold_serif_underline

--- a/config/sites/commencement.uiowa.edu/views.view.events_by_venue.yml
+++ b/config/sites/commencement.uiowa.edu/views.view.events_by_venue.yml
@@ -5,8 +5,12 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - node.type.event
+    - taxonomy.vocabulary.session
+  content:
+    - 'taxonomy_term:session:d4ba66ed-54ff-4cf1-aa1c-a657ae5d99e4'
   module:
     - node
+    - taxonomy
     - user
 id: events_by_venue
 label: 'Events by venue'
@@ -184,6 +188,59 @@ display:
           plugin_id: bundle
           value:
             event: event
+        field_event_session_target_id:
+          id: field_event_session_target_id
+          table: node__field_event_session
+          field: field_event_session_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value:
+            211: 211
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: session
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+          save_lineage: false
+          force_deepest: false
+          parent: null
+          level_labels: ''
+          hierarchy_depth: 0
+          required_depth: 0
+          none_label: '- Please select -'
       style:
         type: default
         options:
@@ -212,6 +269,7 @@ display:
           admin_label: 'field_event_venue: Content'
           plugin_id: standard
           required: true
+      use_ajax: true
       header: {  }
       footer: {  }
       display_extenders: {  }

--- a/config/sites/commencement.uiowa.edu/views.view.events_by_venue.yml
+++ b/config/sites/commencement.uiowa.edu/views.view.events_by_venue.yml
@@ -270,6 +270,11 @@ display:
           plugin_id: standard
           required: true
       use_ajax: true
+      use_more: true
+      use_more_always: true
+      use_more_text: 'See all events'
+      link_display: custom_url
+      link_url: ceremonies
       header: {  }
       footer: {  }
       display_extenders: {  }

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/commencement_core.module
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/commencement_core.module
@@ -98,7 +98,10 @@ function commencement_core_taxonomy_term_session_form_submit($form, FormStateInt
     $term_id = $form_state->getFormObject()->getEntity()->id();
     $config->set('default_session', $term_id)->save();
     // Invalidate the views cache for the ceremonies view.
-    Cache::invalidateTags(['config:views.view.ceremonies']);
+    Cache::invalidateTags([
+      'config:views.view.ceremonies',
+      'config:views.view.events_by_venue',
+    ]);
   }
 }
 
@@ -370,13 +373,19 @@ function commencement_core_theme($existing, $type, $theme, $path) {
  * Implements hook_views_pre_build().
  */
 function commencement_core_views_pre_build(ViewExecutable $view) {
-
   if (in_array($view->id(), ['ceremonies', 'events_by_venue'])) {
     $config = \Drupal::config('commencement_core.settings');
     $default_session = $config->get('default_session');
     if ($default_session) {
       $filter = $view->display_handler->getHandler('filter', 'field_event_session_target_id');
-      $filter->value['value'] = $default_session;
+      if ($view->id() === 'ceremonies') {
+        $filter->value['value'] = $default_session;
+      }
+      else {
+        $filter->value = [];
+        $filter->value[$default_session] = $default_session;
+      }
+      $view->display_handler->overrideOption('filters', $filter);
     }
   }
 }

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/commencement_core.module
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/commencement_core.module
@@ -370,7 +370,8 @@ function commencement_core_theme($existing, $type, $theme, $path) {
  * Implements hook_views_pre_build().
  */
 function commencement_core_views_pre_build(ViewExecutable $view) {
-  if ($view->id() == 'ceremonies') {
+
+  if (in_array($view->id(), ['ceremonies', 'events_by_venue'])) {
     $config = \Drupal::config('commencement_core.settings');
     $default_session = $config->get('default_session');
     if ($default_session) {


### PR DESCRIPTION
Resolves #7672 

# How to test
```
ddev blt ds --site commencement.uiowa.edu && ddev drush @commencement.local uli "admin/content?type=venue"
```
- Review venues and confirm that they are only showing events from the current session
- Pick another session and set it as the default by editing and selecting that option: https://commencement.uiowa.ddev.site/admin/structure/taxonomy/manage/session/overview
- Review venues again and confirm that they are only showing events from the session you selected.
- Check https://commencement.uiowa.ddev.site/ceremonies to make sure it is still setting the default session correctly.