### PR TITLE
Write parallel deploy to log and grep for errors

### DIFF
--- a/logrotate.conf
+++ b/logrotate.conf
@@ -1,8 +1,19 @@
-/shared/logs/*.log {
+# Configuration for drush-cron.log
+/shared/logs/drush-cron.log {
   rotate 3
   missingok
   compress
   notifempty
   dateext
   dateformat -%Y-%m-%d.log
+}
+
+# Configuration for parallel_deploy_log_* files
+/shared/logs/parallel_deploy_log_* {
+  rotate 3
+  missingok
+  compress
+  notifempty
+  dateext
+  dateformat -%Y-%m-%d_%H-%M-%S.log
 }


### PR DESCRIPTION
Resolves #8016

Lifted and adjusted https://github.com/uiowa/uiowa/issues/7800#issuecomment-2299134874 to use `tee` to output the result both to the terminal and to a longer term log file.

# To Test

- Set up parallelization locally:
```
ddev ssh
```
- Inside DDEV:
```
sudo apt install parallel && exit
```
Note: This will be removed with a ddev update/restart.
- Test with parallelization:
```
ddev blt artifact:update:drupal:all-sites
```

Observe that the terminal outputs the site specific deployment info, but also mentions writing to a log file with a datetime suffix.

- Mangle some config: make an edit to any config file in the default config set so that the YAML is invalid. This will cause site deployment updates to fail.
```
ddev blt artifact:update:drupal:all-sites
```
- After all output from parallel deployments, you should see `[error]  Error deploying updates. Check the log output for more information. `

You can review the log file by ssh'n back into the ddev container, `cd /tmp` and `cat` the latest file prepended with `parallel_deploy_log_`

We have log rotation setup on each prod app that we can make sure is also added to all stage environments (dev/stage have a shared /shared/logs directory). It calls the logrotate.conf file which has been updated to handle `drush-cron.log` separately as we are potentially dealing with multiple different log files each week for `parallel_deploy_log_` still keeping the latest three. so if more than three deployments happen in a week only the latest ones will be kept for a bit longer. We will need to push this out and watch it for a while to determine if it is actually working as expected.

# Follow-up

- Ensure log rotate jobs are setup in for all ACN apps' stage environments.
- Watch for log writing and rotation as time goes by.
