### PR TITLE
ITS - change replyto from site email to node author email

### DIFF
--- a/config/sites/its.uiowa.edu/workbench_email.workbench_email_template.alert_created.yml
+++ b/config/sites/its.uiowa.edu/workbench_email.workbench_email_template.alert_created.yml
@@ -22,7 +22,7 @@ bundles:
 body:
   value: '<p>[node:title] alert has been created by [node:author]. <a href="[node:url]">Please review and publish the alert</a></p>'
   format: filtered_html
-replyTo: '[site:mail]'
+replyTo: '[node:author:mail]'
 transitions:
   alert:
     needs_review: needs_review


### PR DESCRIPTION
<img width="605" alt="Screenshot 2024-09-17 at 12 56 10 PM" src="https://github.com/user-attachments/assets/a08f8abd-a93f-4f78-95d7-adb630246598">

instead of

![image](https://github.com/user-attachments/assets/e68cedaa-3546-42b6-ba23-7e89ba72be3d)

# How to test

<!-- Include detailed steps for how to test this PR. -->
```
ddev blt ds --site=its.uiowa.edu && ddev drush @its.local uli admin/node/add/alert
```
Create an alert and change the moderation state to submit.

```
ddev mailpit
```

See the email now has a replyto pointing to the user's email.
