### PR TITLE
[Hotfix] Regents theme fix

### DIFF
--- a/docroot/themes/custom/uids_base/templates/layout/header.html.twig
+++ b/docroot/themes/custom/uids_base/templates/layout/header.html.twig
@@ -30,10 +30,9 @@
             logo_path_png: uihc_logo_path_png,
             logo_id: 'header',
           } %}
+        {% else %}
+          <div class="top-bar"></div>
         {% endif %}
-
-      {% else %}
-        <div class="top-bar"></div>
       {% endif %}
     {% endblock %}
 


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/7684. 

# How to test

```
ddev blt ds --site=91stmeridian.iwp.uiowa.edu && ddev drush @iwp91stmeridian.local uli 
```

1. Code review
2. Confirm that `<div class="top-bar">` appears in the header so that the top gray bar appears and that mobile view shows black search bar
3. Confirm that `<div class="top-bar">` does not appear for `Iowa` and  `UIHealthCare` options.
