### PR TITLE
BLT UMC - Additional Checks

### DIFF
--- a/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
+++ b/blt/src/Blt/Plugin/Commands/MultisiteCommands.php
@@ -398,9 +398,42 @@ EOD
       return new CommandError('Cannot parse URI for validation.');
     }
 
-    // RMI does this but we run it with no interaction.
-    if (file_exists("{$root}/docroot/sites/{$host}")) {
+    $sites_dir = "{$root}/docroot/sites/";
+
+    // RMI does this, but we run it with no interaction.
+    if (file_exists("{$sites_dir}{$host}")) {
       return new CommandError("Site {$host} already exists.");
+    }
+
+    // Normalize the host for conflict checking.
+    $normalized_host = str_replace(['.', '-'], '_', $host);
+
+    // Scan the sites directory for potential conflicts with normalized names.
+    $directories = scandir($sites_dir);
+    $potential_conflicts = [];
+
+    foreach ($directories as $dir) {
+      // Skip '.' and '..' directories and non-directories.
+      if ($dir === '.' || $dir === '..' || !is_dir($sites_dir . $dir)) {
+        continue;
+      }
+
+      // Normalize the directory name same as Multisite::getDatabaseName().
+      $normalized_dir_name = str_replace(['.', '-'], '_', $dir);
+
+      // Compare normalized directory name with the normalized host.
+      if (stripos($normalized_dir_name, $normalized_host) !== FALSE) {
+        $potential_conflicts[] = $dir;
+      }
+    }
+
+    // If potential conflicts are found, warn the user and ask for confirmation.
+    if (!empty($potential_conflicts)) {
+      $this->logger->warning('Potential conflicts detected with existing sites: ' . implode(', ', $potential_conflicts));
+
+      if (!$this->confirm('Proceed with creating the site despite the potential conflicts?')) {
+        throw new \Exception('Multisite creation aborted.');
+      }
     }
   }
 
@@ -542,7 +575,7 @@ EOD
 
         // Check if response message indicates success.
         if (stripos($response->message, 'created') !== FALSE) {
-          $this->say("Creating {$db} database on {$app}.");
+          $this->say("The database, {$db}, is being created on {$app}.");
         }
         else {
           // If the response message doesn't indicate success, return error.

--- a/blt/src/Multisite.php
+++ b/blt/src/Multisite.php
@@ -30,8 +30,7 @@ class Multisite {
       throw new \Exception('The default site is configured automatically by BLT.');
     }
     else {
-      $db = str_replace('.', '_', $dir);
-      $db = str_replace('-', '_', $db);
+      $db = str_replace(['.', '-'], '_', $dir);
     }
 
     return $db;


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/7996

References:

- The database creation trigger/response: https://cloudapi-docs.acquia.com/#/Applications/postApplicationDatabaseCreate
- How our database names are generated: https://github.com/uiowa/uiowa/blob/474e37a60c17283774fc7954f4679766332110d0/blt/src/Multisite.php#L28
- Optimized str_replace: https://www.phptutorial.net/php-tutorial/php-str_replace/

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

- Try a command like with a similar site you know will have a `.`/ `-` type conflict:
```
./vendor/bin/blt uiowa:multisite:create gis-sites
.uiowa.edu --requester=jwhitsit --site-name="https://gis-sites.uiowa.edu" --no-commit --no-db
```
- Code previously existed to check for an existing site that matches
- You can try the try/catch (leave the --no-commit, but remove the --no-db flag) but it will create the database on the remotes which will have to be cleaned up through the UI as the deprovision script won't work until the provision is pushed all the way up to PROD.

# Additional

<img width="642" alt="Screenshot 2024-08-28 at 10 32 53 AM" src="https://github.com/user-attachments/assets/3861231e-e0a4-4494-9cf7-913288cbfeb8">

