### PR TITLE
[Bug] Badge adjustments to fix Safari display issue again

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/badge.scss
+++ b/docroot/themes/custom/uids_base/scss/components/badge.scss
@@ -6,15 +6,10 @@
   color: $secondary;
 }
 
-.fa-triangle-exclamation, .fa-arrow-trend-down {
-  vertical-align: -0.225em;
-}
-
 .badge {
-  .field__item & {
-    display: inline-flex;
-  }
+  display: inline-flex;
   .svg-inline--fa {
-    margin-top: 2px;
+    margin-right: .4rem;
+    align-self: center;
   }
 }


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/7765

# How to test

```
ddev blt frontend && ddev blt ds --site=its.uiowa.edu && ddev drush @its.local uli /alerts
```

- Open window in Safari and compare against Safari in prod.  Move your browser to a breakpoint where https://github.com/uiowa/uiowa/issues/7765 is visible and test. 

```
ddev blt frontend && ddev blt ds --site=housing.uiowa.edu && ddev drush @housing.local uli /residence-halls/burge
```
- Compare against prod and confirm that icons and badges appear similar. 