### PR TITLE
Allow page replicate after p2lb cleanup

### DIFF
--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -1483,6 +1483,14 @@ function sitenow_p2lb_cleanup(int $batch_size) {
   $sitenow_p2lb->set('status', FALSE);
   $sitenow_p2lb->save(TRUE);
 
+  // Update replicate_allowed.
+  $uiowa_core_config = $config_factory->getEditable('uiowa_core.settings');
+
+  // Allow these content types to be replicated if they exist.
+  $uiowa_core_config
+    ->set('uiowa_core.replicate_allowed', ['page', 'article', 'event', 'alert'])
+    ->save();
+
   // Programmatically run `cim`.
   $alias = Drush::aliasManager()->getSelf();
   $config_import = Drush::processManager()->drush($alias, 'cim');


### PR DESCRIPTION
Ran manually on staff-council: `ddev drush @staff-council.prod cset --input-format=yaml uiowa_core.settings uiowa_core.replicate_allowed '[page, article, event, alert]'`

Looks like approx 7 sites have completed the p2lb process and didn't get the page replicate functionality.

# To Test

Check latinxcouncil.uiowa.edu (finish conversion and try the p2lb cleanup command)
- Login to the site and go to the converter page. Convert remaining pages.
- Go to content overview and filter by page content type. Select all and bulk publish latest revision.
- Run `ddev drush @latinxcouncil.local sitenow_p2lb:cleanup`
- Pick a page from the content overview and see that you can replicate it.

Check staff-council.uiowa.edu (see that you can replicate pages as a result of the command that ran above)
Check brand.uiowa.edu (finished conversion and doesn't have replicate page ability)

# Follow-up

Run the above command on the sites that have previously finished conversion. See P2LB Site Status spreadsheet