### PR TITLE
[Bug] Menu toggle fix for multiple menu blocks on a page

### DIFF
--- a/docroot/themes/custom/uids_base/assets/js/accessible-menu.init.js
+++ b/docroot/themes/custom/uids_base/assets/js/accessible-menu.init.js
@@ -8,7 +8,7 @@
       if (this.executed) {
         return;
       }
-      
+
       const menuWrappers = context.querySelectorAll('.menu-wrapper--horizontal');
 
       // Bail early if no menu wrappers are found.
@@ -20,26 +20,25 @@
       menuWrappers.forEach(function(menuWrapper, index) {
         const menuElement = menuWrapper.querySelector('.menu');
 
-        // Generate a unique ID for the toggle button based on the index
+        // Generate a unique ID for the toggle button based on the index.
         const toggleBtnId = `main-menu-toggle-${index}`;
 
-        // Check if the toggle button already exists for this menu
+        // Check if the toggle button already exists for this menu.
         if (!menuWrapper.querySelector(`#${toggleBtnId}`)) {
-          // Add mobile toggle button
+          // Add mobile toggle button.
           const toggleBtn = context.createElement('button');
           toggleBtn.setAttribute('id', toggleBtnId);
           toggleBtn.setAttribute('aria-label', 'Toggle secondary menu');
-          let block_name = 'menu_block:main';
-          // Get the unique block identifier from the data-block-name attribute
+          // Get the unique block identifier from the data-block-name attribute.
           let block_identifier = menuWrapper.getAttribute('data-block-name');
 
-          // Get the block title from drupalSettings using the unique identifier
+          // Get the block title from drupalSettings using the unique identifier.
           let block_title = drupalSettings.block_title[block_identifier];
-          // Create a new span element and append the text to it
+          // Create a new span element and append the text to it.
           const span = context.createElement('span');
           span.textContent = block_title + ' Menu';
 
-          // Append the span element to the toggleBtn button element
+          // Append the span element to the toggleBtn button element.
           toggleBtn.appendChild(span);
           menuWrapper.insertAdjacentElement('afterbegin', toggleBtn);
         }

--- a/docroot/themes/custom/uids_base/assets/js/accessible-menu.init.js
+++ b/docroot/themes/custom/uids_base/assets/js/accessible-menu.init.js
@@ -4,6 +4,11 @@
     // Initialize executed flag to false.
     executed: false,
     attach: function (context, settings) {
+      // Ensure the script runs only once.
+      if (this.executed) {
+        return;
+      }
+      
       const menuWrappers = context.querySelectorAll('.menu-wrapper--horizontal');
 
       // Bail early if no menu wrappers are found.

--- a/docroot/themes/custom/uids_base/assets/js/accessible-menu.init.js
+++ b/docroot/themes/custom/uids_base/assets/js/accessible-menu.init.js
@@ -1,37 +1,43 @@
-(function ($, AccessibleMenu) {'use strict';
+(function ($, AccessibleMenu) {
+  'use strict';
   Drupal.behaviors.accessible_menu = {
     // Initialize executed flag to false.
     executed: false,
     attach: function (context, settings) {
-      // Ensure the script runs only once.
-      if (this.executed) {
-        return;
-      }
+      const menuWrappers = context.querySelectorAll('.menu-wrapper--horizontal');
 
-      const menus = context.querySelectorAll('.menu-wrapper--horizontal > .menu');
-
-      // Bail early if this isn't relevant.
-      if (menus === null) {
+      // Bail early if no menu wrappers are found.
+      if (menuWrappers.length === 0) {
         return false;
       }
 
-      // Loop through the menus.
-      menus.forEach(function(menuElement) {
+      // Loop through each menu wrapper.
+      menuWrappers.forEach(function(menuWrapper, index) {
+        const menuElement = menuWrapper.querySelector('.menu');
 
-        // Add mobile toggle button
-        const menuBlock = context.querySelector('.menu-wrapper--horizontal');
-        const toggleBtn = context.createElement('button');
-        toggleBtn.setAttribute('id', 'main-menu-toggle');
-        toggleBtn.setAttribute('aria-label', 'Toggle secondary menu');
-        let block_name = 'menu_block:main';
-        let block_title = drupalSettings.block_title[block_name];
-        // Create a new span element and append the text to it
-        const span = context.createElement('span');
-        span.textContent = block_title + ' Menu';
+        // Generate a unique ID for the toggle button based on the index
+        const toggleBtnId = `main-menu-toggle-${index}`;
 
-        // Append the span element to the toggleBtn button element
-        toggleBtn.appendChild(span);
-        menuBlock.insertAdjacentElement('afterbegin', toggleBtn);
+        // Check if the toggle button already exists for this menu
+        if (!menuWrapper.querySelector(`#${toggleBtnId}`)) {
+          // Add mobile toggle button
+          const toggleBtn = context.createElement('button');
+          toggleBtn.setAttribute('id', toggleBtnId);
+          toggleBtn.setAttribute('aria-label', 'Toggle secondary menu');
+          let block_name = 'menu_block:main';
+          // Get the unique block identifier from the data-block-name attribute
+          let block_identifier = menuWrapper.getAttribute('data-block-name');
+
+          // Get the block title from drupalSettings using the unique identifier
+          let block_title = drupalSettings.block_title[block_identifier];
+          // Create a new span element and append the text to it
+          const span = context.createElement('span');
+          span.textContent = block_title + ' Menu';
+
+          // Append the span element to the toggleBtn button element
+          toggleBtn.appendChild(span);
+          menuWrapper.insertAdjacentElement('afterbegin', toggleBtn);
+        }
 
         // Find all menu items that can be displayed.
         const expandableMenuItems = menuElement.querySelectorAll('li.menu-item--expanded > a, li.menu-item--expanded > span');
@@ -60,9 +66,9 @@
           // We have to add 'span' to handle <nolink>.
           menuLinkSelector: 'a, span',
           submenuItemSelector: 'li.menu-item--expanded',
-          controllerElement: context.querySelector('#main-menu-toggle'),
+          controllerElement: menuWrapper.querySelector(`#${toggleBtnId}`),
           submenuToggleSelector: 'button',
-          containerElement: context.querySelector('.menu-wrapper--horizontal'),
+          containerElement: menuWrapper,
           optionalKeySupport: true,
           hoverType: 'off',
         });

--- a/docroot/themes/custom/uids_base/scss/components/menus/main-menu.scss
+++ b/docroot/themes/custom/uids_base/scss/components/menus/main-menu.scss
@@ -656,7 +656,7 @@
   text-align: inherit;
 }
 
-button#main-menu-toggle {
+button[id^="main-menu-toggle-"] {
   @include breakpoint(sm) {
     display: none;
   }

--- a/docroot/themes/custom/uids_base/scss/components/menus/main-menu.scss
+++ b/docroot/themes/custom/uids_base/scss/components/menus/main-menu.scss
@@ -656,7 +656,7 @@
   text-align: inherit;
 }
 
-button[id^="main-menu-toggle-"] {
+button[id^='main-menu-toggle-'] {
   @include breakpoint(sm) {
     display: none;
   }

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -8,7 +8,6 @@
 use Drupal\block\Entity\Block;
 use Drupal\block_content\Entity\BlockContent;
 use Drupal\Component\Utility\Html;
-use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\Plugin\DataType\EntityAdapter;
 use Drupal\Core\Menu\MenuTreeParameters;
@@ -855,24 +854,24 @@ function uids_base_preprocess_block(&$variables) {
         break;
 
       case 'main':
-        // Initialize a static counter variable
+        // Initialize a static counter variable.
         static $block_counter = 0;
         // Make the block title available to pass to accessible-menu.init.js.
         if (isset($variables['elements']['content']['#title'])) {
           $block_title = $variables['elements']['content']['#title']['#markup'];
           $block_counter++;
 
-          // Create a unique identifier for the block using the counter
+          // Create a unique identifier for the block using the counter.
           $block_identifier = 'block-' . $block_counter;
 
-          // Set the data-block-name attribute with the unique identifier
+          // Set the data-block-name attribute with the unique identifier.
           $variables['attributes']['data-block-name'] = $block_identifier;
 
           if ($variables['configuration']['label_type'] == 'block') {
             $block_title = t('Section');
           }
 
-          // Use the unique identifier as the key in the drupalSettings array
+          // Use the unique identifier as the key in the drupalSettings array.
           $variables['#attached']['drupalSettings']['block_title'][$block_identifier] = $block_title;
         }
         break;

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -860,8 +860,6 @@ function uids_base_preprocess_block(&$variables) {
         // Make the block title available to pass to accessible-menu.init.js.
         if (isset($variables['elements']['content']['#title'])) {
           $block_title = $variables['elements']['content']['#title']['#markup'];
-
-          // Increment the block counter
           $block_counter++;
 
           // Create a unique identifier for the block using the counter

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -855,14 +855,27 @@ function uids_base_preprocess_block(&$variables) {
         break;
 
       case 'main':
+        // Initialize a static counter variable
+        static $block_counter = 0;
         // Make the block title available to pass to accessible-menu.init.js.
         if (isset($variables['elements']['content']['#title'])) {
           $block_title = $variables['elements']['content']['#title']['#markup'];
+
+          // Increment the block counter
+          $block_counter++;
+
+          // Create a unique identifier for the block using the counter
+          $block_identifier = 'block-' . $block_counter;
+
+          // Set the data-block-name attribute with the unique identifier
+          $variables['attributes']['data-block-name'] = $block_identifier;
+
           if ($variables['configuration']['label_type'] == 'block') {
             $block_title = t('Section');
           }
-          $block_name = $variables['elements']['#configuration']['id'];
-          $variables['#attached']['drupalSettings']['block_title'][$block_name] = $block_title;
+
+          // Use the unique identifier as the key in the drupalSettings array
+          $variables['#attached']['drupalSettings']['block_title'][$block_identifier] = $block_title;
         }
         break;
 


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/7780

# How to test

```
ddev blt frontend && ddev blt ds --site=clas.uiowa.edu && ddev drush @clas.local uli /node/726/layout
```
1. Code review - are there custom unique ids for blocks?  I couldn't find one an opted for a counter [variable](https://github.com/uiowa/uiowa/blob/8b156f1435519d2a88742aee8864f1c396e8a002/docroot/themes/custom/uids_base/uids_base.theme#L858).
1. Add an additional horizontal menu block further down the page.  Set the block title to something custom. 
2. Save the page and collapse for mobile and see if the mobile menu's are positioned where they are placed in the layout and that they are functioning.
