### PR TITLE
add if statement to check if logger is null

### DIFF
--- a/docroot/modules/custom/ccom_migrate/src/Plugin/migrate/source/CcomArticle.php
+++ b/docroot/modules/custom/ccom_migrate/src/Plugin/migrate/source/CcomArticle.php
@@ -104,11 +104,13 @@ class CcomArticle extends BaseNodeSource {
         $this->migration
           ->getIdMap()
           ->saveMessage(['nid' => $row->getSourceProperty('nid')], $message);
-        $this->logger->notice('Metatag @item: @value not migrated for node: @nid', [
-          '@item' => $item,
-          '@value' => $value,
-          '@nid' => $row->getSourceProperty('nid'),
-        ]);
+        if ($this->logger != null) {
+          $this->logger->notice('Metatag @item: @value not migrated for node: @nid', [
+            '@item' => $item,
+            '@value' => $value,
+            '@nid' => $row->getSourceProperty('nid'),
+          ]);
+        }
       }
     }
     // If a date is specified in field_date,

--- a/docroot/modules/custom/ccom_migrate/src/Plugin/migrate/source/CcomArticle.php
+++ b/docroot/modules/custom/ccom_migrate/src/Plugin/migrate/source/CcomArticle.php
@@ -104,13 +104,12 @@ class CcomArticle extends BaseNodeSource {
         $this->migration
           ->getIdMap()
           ->saveMessage(['nid' => $row->getSourceProperty('nid')], $message);
-        if ($this->logger != NULL) {
-          $this->logger->notice('Metatag @item: @value not migrated for node: @nid', [
+        $this->logger->notice('Metatag @item: @value not migrated for node: @nid',
+          [
             '@item' => $item,
             '@value' => $value,
             '@nid' => $row->getSourceProperty('nid'),
           ]);
-        }
       }
     }
     // If a date is specified in field_date,

--- a/docroot/modules/custom/ccom_migrate/src/Plugin/migrate/source/CcomArticle.php
+++ b/docroot/modules/custom/ccom_migrate/src/Plugin/migrate/source/CcomArticle.php
@@ -104,7 +104,7 @@ class CcomArticle extends BaseNodeSource {
         $this->migration
           ->getIdMap()
           ->saveMessage(['nid' => $row->getSourceProperty('nid')], $message);
-        if ($this->logger != null) {
+        if ($this->logger != NULL) {
           $this->logger->notice('Metatag @item: @value not migrated for node: @nid', [
             '@item' => $item,
             '@value' => $value,

--- a/docroot/modules/custom/sitenow_migrate/src/Plugin/migrate/source/BaseNodeSource.php
+++ b/docroot/modules/custom/sitenow_migrate/src/Plugin/migrate/source/BaseNodeSource.php
@@ -87,6 +87,7 @@ abstract class BaseNodeSource extends Node implements ImportAwareInterface {
   public function __construct(array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration, StateInterface $state, ModuleHandlerInterface $module_handler, FileSystemInterface $file_system, EntityTypeManager $entityTypeManager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $migration, $state, $entityTypeManager, $module_handler);
     $this->fileSystem = $file_system;
+    $this->logger = $this->getLogger('sitenow_migrate');
     // Add a 'source_file_path' entry to configuration so that we can use it in
     // process plugins later. This is necessary because querying against the
     // source database in a process plugin is not at all straightforward.


### PR DESCRIPTION
Article migration was throwing an error `Error: Call to a member function notice() on null in Drupal\ccom_migrate\Plugin\migrate\source\CcomArticle->prepareRow()` on the metatag section of CcomArticle.php:

```
$this->logger->notice('Metatag @item: @value not migrated for node: @nid', [
            '@item' => $item,
            '@value' => $value,
            '@nid' => $row->getSourceProperty('nid'),
          ]);
```

I added an if statement to check if $this->logger was null around that block of code to fix the issue.

The error was thrown on this article: https://medicinepsychiatry.uiowa.ddev.site/news/2021/02/new-inpatient-psychiatric-unit-now-open

Have not been able to figure out what about this article has caused the issue.