### PR TITLE
[Emergency] Make RAVE endpoint configurable

### DIFF
--- a/config/sites/emergency.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/emergency.uiowa.edu/config_split.config_split.site.yml
@@ -38,5 +38,6 @@ complete_list:
   - 'field.storage.node.field_hawk_alert_*'
   - 'field.storage.paragraph.field_hawk_alert_*'
 partial_list:
+  - config_ignore.settings
   - metatag.settings
   - 'user.role.*'

--- a/docroot/sites/emergency.uiowa.edu/modules/emergency_core/src/EmergencyAPI.php
+++ b/docroot/sites/emergency.uiowa.edu/modules/emergency_core/src/EmergencyAPI.php
@@ -11,10 +11,6 @@ use Psr\Log\LoggerInterface;
  * Emergency API service.
  */
 class EmergencyAPI {
-  // Stage endpoint with test data.
-  const BASE_URL_1 = 'https://content.getrave.com/cap/uiowatest/channel1';
-  // Prod endpoint with real data.
-  const BASE_URL_2 = 'https://content.getrave.com/cap/uiowa/channel1';
 
   /**
    * The emergency_core logger channel.
@@ -56,7 +52,7 @@ class EmergencyAPI {
    * @return mixed
    *   The API response data.
    */
-  public function request($method, array $options = [], $base = self::BASE_URL_2) {
+  public function request($method, array $options = []) {
 
     // Merge additional options with default but allow overriding.
     $options = array_merge([
@@ -67,6 +63,9 @@ class EmergencyAPI {
 
     // Default $data to FALSE in case of API fetch failure.
     $data = FALSE;
+
+    $config = \Drupal::config('emergency_core.settings');
+    $base = $config->get('rave_endpoint') . '/channel1';
 
     try {
       $response = $this->client->request($method, $base, $options);

--- a/docroot/sites/emergency.uiowa.edu/modules/emergency_core/src/EmergencyAPI.php
+++ b/docroot/sites/emergency.uiowa.edu/modules/emergency_core/src/EmergencyAPI.php
@@ -46,8 +46,6 @@ class EmergencyAPI {
    *   The HTTP method to use.
    * @param array $options
    *   Optional request options. All requests expect JSON response data.
-   * @param string $base
-   *   The base URL to use for the request. Defaults to self::BASE_URL_1.
    *
    * @return mixed
    *   The API response data.


### PR DESCRIPTION
# Related to #7654 

# How to test

```
ddev blt ds --site emergency.uiowa.edu && ddev drush @emergency.local config:set emergency_core.settings rave_endpoint https://content.getrave.com/cap/uiowatest -y && ddev drush @emergency.local rave-alerts
```
- Confirm that one alert is imported.