### PR TITLE
[Registrar] Removed full calendar libraries no longer used

### DIFF
--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/registrar_core.libraries.yml
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/registrar_core.libraries.yml
@@ -3,9 +3,6 @@ academic-calendar:
     theme:
       css/academic_calendar.css: {}
   js:
-    https://cdn.jsdelivr.net/npm/fullcalendar@6.1.14/index.global.min.js: { },
-    https://unpkg.com/popper.js/dist/umd/popper.min.js: {}
-    https://unpkg.com/tooltip.js/dist/umd/tooltip.min.js: {}
     js/academic_calendar.js: {}
   dependencies:
     - core/drupal


### PR DESCRIPTION
Fixes this error:
```
php-error web-33204 [06-Aug-2024 11:40:25 America/Chicago] Uncaught PHP Exception Drupal\Core\Asset\Exception\InvalidLibraryFileException: "Invalid library definition in sites/registrar.uiowa.edu/modules/registrar_core/registrar_core.libraries.yml: yaml_parse(): parsing error encountered during parsing: did not find expected key (line 6, column 78), context while parsing a block mapping (line 6, column 5)" at /mnt/www/html/uiowa/docroot/core/lib/Drupal/Core/Asset/LibraryDiscoveryParser.php line 367 request_id="v-944930f4-5412-11ef-b43d-dbd77cd4d4fb" 
```

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
 ddev blt ds --site=registrar.uiowa.edu  && ddev drush @registrar.local uli  /node/111/layout
```
- Confirm that block can be placed and page can be saved. 
