### PR TITLE
V2 col width update fix

### DIFF
--- a/docroot/modules/custom/sitenow_paragraphs/sitenow_paragraphs.install
+++ b/docroot/modules/custom/sitenow_paragraphs/sitenow_paragraphs.install
@@ -20,12 +20,21 @@ function sitenow_paragraphs_update_9001() {
       ->condition('cw.bundle', ['people', 'articles'], 'IN')
       ->execute()->fetchCol();
 
-  $people_and_articles_without_column_entries =
-    $database->select('paragraphs_item', 'pi')
-      ->fields('pi', ['id', 'revision_id', 'type'])
-      ->condition('pi.type', ['people', 'articles'], 'IN')
-      ->condition('pi.id', $people_and_articles_with_column_width_entries, 'NOT IN')
-      ->execute();
+  if (!empty($people_and_articles_with_column_width_entries)) {
+    $people_and_articles_without_column_entries =
+      $database->select('paragraphs_item', 'pi')
+        ->fields('pi', ['id', 'revision_id', 'type'])
+        ->condition('pi.type', ['people', 'articles'], 'IN')
+        ->condition('pi.id', $people_and_articles_with_column_width_entries, 'NOT IN')
+        ->execute();
+  }
+  else {
+    $people_and_articles_without_column_entries =
+      $database->select('paragraphs_item', 'pi')
+        ->fields('pi', ['id', 'revision_id', 'type'])
+        ->condition('pi.type', ['people', 'articles'], 'IN')
+        ->execute();
+  }
 
   $current_entities = [];
   foreach ($people_and_articles_without_column_entries as $paragraph) {
@@ -47,14 +56,25 @@ function sitenow_paragraphs_update_9001() {
       ->condition('cw.bundle', ['people', 'articles'], 'IN')
       ->execute()->fetchCol();
 
-  $query = $database->select('paragraphs_item_revision', 'pi_r')
-    ->fields('pi_r', ['id', 'revision_id']);
-  $query->join('paragraphs_item', 'pi', 'pi.id = pi_r.id');
-  $people_and_articles_revisions_without_column_entries =
-    $query->fields('pi', ['type'])
-      ->condition('pi.type', ['people', 'articles'], 'IN')
-      ->condition('pi_r.revision_id', $people_and_articles_revisions_with_column_width_entries, 'NOT IN')
-      ->execute();
+  if (!empty($people_and_articles_revisions_with_column_width_entries)) {
+    $query = $database->select('paragraphs_item_revision', 'pi_r')
+      ->fields('pi_r', ['id', 'revision_id']);
+    $query->join('paragraphs_item', 'pi', 'pi.id = pi_r.id');
+    $people_and_articles_revisions_without_column_entries =
+      $query->fields('pi', ['type'])
+        ->condition('pi.type', ['people', 'articles'], 'IN')
+        ->condition('pi_r.revision_id', $people_and_articles_revisions_with_column_width_entries, 'NOT IN')
+        ->execute();
+  }
+  else {
+    $query = $database->select('paragraphs_item_revision', 'pi_r')
+      ->fields('pi_r', ['id', 'revision_id']);
+    $query->join('paragraphs_item', 'pi', 'pi.id = pi_r.id');
+    $people_and_articles_revisions_without_column_entries =
+      $query->fields('pi', ['type'])
+        ->condition('pi.type', ['people', 'articles'], 'IN')
+        ->execute();
+  }
 
   $revisions = [];
   foreach ($people_and_articles_revisions_without_column_entries as $paragraph) {

--- a/docroot/modules/custom/sitenow_paragraphs/sitenow_paragraphs.install
+++ b/docroot/modules/custom/sitenow_paragraphs/sitenow_paragraphs.install
@@ -20,21 +20,16 @@ function sitenow_paragraphs_update_9001() {
       ->condition('cw.bundle', ['people', 'articles'], 'IN')
       ->execute()->fetchCol();
 
+  $people_and_articles_without_column_entries_query =
+    $database->select('paragraphs_item', 'pi')
+      ->fields('pi', ['id', 'revision_id', 'type'])
+      ->condition('pi.type', ['people', 'articles'], 'IN');
+
   if (!empty($people_and_articles_with_column_width_entries)) {
-    $people_and_articles_without_column_entries =
-      $database->select('paragraphs_item', 'pi')
-        ->fields('pi', ['id', 'revision_id', 'type'])
-        ->condition('pi.type', ['people', 'articles'], 'IN')
-        ->condition('pi.id', $people_and_articles_with_column_width_entries, 'NOT IN')
-        ->execute();
+    $people_and_articles_without_column_entries_query->condition('pi.id', $people_and_articles_with_column_width_entries, 'NOT IN');
   }
-  else {
-    $people_and_articles_without_column_entries =
-      $database->select('paragraphs_item', 'pi')
-        ->fields('pi', ['id', 'revision_id', 'type'])
-        ->condition('pi.type', ['people', 'articles'], 'IN')
-        ->execute();
-  }
+
+  $people_and_articles_without_column_entries = $people_and_articles_without_column_entries_query->execute();
 
   $current_entities = [];
   foreach ($people_and_articles_without_column_entries as $paragraph) {
@@ -56,25 +51,18 @@ function sitenow_paragraphs_update_9001() {
       ->condition('cw.bundle', ['people', 'articles'], 'IN')
       ->execute()->fetchCol();
 
+  $query = $database->select('paragraphs_item_revision', 'pi_r')
+    ->fields('pi_r', ['id', 'revision_id']);
+  $query->join('paragraphs_item', 'pi', 'pi.id = pi_r.id');
+  $people_and_articles_revisions_without_column_entries_query =
+    $query->fields('pi', ['type'])
+      ->condition('pi.type', ['people', 'articles'], 'IN');
+
   if (!empty($people_and_articles_revisions_with_column_width_entries)) {
-    $query = $database->select('paragraphs_item_revision', 'pi_r')
-      ->fields('pi_r', ['id', 'revision_id']);
-    $query->join('paragraphs_item', 'pi', 'pi.id = pi_r.id');
-    $people_and_articles_revisions_without_column_entries =
-      $query->fields('pi', ['type'])
-        ->condition('pi.type', ['people', 'articles'], 'IN')
-        ->condition('pi_r.revision_id', $people_and_articles_revisions_with_column_width_entries, 'NOT IN')
-        ->execute();
+    $people_and_articles_revisions_without_column_entries_query->condition('pi_r.revision_id', $people_and_articles_revisions_with_column_width_entries, 'NOT IN');
   }
-  else {
-    $query = $database->select('paragraphs_item_revision', 'pi_r')
-      ->fields('pi_r', ['id', 'revision_id']);
-    $query->join('paragraphs_item', 'pi', 'pi.id = pi_r.id');
-    $people_and_articles_revisions_without_column_entries =
-      $query->fields('pi', ['type'])
-        ->condition('pi.type', ['people', 'articles'], 'IN')
-        ->execute();
-  }
+
+  $people_and_articles_revisions_without_column_entries = $people_and_articles_revisions_without_column_entries_query->execute();
 
   $revisions = [];
   foreach ($people_and_articles_revisions_without_column_entries as $paragraph) {


### PR DESCRIPTION
Resolves #7937

# To Test

Reference https://github.com/uiowa/uiowa/pull/7893

`ddev blt ds --site=accreditation.uiowa.edu` on `main` and see the update hook fail.

Checkout `v2_col_width_update_fix`, run `ddev blt ds --site=accreditation.uiowa.edu` and see it succeed.

```
ddev drush @accreditation.local sql-drop -y && ddev drush @accreditation.local cr && ddev drush sql-sync @accreditation.prod @accreditation.local && ddev drush @accreditation.local uli
```

Add an entry that doesn't have the column width set for people and/or articles. Run `ddev drush @accreditation.local updb` and see it succeeds and that the node entry has been updated to Full.