### PR TITLE
fix uiowa_profiles once implementation

### DIFF
--- a/docroot/modules/custom/uiowa_profiles/js/uiowa-profiles.js
+++ b/docroot/modules/custom/uiowa_profiles/js/uiowa-profiles.js
@@ -18,7 +18,7 @@ uiProfiles = { basePath: drupalSettings.uiowaProfiles.basePath };
 
     // Trim any trailing slash.
     if (path.endsWith('/')) {
-      path = path.substr(0, path.length - 1);
+      path = path.slice(0, -1);
     }
 
     // Grab the canonical link element.
@@ -145,7 +145,7 @@ uiProfiles = { basePath: drupalSettings.uiowaProfiles.basePath };
    */
   Drupal.behaviors.uiowaProfiles = {
     attach(context, settings) {
-      once('uiowaProfiles', context).forEach(function(profiles) {
+      once('uiowaProfiles', context.querySelector('#uiprof')).forEach(function (profiles) {
         Drupal.uiowaProfiles.updateSEOData(settings, document.URL);
 
         // Note that this seems to observe multiple changes per person.


### PR DESCRIPTION
When we updated our once implementations, this one wasn't correct and it caused the JS not to trigger for the different controller routes leaving it with stale incomplete data.

There is an email thread in its-web from 9/16, subject line "Canonical profile urls" that provides more details about the symptoms.

# How to test

```
git checkout main && git pull && ddev blt ds --site=orthopedics.medicine.uiowa.edu
```

Go to https://medicineorthopedics.uiowa.ddev.site/profile/ and then navigate to one of the profiles. Inspect the `<head>` looking for the canonical URL. I think it ends up being `https://medicineorthopedics.uiowa.ddev.site/profile/` or `https://medicineorthopedics.uiowa.ddev.site/profile/{name}` (Drupal default) which isn't right in this case. It should point to `https://profiles.uiowa.edu/people/{name}` since "no canonical base set on the Orthopedics directory." Why these routes are behind authentication, is a separate problem I think.

Now checkout `uiowa_profiles_once_tweak`:

```
git checkout uiowa_profiles_once_tweak && ddev drush @medicineorthopedics.local cr
```

Again start by going to https://medicineorthopedics.uiowa.ddev.site/profile/ and then navigating to a profile. It should point to `https://profiles.uiowa.edu/people/{name}`