### PR TITLE
[Commencement] Program archive limited to sessions with programs.

### DIFF
--- a/config/sites/commencement.uiowa.edu/views.view.program_archive.yml
+++ b/config/sites/commencement.uiowa.edu/views.view.program_archive.yml
@@ -276,6 +276,56 @@ display:
           plugin_id: bundle
           value:
             session: session
+        field_session_program_target_id:
+          id: field_session_program_target_id
+          table: taxonomy_term__field_session_program
+          field: field_session_program_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: entity_reference
+          operator: 'not empty'
+          value: {  }
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          handler: 'default:media'
+          widget: autocomplete
+          handler_settings:
+            target_bundles:
+              file: file
+            sort:
+              field: _none
+              direction: ASC
+            auto_create: false
+            auto_create_bundle: ''
       style:
         type: table
         options:


### PR DESCRIPTION
Closes #7814 

# How to test

- `ddev blt ds --site=commencement.uiowa.edu && ddev drush @commencement.local uli /programs`
- Only sessions with a program should now appear (aka only Spring 2024 at this time)
- Edit or add a session and add a program. Double-check that session is now appearing on the program archive page. 