### PR TITLE
[Bug] Added fix for technology icons breaking on classrooms.uiowa.edu

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/typography/paragraph.scss
+++ b/docroot/themes/custom/uids_base/scss/components/typography/paragraph.scss
@@ -91,3 +91,11 @@ iframe {max-width: 100%;}
 .block-field-blocknodepersonbody p:last-child {
   margin-bottom: 0;
 }
+
+.element--two-column,
+.element--three-column {
+  // Avoid breaking apart the content within the field__item.
+  .field__item {
+    break-inside: avoid;
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/7829. 


<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt frontend && ddev blt ds --site=classrooms.uiowa.edu && ddev drush @classrooms.local uli /epb-427
```
Confirm in Chrome, that the HDMI and Windows (https://classrooms.uiowa.ddev.site/ibif-321) icons are not breaking to new lines.  
