### PR TITLE
[Registrar] Adding missing :focus for calendar month checkbox

### DIFF
--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/css/academic_calendar.css
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/css/academic_calendar.css
@@ -4,15 +4,25 @@
   padding-top: 3rem!important;
 }
 
-.block-padding__top:first-child {
-  padding-top: 0!important;
+
+@media (min-width: 768px) {
+  .block-padding__top:first-child {
+    padding-top: 0 !important;
+  }
 }
 
 .badge {
   font-size: .9rem!important;
 }
 
-.academic-calendar-filters.uids-content .form-item-group-by-month.form-type-checkbox  .form-checkbox {
+.academic-calendar-filters.uids-content .form-item-group-by-month.form-type-checkbox  label {
+  margin-left: 0;
+  margin-top: .3rem;
+  font-weight: bold;
+  vertical-align: top;
+}
+
+.form-item-group-by-month.form-type-checkbox .form-checkbox {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -30,18 +40,11 @@
   margin-right: 1rem;
 }
 
-.form-item-group-by-month.form-type-checkbox  .form-checkbox:focus {
-  background: #737373;
+.form-item-group-by-month.form-type-checkbox .form-checkbox:focus {
+  outline: 5px auto #4d90fe;
 }
 
-.academic-calendar-filters.uids-content .form-item-group-by-month.form-type-checkbox  label {
-  margin-left: 0;
-  margin-top: .3rem;
-  font-weight: bold;
-  vertical-align: top;
-}
-
-.form-item-group-by-month.form-type-checkbox  .form-checkbox:before {
+.form-item-group-by-month.form-type-checkbox .form-checkbox:before {
   content: "on off";
   display: block;
   position: absolute;
@@ -60,20 +63,19 @@
   color: var(--brand-secondary);
   white-space: nowrap;
   box-shadow: 0 1px 2px rgba(0,0,0,0.2);
-  transition: all cubic-bezier(0.3,1.5,0.7,1) 0.3s;
+  transition: all cubic-bezier(0.3,1.5,0.7,1) 0.3s
 }
 
-.academic-calendar-filters.uids-content .form-item-group-by-month.form-type-checkbox  .form-checkbox:checked {
-  background-color: var(--brand-primary);
+.form-item-group-by-month.form-type-checkbox .form-checkbox:checked {
+  background-color: var(--brand-primary)
 }
 
-.form-item-group-by-month.form-type-checkbox  .form-checkbox:checked:before {
-  left: 32px;
+.form-item-group-by-month.form-type-checkbox .form-checkbox:checked:before {
+  left: 32px
 }
 
-.academic-calendar-filters [type=checkbox] {
-  height: 1.2rem;
-  width: 1.2rem;
+.academic-calendar-filters [type="checkbox"] {
   margin: 0 .35rem 0 .5rem;
   -webkit-transform: scale(1.3);
+  transform: scale(1.3);
 }

--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/AcademicCalendarBlock.php
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/AcademicCalendarBlock.php
@@ -248,7 +248,7 @@ class AcademicCalendarBlock extends BlockBase implements ContainerFactoryPluginI
     $form = [];
 
     $form['#id'] = 'academic-calendar-filter-form';
-    $form['#attributes']['class'][] = 'academic-calendar-filters sidebar element--padding__all--minimal bg--gray';
+    $form['#attributes']['class'][] = 'academic-calendar-filters sidebar element--margin__bottom--extra  element--padding__all--minimal bg--gray';
 
     $current_request = $this->requestStack->getCurrentRequest();
 


### PR DESCRIPTION
I noticed that the month checkbox focus wasn't working while prepping for demo.  This pr fixes that by adding an outline around the checkbox when focused. 

<img width="302" alt="Screenshot 2024-08-22 at 2 53 28 PM" src="https://github.com/user-attachments/assets/f4c17550-4c9d-448c-88ca-99042d7be1e5">


# How to test

- Code review or run the command below and confirm that checkbox focus style is work and that mobile view of calendar has separation between filter box and content.

```
ddev blt ds --site=registrar.uiowa.edu && ddev drush @registrar.local uli   /calendars-and-deadlines/academic-calendar
```

**Before:**

<img width="432" alt="Screenshot 2024-08-22 at 2 56 05 PM" src="https://github.com/user-attachments/assets/05112425-51f2-4975-a284-e21fa50b6d4c">

**After:**

<img width="452" alt="Screenshot 2024-08-22 at 2 55 28 PM" src="https://github.com/user-attachments/assets/c30b7279-f6b9-4a75-9ced-58f5252df9f1">

