### PR TITLE
[Hotfix] Reverse order for mobile fix for layout with sidebar

### DIFF
--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -421,9 +421,11 @@ body:not(.page-node-type-article, .page-node-type-page).layout-builder-disabled 
   // sidebar layout
   &.layout--has-sidebar {
     .layout__spacing_container {
-      flex-direction: column-reverse;
-      @include breakpoint(md) {
-        flex-direction: unset;
+      .layout__region--sidebar {
+        order: 2;
+        @include breakpoint(md) {
+          order: inherit;
+        }
       }
     }
   }
@@ -444,7 +446,7 @@ body:not(.page-node-type-article, .page-node-type-page).layout-builder-disabled 
       .layout__region--second,
       .layout__region--content,
       .layout__region-container {
-        order: 1;
+        order: 2;
         @include breakpoint(md) {
           order: inherit;
         }


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/7691

# How to test

```
ddev blt frontend && ddev blt ds --site=basicneeds.uiowa.edu && ddev drush @basicneeds.local uli /food-pantry
```

- Confirm mobile view is stacked in reverse order and that giant spacing is gone
- This should only affect v3 layout with sidebar sections