### PR TITLE
[ DX ] Adding default to each apps list of updates.

### DIFF
--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -40,7 +40,9 @@ class ReplaceCommands extends BltTasks {
       if (!isset($manifest[$app])) {
         $this->logger->warning('No multisites found in manifest for application: ' . $app);
       }
-      $multisites = $manifest[$app] ?: [];
+
+      // Ensure that default is added to each app, so we update the default site.
+      $multisites = $manifest[$app] ? [...['default'], ...$manifest[$app]] : [];
     }
 
     // Unshift sites to the beginning to run first.

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -41,9 +41,9 @@ class ReplaceCommands extends BltTasks {
         $this->logger->warning('No multisites found in manifest for application: ' . $app);
       }
 
-      // Ensure that default is added to each app, so we update the default site.
       $multisites = $manifest[$app] ?: [];
 
+      // Ensure that default is added to uiowa app, so we update the default site.
       if ($app === 'uiowa') {
         $multisites = [...['default'], ...$multisites];
       }

--- a/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
+++ b/blt/src/Blt/Plugin/Commands/ReplaceCommands.php
@@ -42,7 +42,11 @@ class ReplaceCommands extends BltTasks {
       }
 
       // Ensure that default is added to each app, so we update the default site.
-      $multisites = $manifest[$app] ? [...['default'], ...$manifest[$app]] : [];
+      $multisites = $manifest[$app] ?: [];
+
+      if ($app === 'uiowa') {
+        $multisites = [...['default'], ...$multisites];
+      }
     }
 
     // Unshift sites to the beginning to run first.


### PR DESCRIPTION
# How to test

1. take a look at the output for the updates of uiowa in acquia cloud. 
2. Observe that the default site is getting hit and its database updated.

<details><summary>Output from acquia cloud uiowa</summary>

```
[16:47:35] [16:47:35] Started

[16:58:28] [2024-09-16 16:47:36] Sending push event develop-build d9542e62825d3a2506d21f78e02996f91d3a7bbc
[2024-09-16 16:53:11] Attempting to invalidate Twig cache...
[2024-09-16 16:53:11] Twig cache not invalidated; this is only supported for Drupal 8.6+
[2024-09-16 16:53:11] Starting hook: post-code-update
[2024-09-16 16:53:12] Executing: /mnt/users/uiowa/dev.shell /var/www/html/uiowa.dev/hooks/dev/post-code-update/post-code-update.sh uiowa dev develop-build develop-build uiowa@svn-14671.prod.hosting.acquia.com:uiowa.git git < /dev/null (as uiowa.dev@staging-15039})

site="$1"
target_env="$2"
source_branch="$3"
deployed_tag="$4"
repo_url="$5"
repo_type="$6"

# Prep for BLT commands.
repo_root="/var/www/html/$site.$target_env"
export PATH=$repo_root/vendor/bin:$PATH
cd $repo_root

blt artifact:ac-hooks:post-code-update $site $target_env $source_branch $deployed_tag $repo_url $repo_type --environment=$target_env --no-interaction -D drush.ansi=false
Running updates for environment: dev
> artifact:update:drupal:all-sites
 [Exec]   
 [Exec]  Exit code 127 
Running multisite updates sequentially.
Skipping police.uiowa.edu. Drupal is not installed.
Deploying updates to dentistry.uiowa.edu...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --uri=dentistry.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.813s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --uri=dentistry.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.463s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --uri=dentistry.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 ------------ ----------- --------------- ------------------------------- 
  Module       Update ID   Type            Description                    
 ------------ ----------- --------------- ------------------------------- 
  aggregator   8608        hook_update_n   8608 - Set                     
                                           filter.format.aggregator_html  
                                           dependency on aggregator.      
 ------------ ----------- --------------- ------------------------------- 

>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [success] Finished performing updates.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 3.901s
> drupal:config:import
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self pm-enable config_split --uri=dentistry.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [notice] Already enabled: config_split
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.861s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config:set system.site uuid c1ef7643-9de3-4182-882f-63cda337515a --uri=dentistry.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=dentistry.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=dentistry.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self cache-rebuild --uri=dentistry.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
+------------+-------------------------------+-----------+
| Collection | Config                        | Operation |
+------------+-------------------------------+-----------+
|            | filter.format.aggregator_html | Update    |
+------------+-------------------------------+-----------+
 [notice] Synchronized configuration: update filter.format.aggregator_html.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
 [notice] There are no changes to import.
 [success] Cache rebuild complete.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 6.917s
> drupal:deploy:hook
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self deploy:hook --uri=dentistry.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [success] No pending deploy hooks.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.434s
Finished deploying updates to dentistry.uiowa.edu.
Skipping engineering.uiowa.edu. Drupal is not installed.
Deploying updates to law.uiowa.edu...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --uri=law.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.79s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --uri=law.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.48s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --uri=law.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 ------------ ----------- --------------- ------------------------------- 
  Module       Update ID   Type            Description                    
 ------------ ----------- --------------- ------------------------------- 
  aggregator   8608        hook_update_n   8608 - Set                     
                                           filter.format.aggregator_html  
                                           dependency on aggregator.      
 ------------ ----------- --------------- ------------------------------- 

 [notice] Module ckeditor has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module oembed_providers has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [success] Finished performing updates.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 3.621s
> drupal:config:import
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self pm-enable config_split --uri=law.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [notice] Already enabled: config_split
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.842s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config:set system.site uuid c1ef7643-9de3-4182-882f-63cda337515a --uri=law.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=law.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=law.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self cache-rebuild --uri=law.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
+------------+-------------------------------+-----------+
| Collection | Config                        | Operation |
+------------+-------------------------------+-----------+
|            | filter.format.aggregator_html | Update    |
+------------+-------------------------------+-----------+
 [notice] Synchronized configuration: update filter.format.aggregator_html.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
 [notice] There are no changes to import.
 [success] Cache rebuild complete.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 8.817s
> drupal:deploy:hook
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self deploy:hook --uri=law.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [success] No pending deploy hooks.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.434s
Finished deploying updates to law.uiowa.edu.
Deploying updates to default...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.797s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.494s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --no-interaction in /var/www/html/uiowa.dev/docroot
 ------------ ----------- --------------- ------------------------------- 
  Module       Update ID   Type            Description                    
 ------------ ----------- --------------- ------------------------------- 
  aggregator   8608        hook_update_n   8608 - Set                     
                                           filter.format.aggregator_html  
                                           dependency on aggregator.      
 ------------ ----------- --------------- ------------------------------- 

 [notice] Module ckeditor has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module oembed_providers has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [success] Finished performing updates.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 3.522s
> drupal:config:import
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self pm-enable config_split --no-interaction in /var/www/html/uiowa.dev/docroot
 [notice] Already enabled: config_split
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.835s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config:set system.site uuid c1ef7643-9de3-4182-882f-63cda337515a --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self cache-rebuild --no-interaction in /var/www/html/uiowa.dev/docroot
+------------+-------------------------------+-----------+
| Collection | Config                        | Operation |
+------------+-------------------------------+-----------+
|            | filter.format.aggregator_html | Update    |
+------------+-------------------------------+-----------+
 [notice] Synchronized configuration: update filter.format.aggregator_html.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
 [notice] There are no changes to import.
 [success] Cache rebuild complete.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 6.192s
> drupal:deploy:hook
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self deploy:hook --no-interaction in /var/www/html/uiowa.dev/docroot
 [success] No pending deploy hooks.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.436s
Finished deploying updates to default.
Skipping accel.education.uiowa.edu. Drupal is not installed.
Deploying updates to accreditation.uiowa.edu...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --uri=accreditation.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.81s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --uri=accreditation.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.458s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --uri=accreditation.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 ------------ ----------- --------------- ------------------------------- 
  Module       Update ID   Type            Description                    
 ------------ ----------- --------------- ------------------------------- 
  aggregator   8608        hook_update_n   8608 - Set                     
                                           filter.format.aggregator_html  
                                           dependency on aggregator.      
 ------------ ----------- --------------- ------------------------------- 

 [notice] Module ckeditor has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module oembed_providers has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module smtp has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [success] Finished performing updates.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 3.521s
> drupal:config:import
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self pm-enable config_split --uri=accreditation.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [notice] Already enabled: config_split
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.837s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config:set system.site uuid c1ef7643-9de3-4182-882f-63cda337515a --uri=accreditation.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=accreditation.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=accreditation.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self cache-rebuild --uri=accreditation.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
+------------+-------------------------------+-----------+
| Collection | Config                        | Operation |
+------------+-------------------------------+-----------+
|            | filter.format.aggregator_html | Update    |
+------------+-------------------------------+-----------+
 [notice] Synchronized configuration: update filter.format.aggregator_html.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
 [notice] There are no changes to import.
 [success] Cache rebuild complete.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 8.38s
> drupal:deploy:hook
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self deploy:hook --uri=accreditation.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [success] No pending deploy hooks.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.429s
Finished deploying updates to accreditation.uiowa.edu.
Skipping ace.lab.uiowa.edu. Drupal is not installed.
Skipping adsforruralamerica.uiowa.edu. Drupal is not installed.
Skipping advising.uiowa.edu. Drupal is not installed.
Skipping afr.fo.uiowa.edu. Drupal is not installed.
Skipping alphachisigma-alphatheta.org.uiowa.edu. Drupal is not installed.
Skipping annefranksapling.studio.uiowa.edu. Drupal is not installed.
Skipping ap-purchasing.fo.uiowa.edu. Drupal is not installed.
Skipping asce.engineering.uiowa.edu. Drupal is not installed.
Skipping assessment.uiowa.edu. Drupal is not installed.
Skipping audit.org.uiowa.edu. Drupal is not installed.
Skipping autismcenter.centerforconferences.uiowa.edu. Drupal is not installed.
Skipping bands.uiowa.edu. Drupal is not installed.
Skipping basicneeds.uiowa.edu. Drupal is not installed.
Skipping billing.uiowa.edu. Drupal is not installed.
Skipping biomost.engineering.uiowa.edu. Drupal is not installed.
Deploying updates to brand.uiowa.edu...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --uri=brand.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.801s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --uri=brand.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.462s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --uri=brand.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 ------------ ----------- --------------- ------------------------------- 
  Module       Update ID   Type            Description                    
 ------------ ----------- --------------- ------------------------------- 
  aggregator   8608        hook_update_n   8608 - Set                     
                                           filter.format.aggregator_html  
                                           dependency on aggregator.      
 ------------ ----------- --------------- ------------------------------- 

 [notice] Module ckeditor has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module oembed_providers has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [success] Finished performing updates.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 3.604s
> drupal:config:import
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self pm-enable config_split --uri=brand.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [notice] Already enabled: config_split
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.835s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config:set system.site uuid c1ef7643-9de3-4182-882f-63cda337515a --uri=brand.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=brand.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=brand.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self cache-rebuild --uri=brand.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
+------------+-------------------------------+-----------+
| Collection | Config                        | Operation |
+------------+-------------------------------+-----------+
|            | filter.format.aggregator_html | Update    |
+------------+-------------------------------+-----------+
 [notice] Synchronized configuration: update filter.format.aggregator_html.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
 [notice] There are no changes to import.
 [success] Cache rebuild complete.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 9.186s
> drupal:deploy:hook
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self deploy:hook --uri=brand.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [success] No pending deploy hooks.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.436s
Finished deploying updates to brand.uiowa.edu.
Skipping buchholz.lab.uiowa.edu. Drupal is not installed.
Skipping businessmanager.fo.uiowa.edu. Drupal is not installed.
Skipping businsvc.fo.uiowa.edu. Drupal is not installed.
Skipping byrne.lab.uiowa.edu. Drupal is not installed.
Skipping cam.fo.uiowa.edu. Drupal is not installed.
Skipping careers.uiowa.edu. Drupal is not installed.
Skipping cbig.iibi.uiowa.edu. Drupal is not installed.
Skipping cd2h.org. Drupal is not installed.
Skipping cda.org.uiowa.edu. Drupal is not installed.
Skipping celebrationofexcellence.sites.uiowa.edu. Drupal is not installed.
Skipping cfclincore.lab.uiowa.edu. Drupal is not installed.
Skipping chd.engineering.uiowa.edu. Drupal is not installed.
Skipping ci.lab.uiowa.edu. Drupal is not installed.
Deploying updates to classrooms.uiowa.edu...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --uri=classrooms.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.802s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --uri=classrooms.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.481s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --uri=classrooms.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [error]   (Currently using Removed core modules You must add the following contributed modules and reload this page.
 * CKEditor [1]
 * HAL [2]

These modules are installed on your site but are no longer provided by Core.
For more information read the documentation on deprecated modules. [3]

[1] https://www.drupal.org/project/ckeditor
[2] https://www.drupal.org/project/hal
[3] https://www.drupal.org/node/3223395#s-recommendations-for-deprecated-modules
) 
 [error]   (Currently using Missing or invalid modules The following modules are marked as installed in the core.extension 
configuration, but they are missing:
 * better_normalizers
 * block_content_permissions
 * components
 * embed
 * entity_embed
 * oembed_providers
 * schemadotorg
 * schemadotorg_inline_entity_form
 * schemadotorg_jsonld
 * schemadotorg_media
 * schemadotorg_smart_date

Review the  suggestions for resolving this incompatibility [1] to repair your 
installation, and then re-run update.php.

[1] https://www.drupal.org/docs/updating-drupal/troubleshooting-database-updates
) 
 ------------------ ------------- --------------- ----------------------------- 
  Module             Update ID     Type            Description                  
 ------------------ ------------- --------------- ----------------------------- 
  aggregator         8608          hook_update_n   8608 - Set                   
                                                   filter.format.aggregator_ht  
                                                   ml dependency on             
                                                   aggregator.                  
  classrooms_core    9002          hook_update_n   9002 - Trigger a presave to  
                                                   populate new field on all    
                                                   existing rooms.              
  classrooms_core    9003          hook_update_n   9003 - Remove excess old     
                                                   revisions for rooms.         
  aggregator         add_item_uu   post-update     Add UUIDs to Aggregator      
                     ids                           Items.                       
  aggregator         delete_queu   post-update     Delete the aggregator_feeds  
                     e_items                       queue to eliminate old       
                                                   items containing entities.   
  allowed_formats    formats2cor   post-update     Convert allowed formats to   
                     e                             Drupal 10.1.x.               
  big_pipe           html5_place   post-update     Clear the render cache.      
                     holders                                                    
  block_content      block_libra   post-update     Update block_content 'block  
                     ry_view_per                   library' view permission.    
                     mission                                                    
  block_content      move_custom   post-update     Moves the custom block       
                     _block_libr                   library to Content.          
                     ary                                                        
  block_content      sort_permis   post-update     Update permissions for       
                     sions                         users with "administer       
                                                   blocks" permission.          
  ctools             remove_enti   post-update     Invalidate the service       
                     tybundlecon                   container to force           
                     straint                       EntityBundleConstriant is    
                                                   Removed.                     
  editor             image_lazy_   post-update     Enable                       
                     load                          filter_image_lazy_load if    
                                                   editor_file_reference is     
                                                   enabled.                     
  externalauth       add_view_au   post-update     Imports new view for         
                     thmap                         authmap entries.             
  file               add_default   post-update     Add default filename         
                     _filename_s                   sanitization configuration.  
                     anitization                                                
                     _configurat                                                
                     ion                                                        
  file               add_permiss   post-update     Grant all non-anonymous      
                     ions_to_rol                   roles the 'delete own        
                     es                            files' permission.           
  filter             sort_filter   post-update     Sorts filter format filter   
                     s                             configuration.               
  layout_builder     timestamp_f   post-update     Update timestamp formatter   
                     ormatter                      settings for Layout Builder  
                                                   fields.                      
  masquerade         add_block_s   post-update     Add settings to to           
                     etting_link                   masquerade blocks for link   
                                                   to unmasquerade.             
  media              oembed_load   post-update     Add the oEmbed loading       
                     ing_attribu                   attribute setting to field   
                     te                            formatter instances.         
  media              set_blank_i   post-update     Updates                      
                     frame_domai                   media.settings:iframe_domai  
                     n_to_null                     n config if it's still at    
                                                   the default.                 
  metatag            remove_robo   post-update     Remove 'noydir', 'noodp'     
                     ts_noydir_n                   ROBOTS options from meta     
                     oodp                          tag entity fields.           
  path_alias         drop_path_a   post-update     Remove the                   
                     lias_status                   path_alias__status index.    
                     _index                                                     
  responsive_image   image_loadi   post-update     Add the image loading        
                     ng_attribut                   settings to responsive       
                     e                             image field formatter        
                                                   instances.                   
  responsive_image   order_multi   post-update     Re-order mappings by         
                     plier_numer                   breakpoint ID and            
                     ically                        descending numeric           
                                                   multiplier order.            
  schema_metatag     add_ids       post-update     Read in new config schema    
                                                   with @id definitions.        
  smart_date         increase_co   post-update     Increase the storage size    
                     lumn_revisi                   to resolve the 2038 problem  
                     ons                           on revisions.                
  smart_date         increase_co   post-update     Increase the storage size    
                     lumn_storag                   to resolve the 2038          
                     e                             problem.                     
  smart_date         refresh_val   post-update     Increase the storage size    
                     ue_schema                     to resolve the 2038 problem  
                                                   on revisions.                
  smart_date         resize_dura   post-update     Increase the storage size    
                     tion                          for the duration column.     
  smart_date         resize_dura   post-update     Increase the schema size     
                     tion_schema                   for durations.               
  system             add_descrip   post-update     Update description for form  
                     tion_to_ent                   modes.                       
                     ity_form_mo                                                
                     de                                                         
  system             add_descrip   post-update     Update description for view  
                     tion_to_ent                   modes.                       
                     ity_view_mo                                                
                     de                                                         
  system             enable_pass   post-update     Enable the password          
                     word_compat                   compatibility module.        
                     ibility                                                    
  system             linkset_set   post-update     Add new menu linkset         
                     tings                         endpoint setting.            
  system             mailer_dsn_   post-update     Add new default mail         
                     settings                      transport dsn.               
  system             mailer_stru   post-update     Add new default mail         
                     ctured_dsn_                   transport dsn.               
                     settings                                                   
  system             remove_asse   post-update     Remove redundant asset       
                     t_entries                     state and config.            
  system             remove_asse   post-update     Remove redundant asset       
                     t_query_str                   query string state.          
                     ing                                                        
  system             set_blank_l   post-update     Updates                      
                     og_url_to_n                   system.theme.global:logo.ur  
                     ull                           l config if it's still at    
                                                   the default.                 
  system             timestamp_f   post-update     Update timestamp formatter   
                     ormatter                      settings for entity view     
                                                   displays.                    
  text               allowed_for   post-update     Add allowed_formats setting  
                     mats                          to existing text fields.     
  views              add_missing   post-update     Add labels to views which    
                     _labels                       don't have one.              
  views              boolean_cus   post-update     Update Views config schema   
                     tom_titles                    to make boolean custom       
                                                   titles translatable.         
  views              fix_revisio   post-update     Fix '-revision_id'           
                     n_id_part                     replacement token syntax.    
  views              oembed_eage   post-update     Add eager load option to     
                     r_load                        all oembed type field        
                                                   configurations.              
  views              remove_defa   post-update     Remove                       
                     ult_argumen                   default_argument_skip_url    
                     t_skip_url                    setting.                     
  views              remove_skip   post-update     Remove the skip_cache        
                     _cache_sett                   settings.                    
                     ing                                                        
  views              responsive_   post-update     Add lazy load options to     
                     image_lazy_                   all responsive image type    
                     load                          field configurations.        
  views              taxonomy_fi   post-update     Removes User context from    
                     lter_user_c                   views with taxonomy          
                     ontext                        filters.                     
  views              timestamp_f   post-update     Update timestamp formatter   
                     ormatter                      settings for views.          
  webform            authenticat   post-update     Issue #3404493:              
                     ed_user_per                   webform_default permission.  
                     mission                                                    
  webform            ckeditor      post-update     Move from custom CKEditor    
                                                   to hidden 'webform_default'  
                                                   text format.                 
  webform            ckeditor01    post-update     Issue #3351348:              
                                                   '#multiple__no_items_messag  
                                                   e' added to every field.     
  webform            confirmatio   post-update     #3335924: Allow the          
                     n_page_noin                   confirmation page to         
                     dex                           include robots noindex meta  
                                                   tag.                         
  webform            deprecate_j   post-update     #3254570: Move jQuery UI     
                     query_ui_da                   datepicker support into      
                     tepicker                      dedicated deprecated         
                                                   module.                      
  webform            deprecate_l   post-update     Issue #3247475: Location     
                     ocation_pla                   field Algolia Places         
                     ces                           sunsetting May 31, 2022.     
  webform            multiple_ca   post-update     Issue #3339769: Improve      
                     tegories                      Webform categorization to    
                                                   support assigning multiple   
                                                   categories and default       
                                                   categories.                  
 ------------------ ------------- --------------- ----------------------------- 

 [notice] Module better_normalizers has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module block_content_permissions has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module ckeditor has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module components has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module embed has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module entity_embed has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module hal has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module oembed_providers has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module schemadotorg has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module schemadotorg_inline_entity_form has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module schemadotorg_jsonld has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module schemadotorg_media has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module schemadotorg_smart_date has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
>  [notice] Update started: classrooms_core_update_9002
>  [error]  InvalidArgumentException: Field field_room_combined_id is unknown. in Drupal\Core\Entity\ContentEntityBase->getTranslatedField() (line 616 of /mnt/www/html/uiowadev/docroot/core/lib/Drupal/Core/Entity/ContentEntityBase.php). 
>  [error]  Field field_room_combined_id is unknown. 
>  [error]  Update failed: classrooms_core_update_9002 
>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [error]  Update aborted by: classrooms_core_update_9002 
 [error]  Finished performing updates. 
 [Acquia\Blt\Robo\Tasks\DrushTask]  Exit code 1  Time 4.913s
 [error]  Failed to execute database updates!
For troubleshooting guidance and support, see https://docs.acquia.com/blt/support/ 
The command failed. This often indicates a problem with your configuration. Review the command output above for more detailed errors, and consider re-running with verbose output for more information.
Failed deploying updates to classrooms.uiowa.edu.
Skipping climatecollective.uiowa.edu. Drupal is not installed.
Skipping clp.law.uiowa.edu. Drupal is not installed.
Skipping cmc.sites.uiowa.edu. Drupal is not installed.
Skipping cmdd.lab.uiowa.edu. Drupal is not installed.
Skipping cmrf.research.uiowa.edu. Drupal is not installed.
Skipping cnm.uiowa.edu. Drupal is not installed.
Skipping coepe.uiowa.edu. Drupal is not installed.
Skipping cogaresearch.lab.uiowa.edu. Drupal is not installed.
Skipping cognitivecontrol.psychology.uiowa.edu. Drupal is not installed.
Skipping coi.research.uiowa.edu. Drupal is not installed.
Skipping coleresearchgroup.lab.uiowa.edu. Drupal is not installed.
Skipping compliance.fo.uiowa.edu. Drupal is not installed.
Skipping computational-symposium.psychiatry.uiowa.edu. Drupal is not installed.
Skipping conflictmanagement.org.uiowa.edu. Drupal is not installed.
Skipping controller.fo.uiowa.edu. Drupal is not installed.
Skipping cot.org.uiowa.edu. Drupal is not installed.
Skipping cpl.lab.uiowa.edu. Drupal is not installed.
Skipping crisp.org.uiowa.edu. Drupal is not installed.
Skipping dale-stille.lab.uiowa.edu. Drupal is not installed.
Skipping dasblatt.sites.uiowa.edu. Drupal is not installed.
Deploying updates to designcenter.uiowa.edu...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --uri=designcenter.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.797s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --uri=designcenter.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.455s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --uri=designcenter.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 ------------ ----------- --------------- ------------------------------- 
  Module       Update ID   Type            Description                    
 ------------ ----------- --------------- ------------------------------- 
  aggregator   8608        hook_update_n   8608 - Set                     
                                           filter.format.aggregator_html  
                                           dependency on aggregator.      
 ------------ ----------- --------------- ------------------------------- 

 [notice] Module ckeditor has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module oembed_providers has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module smtp has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [success] Finished performing updates.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 3.459s
> drupal:config:import
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self pm-enable config_split --uri=designcenter.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [notice] Already enabled: config_split
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.832s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config:set system.site uuid c1ef7643-9de3-4182-882f-63cda337515a --uri=designcenter.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=designcenter.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=designcenter.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self cache-rebuild --uri=designcenter.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
+------------+-------------------------------+-----------+
| Collection | Config                        | Operation |
+------------+-------------------------------+-----------+
|            | filter.format.aggregator_html | Update    |
+------------+-------------------------------+-----------+
 [notice] Synchronized configuration: update filter.format.aggregator_html.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
 [notice] There are no changes to import.
 [success] Cache rebuild complete.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 8.967s
> drupal:deploy:hook
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self deploy:hook --uri=designcenter.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [success] No pending deploy hooks.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.431s
Finished deploying updates to designcenter.uiowa.edu.
Deploying updates to diversity.uiowa.edu...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --uri=diversity.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.798s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --uri=diversity.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.462s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --uri=diversity.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 ------------ ----------- --------------- ------------------------------- 
  Module       Update ID   Type            Description                    
 ------------ ----------- --------------- ------------------------------- 
  aggregator   8608        hook_update_n   8608 - Set                     
                                           filter.format.aggregator_html  
                                           dependency on aggregator.      
 ------------ ----------- --------------- ------------------------------- 

 [notice] Module ckeditor has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module oembed_providers has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module smtp has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [success] Finished performing updates.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 3.493s
> drupal:config:import
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self pm-enable config_split --uri=diversity.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [notice] Already enabled: config_split
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.821s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config:set system.site uuid c1ef7643-9de3-4182-882f-63cda337515a --uri=diversity.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=diversity.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=diversity.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self cache-rebuild --uri=diversity.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
+------------+-------------------------------+-----------+
| Collection | Config                        | Operation |
+------------+-------------------------------+-----------+
|            | filter.format.aggregator_html | Update    |
+------------+-------------------------------+-----------+
 [notice] Synchronized configuration: update filter.format.aggregator_html.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
 [notice] There are no changes to import.
 [success] Cache rebuild complete.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 8.168s
> drupal:deploy:hook
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self deploy:hook --uri=diversity.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [success] No pending deploy hooks.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.432s
Finished deploying updates to diversity.uiowa.edu.
Skipping doublebass.studio.uiowa.edu. Drupal is not installed.
Skipping dsp.research.uiowa.edu. Drupal is not installed.
Skipping edgeofspace.sites.uiowa.edu. Drupal is not installed.
Skipping eforms.uiowa.edu. Drupal is not installed.
Skipping electronicmusic.studio.uiowa.edu. Drupal is not installed.
Skipping els.law.uiowa.edu. Drupal is not installed.
Skipping emeritus-faculty.uiowa.edu. Drupal is not installed.
Skipping empirical.law.uiowa.edu. Drupal is not installed.
Skipping enterpriseriskmanagement.fo.uiowa.edu. Drupal is not installed.
Skipping epx.org.uiowa.edu. Drupal is not installed.
Skipping fa.fo.uiowa.edu. Drupal is not installed.
Skipping faculty-senate.uiowa.edu. Drupal is not installed.
Skipping familyphysician.centerforconferences.uiowa.edu. Drupal is not installed.
Skipping fbis.fo.uiowa.edu. Drupal is not installed.
Skipping fmb.fo.uiowa.edu. Drupal is not installed.
Skipping fric.sites.uiowa.edu. Drupal is not installed.
Skipping fsl.uiowa.edu. Drupal is not installed.
Skipping gao.fo.uiowa.edu. Drupal is not installed.
Skipping generalstores.fo.uiowa.edu. Drupal is not installed.
Skipping genome.uiowa.edu. Drupal is not installed.
Skipping gpsg.uiowa.edu. Drupal is not installed.
Skipping habelhah.lab.uiowa.edu. Drupal is not installed.
Skipping hawchi.lab.uiowa.edu. Drupal is not installed.
Deploying updates to hawkeyemarchingband.uiowa.edu...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --uri=hawkeyemarchingband.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.804s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --uri=hawkeyemarchingband.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.461s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --uri=hawkeyemarchingband.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 ------------ ----------- --------------- ------------------------------- 
  Module       Update ID   Type            Description                    
 ------------ ----------- --------------- ------------------------------- 
  aggregator   8608        hook_update_n   8608 - Set                     
                                           filter.format.aggregator_html  
                                           dependency on aggregator.      
 ------------ ----------- --------------- ------------------------------- 

 [notice] Module ckeditor has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module oembed_providers has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [success] Finished performing updates.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 3.49s
> drupal:config:import
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self pm-enable config_split --uri=hawkeyemarchingband.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [notice] Already enabled: config_split
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.827s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config:set system.site uuid c1ef7643-9de3-4182-882f-63cda337515a --uri=hawkeyemarchingband.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=hawkeyemarchingband.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=hawkeyemarchingband.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self cache-rebuild --uri=hawkeyemarchingband.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
+------------+-------------------------------+-----------+
| Collection | Config                        | Operation |
+------------+-------------------------------+-----------+
|            | filter.format.aggregator_html | Update    |
+------------+-------------------------------+-----------+
 [notice] Synchronized configuration: update filter.format.aggregator_html.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
 [notice] There are no changes to import.
 [success] Cache rebuild complete.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 8.225s
> drupal:deploy:hook
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self deploy:hook --uri=hawkeyemarchingband.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [success] No pending deploy hooks.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.428s
Finished deploying updates to hawkeyemarchingband.uiowa.edu.
Skipping hbrl-neurosurgery.lab.uiowa.edu. Drupal is not installed.
Skipping health-research-network.sites.uiowa.edu. Drupal is not installed.
Skipping hefti.lab.uiowa.edu. Drupal is not installed.
Skipping heli.law.uiowa.edu. Drupal is not installed.
Skipping help.maui.uiowa.edu. Drupal is not installed.
Skipping hoadley.lab.uiowa.edu. Drupal is not installed.
Skipping homecoming.uiowa.edu. Drupal is not installed.
Skipping honorary-degrees.sites.uiowa.edu. Drupal is not installed.
Skipping honors.uiowa.edu. Drupal is not installed.
Skipping horn.studio.uiowa.edu. Drupal is not installed.
Skipping hr.fo.uiowa.edu. Drupal is not installed.
Deploying updates to hr.uiowa.edu...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --uri=hr.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.8s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --uri=hr.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.463s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --uri=hr.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 ------------ ----------- --------------- ------------------------------- 
  Module       Update ID   Type            Description                    
 ------------ ----------- --------------- ------------------------------- 
  aggregator   8608        hook_update_n   8608 - Set                     
                                           filter.format.aggregator_html  
                                           dependency on aggregator.      
 ------------ ----------- --------------- ------------------------------- 

 [notice] Module ckeditor has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module oembed_providers has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [success] Finished performing updates.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 3.599s
> drupal:config:import
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self pm-enable config_split --uri=hr.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [notice] Already enabled: config_split
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.821s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config:set system.site uuid c1ef7643-9de3-4182-882f-63cda337515a --uri=hr.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=hr.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=hr.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self cache-rebuild --uri=hr.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
+------------+------------------------------------------------------+-----------+
| Collection | Config                                               | Operation |
+------------+------------------------------------------------------+-----------+
|            | filter.format.aggregator_html                        | Update    |
|            | core.entity_view_display.taxonomy_term.units.teaser  | Update    |
|            | core.entity_view_display.taxonomy_term.units.default | Update    |
+------------+------------------------------------------------------+-----------+
 [notice] Synchronized configuration: update filter.format.aggregator_html.
 [notice] Synchronized configuration: update core.entity_view_display.taxonomy_term.units.teaser.
 [notice] Synchronized configuration: update core.entity_view_display.taxonomy_term.units.default.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
+------------+------------------------------------------------------+-----------+
| Collection | Config                                               | Operation |
+------------+------------------------------------------------------+-----------+
|            | core.entity_view_display.taxonomy_term.units.teaser  | Update    |
|            | core.entity_view_display.taxonomy_term.units.default | Update    |
+------------+------------------------------------------------------+-----------+
 [notice] Synchronized configuration: update core.entity_view_display.taxonomy_term.units.teaser.
 [notice] Synchronized configuration: update core.entity_view_display.taxonomy_term.units.default.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
 [success] Cache rebuild complete.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 10.677s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config-status --uri=hr.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 --------------------------------------- ----------- 
  Name                                    State      
 --------------------------------------- ----------- 
  core.entity_view_display.taxonomy_ter   Different  
  m.units.default                                    
  core.entity_view_display.taxonomy_ter   Different  
  m.units.teaser                                     
 --------------------------------------- ----------- 
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 2.99s
 [error]  Configuration in the database does not match configuration on disk. This indicates that your configuration on disk needs attention. Please read https://support.acquia.com/hc/en-us/articles/360034687394--Configuration-in-the-database-does-not-match-configuration-on-disk-when-using-BLT
For troubleshooting guidance and support, see https://docs.acquia.com/blt/support/ 
The command failed. This often indicates a problem with your configuration. Review the command output above for more detailed errors, and consider re-running with verbose output for more information.
 [error]  Command `drupal:config:import --environment=dev` exited with code 1.
For troubleshooting guidance and support, see https://docs.acquia.com/blt/support/ 
The command failed. This often indicates a problem with your configuration. Review the command output above for more detailed errors, and consider re-running with verbose output for more information.
Failed deploying updates to hr.uiowa.edu.
Skipping hrmsf.research.uiowa.edu. Drupal is not installed.
Skipping hso.research.uiowa.edu. Drupal is not installed.
Skipping human-auditory-neuroscience-group.lab.uiowa.edu. Drupal is not installed.
Skipping ibl.law.uiowa.edu. Drupal is not installed.
Skipping icred.org.uiowa.edu. Drupal is not installed.
Deploying updates to ighn.international.uiowa.edu...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --uri=ighn.international.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.817s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --uri=ighn.international.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.457s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --uri=ighn.international.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 ------------ ----------- --------------- ------------------------------- 
  Module       Update ID   Type            Description                    
 ------------ ----------- --------------- ------------------------------- 
  aggregator   8608        hook_update_n   8608 - Set                     
                                           filter.format.aggregator_html  
                                           dependency on aggregator.      
 ------------ ----------- --------------- ------------------------------- 

 [notice] Module ckeditor has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module oembed_providers has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [success] Finished performing updates.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 3.455s
> drupal:config:import
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self pm-enable config_split --uri=ighn.international.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [notice] Already enabled: config_split
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.822s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config:set system.site uuid c1ef7643-9de3-4182-882f-63cda337515a --uri=ighn.international.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=ighn.international.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=ighn.international.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self cache-rebuild --uri=ighn.international.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
+------------+-------------------------------+-----------+
| Collection | Config                        | Operation |
+------------+-------------------------------+-----------+
|            | filter.format.aggregator_html | Update    |
+------------+-------------------------------+-----------+
 [notice] Synchronized configuration: update filter.format.aggregator_html.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
 [notice] There are no changes to import.
 [success] Cache rebuild complete.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 8.783s
> drupal:deploy:hook
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self deploy:hook --uri=ighn.international.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [success] No pending deploy hooks.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.433s
Finished deploying updates to ighn.international.uiowa.edu.
Skipping iisicca.uiowa.edu. Drupal is not installed.
Skipping ilg.course.uiowa.edu. Drupal is not installed.
Skipping ilr.law.uiowa.edu. Drupal is not installed.
Skipping indianstudentalliance.org.uiowa.edu. Drupal is not installed.
Skipping iniworkshop.conference.uiowa.edu. Drupal is not installed.
Deploying updates to inrc.law.uiowa.edu...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --uri=inrc.law.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.811s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --uri=inrc.law.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.465s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --uri=inrc.law.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 ------------ ----------- --------------- ------------------------------- 
  Module       Update ID   Type            Description                    
 ------------ ----------- --------------- ------------------------------- 
  aggregator   8608        hook_update_n   8608 - Set                     
                                           filter.format.aggregator_html  
                                           dependency on aggregator.      
 ------------ ----------- --------------- ------------------------------- 

>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [success] Finished performing updates.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 4.469s
> drupal:config:import
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self pm-enable config_split --uri=inrc.law.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [notice] Already enabled: config_split
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.839s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config:set system.site uuid c1ef7643-9de3-4182-882f-63cda337515a --uri=inrc.law.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=inrc.law.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=inrc.law.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self cache-rebuild --uri=inrc.law.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
+------------+--------------------------------------------------+-----------+
| Collection | Config                                           | Operation |
+------------+--------------------------------------------------+-----------+
|            | field.storage.node.field_event_sponsor           | Create    |
|            | field.storage.node.field_event_cost              | Create    |
|            | field.storage.node.field_event_contact_name      | Create    |
|            | field.storage.node.field_event_contact_email     | Create    |
|            | field.field.node.event.field_event_sponsor       | Create    |
|            | field.field.node.event.field_event_cost          | Create    |
|            | field.field.node.event.field_event_contact_name  | Create    |
|            | field.field.node.event.field_event_contact_email | Create    |
|            | field.storage.node.field_event_contact_phone     | Create    |
|            | field.field.node.event.field_event_contact_phone | Create    |
|            | views.view.download_nonprofit_organizations      | Create    |
|            | core.extension                                   | Update    |
|            | filter.format.aggregator_html                    | Update    |
|            | core.entity_view_display.node.event.token        | Update    |
|            | core.entity_view_display.node.event.teaser       | Update    |
|            | views.view.nonprofit_organization                | Update    |
|            | core.entity_view_display.node.event.default      | Update    |
|            | config_split.config_split.site                   | Update    |
|            | core.entity_form_display.node.event.default      | Update    |
|            | migrate_drupal.settings                          | Delete    |
|            | migrate_plus.migration.inrc_nonprofit_redirects  | Delete    |
|            | migrate_plus.migration.inrc_nonprofit            | Delete    |
|            | migrate_plus.migration.inrc_grant_redirects      | Delete    |
|            | migrate_plus.migration.inrc_grant                | Delete    |
|            | config_split.config_split.inrc_migrate           | Delete    |
+------------+--------------------------------------------------+-----------+
 [error]  Drupal\Core\Config\ConfigImporterException: There were errors validating the config synchronization.
Configuration <em class="placeholder">migrate_plus.migration_group.default</em> depends on the <em class="placeholder">Migrate Plus</em> module that will not be installed after import.
Configuration <em class="placeholder">migrate_plus.migration_group.sitenow_migrate</em> depends on the <em class="placeholder">Migrate Plus</em> module that will not be installed after import. in Drupal\Core\Config\ConfigImporter->validate() (line 814 of /mnt/www/html/uiowadev/docroot/core/lib/Drupal/Core/Config/ConfigImporter.php). 

In ConfigImportCommands.php line 290:
                                                                               
  The import failed due to the following reasons:                              
  Configuration <em class="placeholder">migrate_plus.migration_group.default<  
  /em> depends on the <em class="placeholder">Migrate Plus</em> module that w  
  ill not be installed after import.                                           
  Configuration <em class="placeholder">migrate_plus.migration_group.sitenow_  
  migrate</em> depends on the <em class="placeholder">Migrate Plus</em> modul  
  e that will not be installed after import.                                   
                                                                               

In ConfigImporter.php line 814:
                                                                               
  There were errors validating the config synchronization.                     
  Configuration <em class="placeholder">migrate_plus.migration_group.default<  
  /em> depends on the <em class="placeholder">Migrate Plus</em> module that w  
  ill not be installed after import.                                           
  Configuration <em class="placeholder">migrate_plus.migration_group.sitenow_  
  migrate</em> depends on the <em class="placeholder">Migrate Plus</em> modul  
  e that will not be installed after import.                                   
                                                                               

 [Acquia\Blt\Robo\Tasks\DrushTask]  Exit code 1  Time 3.282s
 [error]  Failed to import configuration!
For troubleshooting guidance and support, see https://docs.acquia.com/blt/support/ 
The command failed. This often indicates a problem with your configuration. Review the command output above for more detailed errors, and consider re-running with verbose output for more information.
 [error]  Command `drupal:config:import --environment=dev` exited with code 1.
For troubleshooting guidance and support, see https://docs.acquia.com/blt/support/ 
The command failed. This often indicates a problem with your configuration. Review the command output above for more detailed errors, and consider re-running with verbose output for more information.
Failed deploying updates to inrc.law.uiowa.edu.
Deploying updates to international.uiowa.edu...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --uri=international.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.812s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --uri=international.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.457s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --uri=international.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 ------------ ----------- --------------- ------------------------------- 
  Module       Update ID   Type            Description                    
 ------------ ----------- --------------- ------------------------------- 
  aggregator   8608        hook_update_n   8608 - Set                     
                                           filter.format.aggregator_html  
                                           dependency on aggregator.      
 ------------ ----------- --------------- ------------------------------- 

 [notice] Module ckeditor has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module oembed_providers has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [success] Finished performing updates.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 3.54s
> drupal:config:import
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self pm-enable config_split --uri=international.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [notice] Already enabled: config_split
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.835s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config:set system.site uuid c1ef7643-9de3-4182-882f-63cda337515a --uri=international.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=international.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=international.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self cache-rebuild --uri=international.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
+------------+-------------------------------+-----------+
| Collection | Config                        | Operation |
+------------+-------------------------------+-----------+
|            | filter.format.aggregator_html | Update    |
+------------+-------------------------------+-----------+
 [notice] Synchronized configuration: update filter.format.aggregator_html.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
 [notice] There are no changes to import.
 [success] Cache rebuild complete.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 6.418s
> drupal:deploy:hook
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self deploy:hook --uri=international.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [success] No pending deploy hooks.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.433s
Finished deploying updates to international.uiowa.edu.
Skipping intradent.dentistry.uiowa.edu. Drupal is not installed.
Skipping iowahousehotel.uiowa.edu. Drupal is not installed.
Skipping iowaresearch.lab.uiowa.edu. Drupal is not installed.
Skipping irbr.org.uiowa.edu. Drupal is not installed.
Skipping isba.law.uiowa.edu. Drupal is not installed.
Skipping iseh.engineering.uiowa.edu. Drupal is not installed.
Deploying updates to itaccessibility.uiowa.edu...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --uri=itaccessibility.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.793s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --uri=itaccessibility.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.45s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --uri=itaccessibility.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 ------------ ----------- --------------- ------------------------------- 
  Module       Update ID   Type            Description                    
 ------------ ----------- --------------- ------------------------------- 
  aggregator   8608        hook_update_n   8608 - Set                     
                                           filter.format.aggregator_html  
                                           dependency on aggregator.      
 ------------ ----------- --------------- ------------------------------- 

 [notice] Module ckeditor has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module oembed_providers has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [success] Finished performing updates.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 3.642s
> drupal:config:import
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self pm-enable config_split --uri=itaccessibility.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [notice] Already enabled: config_split
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.827s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config:set system.site uuid c1ef7643-9de3-4182-882f-63cda337515a --uri=itaccessibility.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=itaccessibility.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=itaccessibility.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self cache-rebuild --uri=itaccessibility.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
+------------+-------------------------------+-----------+
| Collection | Config                        | Operation |
+------------+-------------------------------+-----------+
|            | filter.format.aggregator_html | Update    |
+------------+-------------------------------+-----------+
 [notice] Synchronized configuration: update filter.format.aggregator_html.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
 [notice] There are no changes to import.
 [success] Cache rebuild complete.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 8.524s
> drupal:deploy:hook
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self deploy:hook --uri=itaccessibility.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [success] No pending deploy hooks.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.434s
Finished deploying updates to itaccessibility.uiowa.edu.
Skipping iti.uiowa.edu. Drupal is not installed.
Skipping iwwerp.engineering.uiowa.edu. Drupal is not installed.
Skipping jaynesresearchgroup.lab.uiowa.edu. Drupal is not installed.
Skipping jcl.law.uiowa.edu. Drupal is not installed.
Skipping jgrj.law.uiowa.edu. Drupal is not installed.
Skipping jian-zhang.lab.uiowa.edu. Drupal is not installed.
Skipping jrg.sites.uiowa.edu. Drupal is not installed.
Skipping karandikar.lab.uiowa.edu. Drupal is not installed.
Skipping kardon.lab.uiowa.edu. Drupal is not installed.
Skipping korn.uiowa.edu. Drupal is not installed.
Skipping kroska.lab.uiowa.edu. Drupal is not installed.
Skipping krysan.lab.uiowa.edu. Drupal is not installed.
Skipping kuehn.lab.uiowa.edu. Drupal is not installed.
Skipping lalumiere.lab.uiowa.edu. Drupal is not installed.
Skipping laundry.fo.uiowa.edu. Drupal is not installed.
Skipping leadandengage.uiowa.edu. Drupal is not installed.
Skipping legge.lab.uiowa.edu. Drupal is not installed.
Skipping lhpdc.law.uiowa.edu. Drupal is not installed.
Skipping li.lab.uiowa.edu. Drupal is not installed.
Skipping library.law.uiowa.edu. Drupal is not installed.
Skipping logsdon.lab.uiowa.edu. Drupal is not installed.
Skipping looc.course.uiowa.edu. Drupal is not installed.
Skipping magazine.engineering.uiowa.edu. Drupal is not installed.
Skipping mangalam.lab.uiowa.edu. Drupal is not installed.
Skipping matfab.research.uiowa.edu. Drupal is not installed.
Skipping mbhd2022.conference.uiowa.edu. Drupal is not installed.
Skipping mentalhealth.uiowa.edu. Drupal is not installed.
Skipping mentor.uiowa.edu. Drupal is not installed.
Skipping merlino.lab.uiowa.edu. Drupal is not installed.
Skipping mew.conference.uiowa.edu. Drupal is not installed.
Skipping meyerholz.lab.uiowa.edu. Drupal is not installed.
Skipping michaelson.lab.uiowa.edu. Drupal is not installed.
Skipping microvascularphys.lab.uiowa.edu. Drupal is not installed.
Skipping miles.lab.uiowa.edu. Drupal is not installed.
Skipping mlk.uiowa.edu. Drupal is not installed.
Skipping mnh.uiowa.edu. Drupal is not installed.
Skipping moore.lab.uiowa.edu. Drupal is not installed.
Skipping mootcourt.org.uiowa.edu. Drupal is not installed.
Skipping moyerowley.lab.uiowa.edu. Drupal is not installed.
Skipping multilingualsyntax.lab.uiowa.edu. Drupal is not installed.
Skipping museumstudies.sites.uiowa.edu. Drupal is not installed.
Skipping news.engineering.uiowa.edu. Drupal is not installed.
Skipping nhlp.law.uiowa.edu. Drupal is not installed.
Skipping nightatthesciencelabs.conference.uiowa.edu. Drupal is not installed.
Skipping ogallala.research.uiowa.edu. Drupal is not installed.
Skipping oldcap.uiowa.edu. Drupal is not installed.
Skipping ombudsperson.org.uiowa.edu. Drupal is not installed.
Skipping omicron.engineering.uiowa.edu. Drupal is not installed.
Skipping pac.org.uiowa.edu. Drupal is not installed.
Skipping pchs.lhpdc.law.uiowa.edu. Drupal is not installed.
Skipping pediatriccardiology.centerforconferences.uiowa.edu. Drupal is not installed.
Skipping pentacrestmuseums.uiowa.edu. Drupal is not installed.
Skipping pinyin.uiowa.edu. Drupal is not installed.
Skipping planning-and-development.fo.uiowa.edu. Drupal is not installed.
Skipping printmail.fo.uiowa.edu. Drupal is not installed.
Skipping protostudios.uiowa.edu. Drupal is not installed.
Skipping psp.org.uiowa.edu. Drupal is not installed.
Skipping qulat.sites.uiowa.edu. Drupal is not installed.
Skipping ratner.lab.uiowa.edu. Drupal is not installed.
Skipping registrar.uiowa.edu. Drupal is not installed.
Deploying updates to research.uiowa.edu...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --uri=research.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.813s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --uri=research.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.459s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --uri=research.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 ------------ ----------- --------------- ------------------------------- 
  Module       Update ID   Type            Description                    
 ------------ ----------- --------------- ------------------------------- 
  aggregator   8608        hook_update_n   8608 - Set                     
                                           filter.format.aggregator_html  
                                           dependency on aggregator.      
 ------------ ----------- --------------- ------------------------------- 

 [notice] Module ckeditor has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module oembed_providers has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [success] Finished performing updates.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 3.565s
> drupal:config:import
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self pm-enable config_split --uri=research.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [notice] Already enabled: config_split
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.828s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config:set system.site uuid c1ef7643-9de3-4182-882f-63cda337515a --uri=research.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=research.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=research.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self cache-rebuild --uri=research.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
+------------+-------------------------------+-----------+
| Collection | Config                        | Operation |
+------------+-------------------------------+-----------+
|            | filter.format.aggregator_html | Update    |
+------------+-------------------------------+-----------+
 [notice] Synchronized configuration: update filter.format.aggregator_html.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
 [notice] There are no changes to import.
 [success] Cache rebuild complete.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 6.206s
> drupal:deploy:hook
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self deploy:hook --uri=research.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [success] No pending deploy hooks.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.437s
Finished deploying updates to research.uiowa.edu.
Skipping research2.education.uiowa.edu. Drupal is not installed.
Skipping researcherhandbook.research.uiowa.edu. Drupal is not installed.
Skipping riskmanagement.fo.uiowa.edu. Drupal is not installed.
Skipping robotics.org.uiowa.edu. Drupal is not installed.
Skipping rvap.uiowa.edu. Drupal is not installed.
Skipping schultz.lab.uiowa.edu. Drupal is not installed.
Skipping sem.sites.uiowa.edu. Drupal is not installed.
Skipping seru.uiowa.edu. Drupal is not installed.
Skipping simonsburnett.lab.uiowa.edu. Drupal is not installed.
Skipping sinapselab.ece.engineering.uiowa.edu. Drupal is not installed.
Deploying updates to sitenow.uiowa.edu...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --uri=sitenow.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.802s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --uri=sitenow.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.454s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --uri=sitenow.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 ------------ ----------- --------------- ------------------------------- 
  Module       Update ID   Type            Description                    
 ------------ ----------- --------------- ------------------------------- 
  aggregator   8608        hook_update_n   8608 - Set                     
                                           filter.format.aggregator_html  
                                           dependency on aggregator.      
 ------------ ----------- --------------- ------------------------------- 

 [notice] Module ckeditor has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [success] Finished performing updates.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 3.468s
> drupal:config:import
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self pm-enable config_split --uri=sitenow.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [notice] Already enabled: config_split
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.821s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config:set system.site uuid c1ef7643-9de3-4182-882f-63cda337515a --uri=sitenow.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=sitenow.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=sitenow.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self cache-rebuild --uri=sitenow.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
+------------+-------------------------------+-----------+
| Collection | Config                        | Operation |
+------------+-------------------------------+-----------+
|            | filter.format.aggregator_html | Update    |
+------------+-------------------------------+-----------+
 [notice] Synchronized configuration: update filter.format.aggregator_html.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
 [notice] There are no changes to import.
 [success] Cache rebuild complete.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 6.051s
> drupal:deploy:hook
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self deploy:hook --uri=sitenow.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [success] No pending deploy hooks.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.429s
Finished deploying updates to sitenow.uiowa.edu.
Skipping staff-council.uiowa.edu. Drupal is not installed.
Skipping stocktaken.org.uiowa.edu. Drupal is not installed.
Skipping stonewall50.sites.uiowa.edu. Drupal is not installed.
Skipping studenthealth.uiowa.edu. Drupal is not installed.
Skipping studentspace.uiowa.edu. Drupal is not installed.
Skipping surplus.fo.uiowa.edu. Drupal is not installed.
Skipping sustainabilitycommittee.uiowa.edu. Drupal is not installed.
Skipping talbert.lab.uiowa.edu. Drupal is not installed.
Skipping tanas.lab.uiowa.edu. Drupal is not installed.
Skipping tax.fo.uiowa.edu. Drupal is not installed.
Skipping tedabel.lab.uiowa.edu. Drupal is not installed.
Skipping themaclab.lab.uiowa.edu. Drupal is not installed.
Skipping theranostics.lab.uiowa.edu. Drupal is not installed.
Skipping tlcp.law.uiowa.edu. Drupal is not installed.
Skipping training.itaccessibility.uiowa.edu. Drupal is not installed.
Skipping trans-resources.org.uiowa.edu. Drupal is not installed.
Skipping treasury.fo.uiowa.edu. Drupal is not installed.
Skipping uiadvise.sites.uiowa.edu. Drupal is not installed.
Skipping uiarc.uiowa.edu. Drupal is not installed.
Skipping uibio.org.uiowa.edu. Drupal is not installed.
Skipping uibtaa.centerforconferences.uiowa.edu. Drupal is not installed.
Skipping uiobl.uiowa.edu. Drupal is not installed.
Skipping uiqsim.sites.uiowa.edu. Drupal is not installed.
Skipping uira.org.uiowa.edu. Drupal is not installed.
Skipping uirf.research.uiowa.edu. Drupal is not installed.
Skipping uiservicecenter.uiowa.edu. Drupal is not installed.
Skipping uiventures.uiowa.edu. Drupal is not installed.
Skipping university-shared-services.fo.uiowa.edu. Drupal is not installed.
Skipping upsa.org.uiowa.edu. Drupal is not installed.
Skipping vanallenprobes.centerforconferences.uiowa.edu. Drupal is not installed.
Skipping vanotterloo.lab.uiowa.edu. Drupal is not installed.
Deploying updates to veterans.uiowa.edu...
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self php:script /var/www/site-scripts/invalidate-twig-cache.php --uri=veterans.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;46;1m[notice][39;49;22m Invalidating Twig cache after code push.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.794s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self cc plugin --uri=veterans.uiowa.edu --no-interaction --ansi in /var/www/html/uiowa.dev/docroot
 [37;42;1m[success][39;49;22m 'plugin' cache was cleared.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.449s
> drupal:update
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self updb --uri=veterans.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 ------------ ----------- --------------- ------------------------------- 
  Module       Update ID   Type            Description                    
 ------------ ----------- --------------- ------------------------------- 
  aggregator   8608        hook_update_n   8608 - Set                     
                                           filter.format.aggregator_html  
                                           dependency on aggregator.      
 ------------ ----------- --------------- ------------------------------- 

 [notice] Module ckeditor has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module devel has an entry in the system.schema key/value storage, but is not installed. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
 [notice] Module oembed_providers has an entry in the system.schema key/value storage, but is missing from your site. <a href="https://www.drupal.org/node/3137656">More information about this error</a>.
>  [notice] Update started: aggregator_update_8608
>  [notice] Update completed: aggregator_update_8608
 [success] Finished performing updates.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 3.478s
> drupal:config:import
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self pm-enable config_split --uri=veterans.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [notice] Already enabled: config_split
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.826s
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self config:set system.site uuid c1ef7643-9de3-4182-882f-63cda337515a --uri=veterans.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=veterans.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self config-import --uri=veterans.uiowa.edu --no-interaction &&
 /var/www/html/uiowa.dev/vendor/bin/drush @self cache-rebuild --uri=veterans.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
+------------+-------------------------------+-----------+
| Collection | Config                        | Operation |
+------------+-------------------------------+-----------+
|            | filter.format.aggregator_html | Update    |
+------------+-------------------------------+-----------+
 [notice] Synchronized configuration: update filter.format.aggregator_html.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
 [notice] There are no changes to import.
 [success] Cache rebuild complete.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 7.993s
> drupal:deploy:hook
 [Acquia\Blt\Robo\Tasks\DrushTask] Running /var/www/html/uiowa.dev/vendor/bin/drush @self deploy:hook --uri=veterans.uiowa.edu --no-interaction in /var/www/html/uiowa.dev/docroot
 [success] No pending deploy hooks.
 [Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.431s
Finished deploying updates to veterans.uiowa.edu.
Skipping viewbook.engineering.uiowa.edu. Drupal is not installed.
Skipping voice-academy.uiowa.edu. Drupal is not installed.
Skipping weigel.lab.uiowa.edu. Drupal is not installed.
Skipping wics.org.uiowa.edu. Drupal is not installed.
Skipping wise.org.uiowa.edu. Drupal is not installed.
Skipping witry.lab.uiowa.edu. Drupal is not installed.
Skipping wu.lab.uiowa.edu. Drupal is not installed.
Skipping yangs.lab.uiowa.edu. Drupal is not installed.
 [error]  Error deploying updates. Check the log output for more information. 
The command failed. This often indicates a problem with your configuration. Review the command output above for more detailed errors, and consider re-running with verbose output for more information.
Sending slack notification...
 [error]  Command `artifact:update:drupal:all-sites --environment=dev` exited with code 1.
For troubleshooting guidance and support, see https://docs.acquia.com/blt/support/ 
[2024-09-16 16:58:28] Command returned exit code 1: /mnt/users/uiowa/dev.shell /var/www/html/uiowa.dev/hooks/dev/post-code-update/post-code-update.sh uiowa dev develop-build develop-build uiowa@svn-14671.prod.hosting.acquia.com:uiowa.git git executing hook post-code-update
[2024-09-16 16:58:28] Finished hook: post-code-update

[2024-09-16 16:58:28] Sending webhook hook: 'post-code-update' revision: 'd9542e62825d3a2506d21f78e02996f91d3a7bbc'!
[2024-09-16 16:58:28] WARN: Command returned exit code 1: /mnt/users/uiowa/dev.shell /var/www/html/uiowa.dev/hooks/dev/post-code-update/post-code-update.sh uiowa dev develop-build develop-build uiowa@svn-14671.prod.hosting.acquia.com:uiowa.git git executing hook post-code-update in dev environment
```

</details> 
