### PR TITLE
Update GPA Calculator module

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6060,26 +6060,26 @@
         },
         {
             "name": "drupal/gpa_calculator",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/gpa_calculator.git",
-                "reference": "2.0.1"
+                "reference": "2.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/gpa_calculator-2.0.1.zip",
-                "reference": "2.0.1",
-                "shasum": "840a0c931b314bbd979f50d118d2cc3a7cfb4f87"
+                "url": "https://ftp.drupal.org/files/projects/gpa_calculator-2.0.2.zip",
+                "reference": "2.0.2",
+                "shasum": "3dd55f885355287557d6fab7ca356ec8ea948b33"
             },
             "require": {
-                "drupal/core": "^10"
+                "drupal/core": "^10 | ^11"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.1",
-                    "datestamp": "1720471459",
+                    "version": "2.0.2",
+                    "datestamp": "1723822849",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
Resolves #7899 

# How to test

```
ddev composer install && ddev blt ds --site registrar.uiowa.edu
```
- Ensure no issue with sync.
- Visit https://registrar.uiowa.ddev.site/gpa-calculator and re-check the basic functionality. This was already tested, so no need to go to deep.
