### PR TITLE
[Commencement] event importer fixes

### DIFF
--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventItemProcessor.php
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventItemProcessor.php
@@ -14,6 +14,8 @@ class EventItemProcessor extends EntityItemProcessorBase {
    */
   protected static $fieldMap = [
     'title' => 'title',
+    'body' => 'description',
+    'body:format' => 'format',
     'field_event_contact' => 'contact_name',
     'field_event_contact_email' => 'contact_email',
     'field_event_contact_phone' => 'contact_phone',
@@ -26,23 +28,5 @@ class EventItemProcessor extends EntityItemProcessorBase {
     'field_event_when:end_value' => 'end',
     'field_event_when:duration' => 'duration',
   ];
-
-  /**
-   * Process the body field.
-   */
-  public static function process($entity, $record): bool {
-    $updated = parent::process($entity, $record);
-
-    if (isset($record->description)) {
-      // Set both value and format for the body field.
-      $entity->set('body', [
-        'value' => $record->description,
-        'format' => 'filtered_html',
-      ]);
-      $updated = TRUE;
-    }
-
-    return $updated;
-  }
 
 }

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventItemProcessor.php
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventItemProcessor.php
@@ -14,8 +14,6 @@ class EventItemProcessor extends EntityItemProcessorBase {
    */
   protected static $fieldMap = [
     'title' => 'title',
-    'body' => 'description',
-    'body:format' => 'format',
     'field_event_contact' => 'contact_name',
     'field_event_contact_email' => 'contact_email',
     'field_event_contact_phone' => 'contact_phone',
@@ -28,5 +26,23 @@ class EventItemProcessor extends EntityItemProcessorBase {
     'field_event_when:end_value' => 'end',
     'field_event_when:duration' => 'duration',
   ];
+
+  /**
+   * Process the body field.
+   */
+  public static function process($entity, $record): bool {
+    $updated = parent::process($entity, $record);
+
+    if (isset($record->description)) {
+      // Set both value and format for the body field.
+      $entity->set('body', [
+        'value' => $record->description,
+        'format' => 'filtered_html',
+      ]);
+      $updated = TRUE;
+    }
+
+    return $updated;
+  }
 
 }

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventItemProcessor.php
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventItemProcessor.php
@@ -14,7 +14,6 @@ class EventItemProcessor extends EntityItemProcessorBase {
    */
   protected static $fieldMap = [
     'title' => 'title',
-    'body' => 'description_text',
     'field_event_contact' => 'contact_name',
     'field_event_contact_email' => 'contact_email',
     'field_event_contact_phone' => 'contact_phone',
@@ -28,4 +27,21 @@ class EventItemProcessor extends EntityItemProcessorBase {
     'field_event_when:duration' => 'duration',
   ];
 
+  /**
+   * Process the body field.
+   */
+  public static function process($entity, $record): bool {
+    $updated = parent::process($entity, $record);
+
+    if (isset($record->description)) {
+      // Assign the combined hours as processed text.
+      $entity->set('body', [
+        'value' => $record->description,
+        'format' => 'filtered_html',
+      ]);
+      $updated = TRUE;
+    }
+
+    return $updated;
+  }
 }

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventItemProcessor.php
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventItemProcessor.php
@@ -34,7 +34,7 @@ class EventItemProcessor extends EntityItemProcessorBase {
     $updated = parent::process($entity, $record);
 
     if (isset($record->description)) {
-      // Assign the combined hours as processed text.
+      // Set both value and format for the body field.
       $entity->set('body', [
         'value' => $record->description,
         'format' => 'filtered_html',

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventItemProcessor.php
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventItemProcessor.php
@@ -44,4 +44,5 @@ class EventItemProcessor extends EntityItemProcessorBase {
 
     return $updated;
   }
+
 }

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventItemProcessor.php
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventItemProcessor.php
@@ -34,12 +34,14 @@ class EventItemProcessor extends EntityItemProcessorBase {
     $updated = parent::process($entity, $record);
 
     if (isset($record->description)) {
-      // Set both value and format for the body field.
-      $entity->set('body', [
-        'value' => $record->description,
-        'format' => 'filtered_html',
-      ]);
-      $updated = TRUE;
+      if ($entity->get('body')->value !== $record->description) {
+        // Set both value and format for the body field.
+        $entity->set('body', [
+          'value' => $record->description,
+          'format' => 'filtered_html',
+        ]);
+        $updated = TRUE;
+      }
     }
 
     return $updated;

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventsProcessor.php
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventsProcessor.php
@@ -102,12 +102,6 @@ class EventsProcessor extends EntityProcessorBase {
       $record->location_name = $this->findVenueNid($record->location_name);
     }
 
-    // If the description field exists set the format to filtered_html.
-    if (property_exists($record, 'description') && !is_null($record->description)) {
-      // Set default duration.
-      $record->format = 'filtered_html';
-    }
-
     // If there are event instances embedded.
     if (property_exists($record, 'event_instances') && !empty($record->event_instances)) {
       // Set default duration.

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventsProcessor.php
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventsProcessor.php
@@ -102,6 +102,12 @@ class EventsProcessor extends EntityProcessorBase {
       $record->location_name = $this->findVenueNid($record->location_name);
     }
 
+    // If the description field exists set the format to filtered_html.
+    if (property_exists($record, 'description') && !is_null($record->description)) {
+      // Set default duration.
+      $record->format = 'filtered_html';
+    }
+
     // If there are event instances embedded.
     if (property_exists($record, 'event_instances') && !empty($record->event_instances)) {
       // Set default duration.

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventsProcessor.php
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventsProcessor.php
@@ -102,6 +102,14 @@ class EventsProcessor extends EntityProcessorBase {
       $record->location_name = $this->findVenueNid($record->location_name);
     }
 
+    // Convert empty strings to null for the room number field.
+    // Otherwise the importer 'updates' this field every time it is run.
+    if (property_exists($record, 'room_number') && !is_null($record->room_number)) {
+      if (($record->room_number) == "") {
+        $record->room_number = NULL;
+      }
+    }
+
     // If there are event instances embedded.
     if (property_exists($record, 'event_instances') && !empty($record->event_instances)) {
       // Set default duration.

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventsProcessor.php
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventsProcessor.php
@@ -104,10 +104,8 @@ class EventsProcessor extends EntityProcessorBase {
 
     // Convert empty strings to null for the room number field.
     // Otherwise the importer 'updates' this field every time it is run.
-    if (property_exists($record, 'room_number') && !is_null($record->room_number)) {
-      if (($record->room_number) == "") {
-        $record->room_number = NULL;
-      }
+    if (property_exists($record, 'room_number') && $record->room_number === '') {
+      $record->room_number = NULL;
     }
 
     // If there are event instances embedded.


### PR DESCRIPTION
Sort of relates to #7822 

# How to test

- ~~Code review - is this the best way to do this? I tried doing this a different way (see commit number 4) but couldn't get that way to work correctly.~~
- `ddev blt ds --site=commencement.uiowa.edu && ddev drush @commencement.local uli`
- Note how events like https://commencement.uiowa.ddev.site/ceremony/spring-2025/college-liberal-arts-and-sciences-9-am-commencement-ceremony have everything in one paragraph and no links, vs. how it is on the [events calendar](https://events.uiowa.edu/70820)
- `ddev drush @commencement.local import-events`
- Spot check a few different events. Paragraph breaks and links should now appear correctly in the details field. 