### PR TITLE
ITS Updates Sprint 227

### DIFF
--- a/config/default/workflows.workflow.draft.yml
+++ b/config/default/workflows.workflow.draft.yml
@@ -1,0 +1,56 @@
+uuid: d237e481-7313-4ec4-83a8-75b3d13ca8de
+langcode: en
+status: true
+dependencies:
+  module:
+    - content_moderation
+id: draft
+label: Draft
+type: content_moderation
+type_settings:
+  states:
+    archived:
+      label: Archived
+      weight: 1
+      published: false
+      default_revision: true
+    draft:
+      label: Draft
+      weight: -1
+      published: false
+      default_revision: false
+    published:
+      label: Published
+      weight: 0
+      published: true
+      default_revision: true
+  transitions:
+    archive:
+      label: Archive
+      from:
+        - published
+      to: archived
+      weight: 1
+    archived_published:
+      label: 'Restore from archive'
+      from:
+        - archived
+      to: published
+      weight: 2
+    create_new_draft:
+      label: 'Create New Draft'
+      from:
+        - archived
+        - draft
+        - published
+      to: draft
+      weight: -1
+    publish:
+      label: Publish
+      from:
+        - draft
+        - published
+      to: published
+      weight: 0
+  entity_types: {  }
+  default_moderation_state: draft

--- a/config/sites/its.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/its.uiowa.edu/config_split.config_split.site.yml
@@ -72,6 +72,7 @@ partial_list:
   - node.type.alert
   - node.type.article
   - views.view.alerts_list_block
+  - workflows.workflow.draft
   - workflows.workflow.editorial
   - 'workbench_email.*'
   - 'user.role.*'

--- a/config/sites/its.uiowa.edu/config_split.patch.core.entity_form_display.node.alert.default.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.core.entity_form_display.node.alert.default.yml
@@ -10,7 +10,6 @@ adding:
     module:
       - content_moderation
       - paragraphs
-      - uiowa_core
   content:
     body:
       weight: 12
@@ -94,10 +93,11 @@ adding:
     sticky:
       weight: 8
     title:
-      type: string_case_widget
       weight: 1
     uid:
       weight: 2
+  hidden:
+    title: true
 removing:
   dependencies:
     config:
@@ -139,8 +139,11 @@ removing:
     sticky:
       weight: 9
     title:
-      type: string_textfield
       weight: 12
+      settings:
+        size: 60
+        placeholder: ''
+      type: string_textfield
     uid:
       weight: 0
   hidden:

--- a/config/sites/its.uiowa.edu/config_split.patch.user.role.editor.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.user.role.editor.yml
@@ -23,8 +23,6 @@ adding:
     - 'enter alert revision log entry'
     - 'enter service revision log entry'
     - 'enter support_article revision log entry'
-    - 'override service published option'
-    - 'override support_article published option'
     - 'replicate entities'
     - 'revert alert revisions'
     - 'revert service revisions'

--- a/config/sites/its.uiowa.edu/config_split.patch.user.role.editor.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.user.role.editor.yml
@@ -5,6 +5,7 @@ adding:
       - node.type.service
       - node.type.support_article
       - workflows.workflow.alert
+      - workflows.workflow.draft
     module:
       - replicate_ui
   permissions:
@@ -30,6 +31,10 @@ adding:
     - 'revert support_article revisions'
     - 'use alert transition create_new_draft'
     - 'use alert transition needs_review'
+    - 'use draft transition archived_published'
+    - 'use draft transition create_new_draft'
+    - 'use draft transition publish'
+    - 'use editorial transition archive'
     - 'view alert revisions'
     - 'view service revisions'
     - 'view support_article revisions'

--- a/config/sites/its.uiowa.edu/config_split.patch.user.role.publisher.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.user.role.publisher.yml
@@ -4,6 +4,7 @@ adding:
       - node.type.service
       - node.type.support_article
       - workflows.workflow.alert
+      - workflows.workflow.draft
   permissions:
     - 'create support_article content'
     - 'delete any support_article content'
@@ -30,6 +31,10 @@ adding:
     - 'use alert transition create_new_draft'
     - 'use alert transition needs_review'
     - 'use alert transition publish'
+    - 'use draft transition archive'
+    - 'use draft transition archived_published'
+    - 'use draft transition create_new_draft'
+    - 'use draft transition publish'
     - 'view service revisions'
     - 'view support_article revisions'
 removing:

--- a/config/sites/its.uiowa.edu/config_split.patch.user.role.webmaster.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.user.role.webmaster.yml
@@ -8,6 +8,7 @@ adding:
       - taxonomy.vocabulary.service_category
       - taxonomy.vocabulary.support_article_categories
       - workflows.workflow.alert
+      - workflows.workflow.draft
     module:
       - its_core
   permissions:
@@ -56,6 +57,10 @@ adding:
     - 'use alert transition create_new_draft'
     - 'use alert transition needs_review'
     - 'use alert transition publish'
+    - 'use draft transition archive'
+    - 'use draft transition archived_published'
+    - 'use draft transition create_new_draft'
+    - 'use draft transition publish'
     - 'view service revisions'
     - 'view support_article revisions'
 removing: {  }

--- a/config/sites/its.uiowa.edu/config_split.patch.workflows.workflow.draft.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.workflows.workflow.draft.yml
@@ -1,0 +1,6 @@
+adding:
+  dependencies:
+    config:
+      - node.type.service
+      - node.type.support_article
+removing: {  }

--- a/config/sites/its.uiowa.edu/config_split.patch.workflows.workflow.draft.yml
+++ b/config/sites/its.uiowa.edu/config_split.patch.workflows.workflow.draft.yml
@@ -3,4 +3,9 @@ adding:
     config:
       - node.type.service
       - node.type.support_article
+  type_settings:
+    entity_types:
+      node:
+        - service
+        - support_article
 removing: {  }

--- a/config/sites/its.uiowa.edu/core.entity_form_display.node.service.default.yml
+++ b/config/sites/its.uiowa.edu/core.entity_form_display.node.service.default.yml
@@ -85,13 +85,13 @@ content:
     third_party_settings: {  }
   field_service_fees:
     type: options_select
-    weight: 18
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
   field_service_fees_info:
     type: text_textarea
-    weight: 19
+    weight: 20
     region: content
     settings:
       rows: 5
@@ -128,13 +128,13 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 20
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 16
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -146,7 +146,7 @@ content:
       display_label: true
     third_party_settings: {  }
   simple_sitemap:
-    weight: 17
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sites/its.uiowa.edu/core.entity_form_display.node.service.default.yml
+++ b/config/sites/its.uiowa.edu/core.entity_form_display.node.service.default.yml
@@ -15,8 +15,10 @@ dependencies:
     - field.field.node.service.field_service_related_service
     - field.field.node.service.field_service_website
     - node.type.service
+    - workflows.workflow.draft
   module:
     - allowed_formats
+    - content_moderation
     - link
     - metatag
     - path
@@ -124,6 +126,12 @@ content:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   path:
     type: path
     weight: 16
@@ -180,7 +188,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
-  moderation_state: true
   publish_on: true
   publish_state: true
   unpublish_on: true

--- a/config/sites/its.uiowa.edu/core.entity_form_display.node.support_article.default.yml
+++ b/config/sites/its.uiowa.edu/core.entity_form_display.node.support_article.default.yml
@@ -10,8 +10,10 @@ dependencies:
     - field.field.node.support_article.field_support_article_service
     - field.field.node.support_article.field_support_article_short_desc
     - node.type.support_article
+    - workflows.workflow.draft
   module:
     - allowed_formats
+    - content_moderation
     - metatag
     - paragraphs
     - path
@@ -90,6 +92,12 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 15
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   path:
     type: path
     weight: 7
@@ -146,7 +154,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
-  moderation_state: true
   publish_on: true
   publish_state: true
   unpublish_on: true

--- a/config/sites/its.uiowa.edu/core.entity_form_display.node.support_article.default.yml
+++ b/config/sites/its.uiowa.edu/core.entity_form_display.node.support_article.default.yml
@@ -25,7 +25,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 10
+    weight: 11
     region: content
     settings:
       rows: 9
@@ -44,7 +44,7 @@ content:
     third_party_settings: {  }
   field_meta_tags:
     type: metatag_firehose
-    weight: 12
+    weight: 13
     region: content
     settings:
       sidebar: true
@@ -52,13 +52,13 @@ content:
     third_party_settings: {  }
   field_support_article_category:
     type: options_buttons
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   field_support_article_faqs:
     type: paragraphs
-    weight: 14
+    weight: 15
     region: content
     settings:
       title: Paragraph
@@ -76,7 +76,7 @@ content:
     third_party_settings: {  }
   field_support_article_service:
     type: entity_reference_autocomplete
-    weight: 11
+    weight: 12
     region: content
     settings:
       match_operator: CONTAINS
@@ -94,7 +94,7 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 15
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sites/its.uiowa.edu/core.entity_view_display.node.service.default.yml
+++ b/config/sites/its.uiowa.edu/core.entity_view_display.node.service.default.yml
@@ -36,6 +36,33 @@ third_party_settings:
       -
         layout_id: layout_onecol
         layout_settings:
+          label: Moderation
+          context_mapping: {  }
+          layout_builder_styles_style:
+            - ''
+            - section_container_narrow
+        components:
+          -
+            uuid: ''
+            region: content
+            configuration:
+              id: 'extra_field_block:node:service:content_moderation_control'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+            weight: 0
+            additional: {  }
+            third_party_settings: {  }
+        third_party_settings:
+          layout_builder_lock:
+            lock: {  }
+          layout_builder_limit:
+            limit:
+              scope: disabled
+              scope_update: 'Update scope'
+      -
+        layout_id: layout_onecol
+        layout_settings:
           label: ''
           context_mapping: {  }
           layout_builder_styles_style:

--- a/config/sites/its.uiowa.edu/core.entity_view_display.node.support_article.default.yml
+++ b/config/sites/its.uiowa.edu/core.entity_view_display.node.support_article.default.yml
@@ -25,6 +25,33 @@ third_party_settings:
     allow_custom: false
     sections:
       -
+        layout_id: layout_onecol
+        layout_settings:
+          label: Moderation
+          context_mapping: {  }
+          layout_builder_styles_style:
+            - ''
+            - section_container_narrow
+        components:
+          -
+            uuid: ''
+            region: content
+            configuration:
+              id: 'extra_field_block:node:support_article:content_moderation_control'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+            weight: 0
+            additional: {  }
+            third_party_settings: {  }
+        third_party_settings:
+          layout_builder_lock:
+            lock: {  }
+          layout_builder_limit:
+            limit:
+              scope: disabled
+              scope_update: 'Update scope'
+      -
         layout_id: layout_header
         layout_settings:
           label: ''

--- a/config/sites/its.uiowa.edu/views.view.alerts_list_block.yml
+++ b/config/sites/its.uiowa.edu/views.view.alerts_list_block.yml
@@ -1885,7 +1885,18 @@ display:
         filter_groups: false
         footer: false
       display_description: ''
-      footer: {  }
+      footer:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: '&nbsp;'
+          tokenize: false
       display_extenders:
         metatag_display_extender:
           metatags: {  }

--- a/config/sites/its.uiowa.edu/workflows.workflow.alert.yml
+++ b/config/sites/its.uiowa.edu/workflows.workflow.alert.yml
@@ -29,7 +29,7 @@ type_settings:
       published: true
       default_revision: true
     review:
-      label: Review
+      label: Submit
       weight: -1
       published: false
       default_revision: false
@@ -59,6 +59,7 @@ type_settings:
       label: 'Needs Review'
       from:
         - draft
+        - published
         - review
       to: review
       weight: -1

--- a/docroot/sites/its.uiowa.edu/modules/its_core/its_core.module
+++ b/docroot/sites/its.uiowa.edu/modules/its_core/its_core.module
@@ -393,6 +393,8 @@ function its_core_form_alter(&$form, FormStateInterface $form_state, $form_id) {
       // Prevent users that can't publish from sending an email.
       if (!\Drupal::currentUser()->hasPermission('use editorial transition publish')) {
         $form['field_alert_email']['#access'] = FALSE;
+        // Supplement moderation selection with description text explaining workflow.
+        $form['moderation_state']['widget'][0]['state']['#description'] = t('In order to publish, alert must be saved as "Submit" to notify the ITS Help Desk.');
       }
       // Only allow access to these fields for users
       // with the 'administer site configuration' permission.


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt ds --site=its.uiowa.edu
```

Might be moderation control warnings for service, support articles, but that is nothing new.

- As an editor/publisher/webmaster I don't see the node title field on the Alert content type form. Additional details is lower in the form.
- As an editor, I can update a published alert and move it directly to "submit" (needs review). I also see field description text that explains I need to save as submit in order for the helpdesk to publish my alert.
- As a publisher/webmaster I can update a published alert and go directly from published to published and don't see the field description about the submit state.
- As a visitor, I can see the calendar render at /alerts/calendar
- As an editor, I can add/edit a service/support article and save as a draft or directly publish.
  - Saving as a draft, I can see the moderation control functionality when I view the unpublished node and switch it to published.
- As a publisher/webmaster I can archive service/support article content.
- Sync another website to confirm that there are no import errors associated with the new workflow and that you still see "Needs Review" type states for the article content type.