### PR TITLE
[Commencement] Added details label

### DIFF
--- a/config/sites/commencement.uiowa.edu/core.entity_view_display.node.event.default.yml
+++ b/config/sites/commencement.uiowa.edu/core.entity_view_display.node.event.default.yml
@@ -223,16 +223,20 @@ third_party_settings:
             region: main
             configuration:
               id: 'field_block:node:event:body'
-              label_display: '0'
+              label: null
+              label_display: null
+              provider: layout_builder
               context_mapping:
                 entity: layout_builder.entity
+                view_mode: view_mode
               formatter:
                 type: text_default
-                label: hidden
+                label: above
                 settings: {  }
                 third_party_settings: {  }
             weight: 9
-            additional: {  }
+            additional:
+              layout_builder_styles_style: {  }
             third_party_settings: {  }
           -
             uuid: 508cd4a0-aa78-4db8-8bd5-7525e772658f

--- a/config/sites/commencement.uiowa.edu/field.field.node.event.body.yml
+++ b/config/sites/commencement.uiowa.edu/field.field.node.event.body.yml
@@ -11,7 +11,7 @@ id: node.event.body
 field_name: body
 entity_type: node
 bundle: event
-label: Body
+label: Details
 description: ''
 required: false
 translatable: true


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/7752

# How to test

Code review to confirm "Body" has changed to "Details"

```
ddev blt ds --site=commencement.uiowa.edu && ddev drush @commencement.local uli /ceremony/spring-2024/gradfest-2024
```

1. Confirm page is displaying "Details" label above body text. 
