### PR TITLE
[Registrar] Final exam block plugin

### DIFF
--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
@@ -27,7 +27,7 @@ class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPlugin
   protected $maui;
 
   /**
-   * Constructs a new AcademicCalendarBlock instance.
+   * Constructs a new FinalExamScheduleBlock instance.
    *
    * @param array $configuration
    *   The plugin configuration.

--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
@@ -100,7 +100,7 @@ class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPlugin
     $session = $this->configuration['session'];
     $last_updated = $this->configuration['last_updated'];
     return [
-      '#markup' => $session,
+      '#markup' => $session . "<br>Last updated: " . $last_updated,
     ];
   }
 

--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
@@ -74,6 +74,12 @@ class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPlugin
       '#required' => TRUE,
     ];
 
+    $form['session_name'] = [
+      '#title' => $this->t('Session Name'),
+      '#default_value' => $this->configuration['session_name'] ?? NULL,
+      '#required' => TRUE,
+    ];
+
     $form['last_updated'] = [
       '#type' => 'date',
       '#title' => $this->t('Last Updated'),
@@ -90,6 +96,7 @@ class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPlugin
   public function blockSubmit($form, FormStateInterface $form_state) {
     parent::blockSubmit($form, $form_state);
     $this->configuration['session'] = $form_state->getValue('session');
+    $this->configuration['session_name'] = $form["settings"]["session"]["#options"][$form_state->getValue('session')];
     $this->configuration['last_updated'] = $form_state->getValue('last_updated');
   }
 
@@ -98,9 +105,10 @@ class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPlugin
    */
   public function build() {
     $session = $this->configuration['session'];
+    $session_name = $this->configuration['session_name'];
     $last_updated = $this->configuration['last_updated'];
     return [
-      '#markup' => $session . "<br>Last updated: " . $last_updated,
+      '#markup' => $session_name . " " . $session . "<br>Last updated: " . $last_updated,
     ];
   }
 

--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\registrar_core\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * Provides a Final Exam Schedule block.
+ *
+ * @Block(
+ *   id = "final_exam_schedule_block",
+ *   admin_label = @Translation("Final Exam Schedule"),
+ *   category = @Translation("Site custom")
+ * )
+ */
+class FinalExamScheduleBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $markup = '<div>Hello World!</div>';
+    return ['#markup' => $markup];
+  }
+
+}

--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
@@ -74,12 +74,6 @@ class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPlugin
       '#required' => TRUE,
     ];
 
-    $form['session_name'] = [
-      '#title' => $this->t('Session Name'),
-      '#default_value' => $this->configuration['session_name'] ?? NULL,
-      '#required' => TRUE,
-    ];
-
     $form['last_updated'] = [
       '#type' => 'date',
       '#title' => $this->t('Last Updated'),
@@ -96,7 +90,7 @@ class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPlugin
   public function blockSubmit($form, FormStateInterface $form_state) {
     parent::blockSubmit($form, $form_state);
     $this->configuration['session'] = $form_state->getValue('session');
-    $this->configuration['session_name'] = $form["settings"]["session"]["#options"][$form_state->getValue('session')];
+    $this->configuration['session_name'] = $form['settings']['session']['#options'][$form_state->getValue('session')];
     $this->configuration['last_updated'] = $form_state->getValue('last_updated');
   }
 

--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
@@ -102,7 +102,7 @@ class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPlugin
     $session_name = $this->configuration['session_name'];
     $last_updated = $this->configuration['last_updated'];
     return [
-      '#markup' => $session_name . " " . $session . "<br>Last updated: " . $last_updated,
+      '#markup' => $session_name . " " . $session . "<br>Last updated: " . date('F j, Y', strtotime($last_updated)),
     ];
   }
 

--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
@@ -24,8 +24,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * )
  */
 class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPluginInterface, FormInterface, TrustedCallbackInterface {
-  use SessionColorTrait;
-
   /**
    * The MAUI API service.
    *
@@ -88,7 +86,7 @@ class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPlugin
    * {@inheritdoc}
    */
   public function getFormId() {
-    return 'academic_calendar_filter_form';
+    return 'final_exam_schedule_filter_form';
   }
 
   /**
@@ -108,15 +106,6 @@ class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPlugin
   /**
    * {@inheritdoc}
    */
-  public function defaultConfiguration() {
-    return [
-        'steps' => 0,
-      ] + parent::defaultConfiguration();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function blockForm($form, FormStateInterface $form_state) {
     $form = parent::blockForm($form, $form_state);
 
@@ -127,16 +116,12 @@ class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPlugin
 
     $form['steps'] = [
       '#title' => $this->t('Session(s) to display'),
-      '#description' => $this->t('What session(s) you wish to display academic calendar information for.'),
+      '#description' => $this->t('What session(s) you wish to display final exam schedule information for.'),
       '#type' => 'select',
       '#options' => [
         0 => $this->t('Current session'),
         1 => $this->t('Current session, plus next session'),
         2 => $this->t('Current session, plus next two sessions'),
-        3 => $this->t('Current session, plus next three sessions'),
-        4 => $this->t('Current session, plus next four sessions'),
-        5 => $this->t('Current session, plus next five sessions'),
-        10 => $this->t('Current session, plus next ten sessions'),
       ],
       '#default_value' => $this->configuration['steps'] ?? 0,
       '#required' => FALSE,
@@ -205,18 +190,10 @@ class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPlugin
     // the current session, wrap it in an array but don't fetch others.
     $sessions = ((int) $steps === 0) ? [$current] : $this->maui->getSessionsRange($current->id, max(1, $steps));
 
-    // Get the start date of the first session.
-    $first_session_start_date = $sessions[0]->startDate;
-
-    // Get the end date of the last session.
-    $last_session_end_date = end($sessions)->endDate;
-
     // Add the configuration values to drupalSettings.
     $build['#attached']['drupalSettings']['academicCalendar'] = [
       'steps' => $steps,
       'includePastSessions' => $this?->configuration['include_past_sessions'] ?? FALSE,
-      'firstSessionStartDate' => $first_session_start_date,
-      'lastSessionEndDate' => $last_session_end_date,
     ];
 
     return $build;
@@ -229,7 +206,6 @@ class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPlugin
     $form = [];
 
     $form['#id'] = 'academic-calendar-filter-form';
-    $form['#attributes']['class'][] = 'academic-calendar-filters sidebar element--margin__bottom--extra  element--padding__all--minimal bg--gray';
 
     $current_request = $this->requestStack->getCurrentRequest();
 

--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
@@ -2,7 +2,17 @@
 
 namespace Drupal\registrar_core\Plugin\Block;
 
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Form\FormInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Security\TrustedCallbackInterface;
+use Drupal\registrar_core\SessionColorTrait;
+use Drupal\uiowa_maui\MauiApi;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Provides a Final Exam Schedule block.
@@ -13,14 +23,295 @@ use Drupal\Core\Block\BlockBase;
  *   category = @Translation("Site custom")
  * )
  */
-class FinalExamScheduleBlock extends BlockBase {
+class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPluginInterface, FormInterface, TrustedCallbackInterface {
+  use SessionColorTrait;
+
+  /**
+   * The MAUI API service.
+   *
+   * @var \Drupal\uiowa_maui\MauiApi
+   */
+  protected $maui;
+
+  /**
+   * The form builder service.
+   *
+   * @var \Drupal\Core\Form\FormBuilderInterface
+   */
+  protected $formBuilder;
+
+  /**
+   * The request stack service.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * Constructs a new AcademicCalendarBlock instance.
+   *
+   * @param array $configuration
+   *   The plugin configuration.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\uiowa_maui\MauiApi $maui
+   *   The MAUI API service.
+   * @param \Drupal\Core\Form\FormBuilderInterface $formBuilder
+   *   The form builder service.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+   *   The request stack service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, MauiApi $maui, FormBuilderInterface $formBuilder, RequestStack $requestStack) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->maui = $maui;
+    $this->formBuilder = $formBuilder;
+    $this->requestStack = $requestStack;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('uiowa_maui.api'),
+      $container->get('form_builder'),
+      $container->get('request_stack')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'academic_calendar_filter_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    // Add any validation if needed.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    // Handle form submission if needed.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+        'steps' => 0,
+      ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $form = parent::blockForm($form, $form_state);
+
+    $sessions = [];
+    foreach ($this->maui->getSessionsBounded() as $session) {
+      $sessions[$session->id] = Html::escape($session->shortDescription);
+    }
+
+    $form['steps'] = [
+      '#title' => $this->t('Session(s) to display'),
+      '#description' => $this->t('What session(s) you wish to display academic calendar information for.'),
+      '#type' => 'select',
+      '#options' => [
+        0 => $this->t('Current session'),
+        1 => $this->t('Current session, plus next session'),
+        2 => $this->t('Current session, plus next two sessions'),
+        3 => $this->t('Current session, plus next three sessions'),
+        4 => $this->t('Current session, plus next four sessions'),
+        5 => $this->t('Current session, plus next five sessions'),
+        10 => $this->t('Current session, plus next ten sessions'),
+      ],
+      '#default_value' => $this->configuration['steps'] ?? 0,
+      '#required' => FALSE,
+    ];
+
+    $form['include_past_sessions'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Include past sessions'),
+      '#description' => $this->t('Include an amount of sessions in the past equal to the number set above.'),
+      '#default_value' => $this->configuration['include_past_sessions'] ?? FALSE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    parent::blockSubmit($form, $form_state);
+    $this->configuration['steps'] = $form_state->getValue('steps');
+    $this->configuration['include_past_sessions'] = $form_state->getValue('include_past_sessions');
+  }
 
   /**
    * {@inheritdoc}
    */
   public function build() {
-    $markup = '<div>Hello World!</div>';
-    return ['#markup' => $markup];
+    $form = $this->formBuilder->getForm($this);
+
+    $build = [
+      'wrapper' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => [
+            'list-container__inner',
+            'sitenow-academic-calendar',
+          ],
+        ],
+        'form' => $form,
+        'calendar' => [
+          '#type' => 'container',
+          '#attributes' => [
+            'class' => ['academic-calendar content'],
+            'id' => 'academic-calendar-content',
+          ],
+          'content' => [
+            '#lazy_builder' => [
+              static::class . '::lazyBuilder',
+              [],
+            ],
+            '#create_placeholder' => TRUE,
+          ],
+        ],
+      ],
+    ];
+
+    // Attach the library for the calendar.
+    $build['#attached']['library'][] = 'uids_base/card';
+    $build['#attached']['library'][] = 'uids_base/chosen';
+    $build['#attached']['library'][] = 'registrar_core/academic-calendar';
+
+    $current = $this->maui->getCurrentSession();
+    $steps = $this->configuration['steps'];
+    // Session range steps must be 1 or greater, so if we want only
+    // the current session, wrap it in an array but don't fetch others.
+    $sessions = ((int) $steps === 0) ? [$current] : $this->maui->getSessionsRange($current->id, max(1, $steps));
+
+    // Get the start date of the first session.
+    $first_session_start_date = $sessions[0]->startDate;
+
+    // Get the end date of the last session.
+    $last_session_end_date = end($sessions)->endDate;
+
+    // Add the configuration values to drupalSettings.
+    $build['#attached']['drupalSettings']['academicCalendar'] = [
+      'steps' => $steps,
+      'includePastSessions' => $this?->configuration['include_past_sessions'] ?? FALSE,
+      'firstSessionStartDate' => $first_session_start_date,
+      'lastSessionEndDate' => $last_session_end_date,
+    ];
+
+    return $build;
+  }
+
+  /**
+   * Builds the form elements for the block.
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form = [];
+
+    $form['#id'] = 'academic-calendar-filter-form';
+    $form['#attributes']['class'][] = 'academic-calendar-filters sidebar element--margin__bottom--extra  element--padding__all--minimal bg--gray';
+
+    $current_request = $this->requestStack->getCurrentRequest();
+
+    $form['search'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Search'),
+      '#attributes' => [
+        'placeholder' => $this->t('Search the calendar'),
+        'class' => ['academic-calendar-search'],
+      ],
+    ];
+
+    $form['session'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Session'),
+      '#options' => ['all' => $this->t('All Sessions')],
+      '#empty_option' => $this->t('- Select -'),
+      '#attributes' => ['class' => ['academic-calendar-session']],
+    ];
+
+    $form['start_date'] = [
+      '#type' => 'date',
+      '#title' => $this->t('Start Date'),
+      '#attributes' => ['class' => ['academic-calendar-start-date']],
+    ];
+
+    $form['category'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Category'),
+      '#options' => $this->maui->getDateCategories(),
+      '#default_value' => $current_request->query->get('category', 'STUDENT'),
+      '#multiple' => FALSE,
+    ];
+
+    $form['actions'] = [
+      '#type' => 'actions',
+      '#attributes' => ['class' => ['form-actions--stacked']],
+    ];
+
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Search'),
+      '#attributes' => ['class' => ['bttn--full']],
+    ];
+
+    $form['actions']['reset'] = [
+      '#type' => 'button',
+      '#value' => $this->t('Reset'),
+      '#attributes' => [
+        'class' => [
+          'bttn',
+          'bttn--secondary',
+          'bttn--full',
+          'js-form-reset',
+        ],
+      ],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * A #lazy_builder callback.
+   */
+  public static function lazyBuilder() {
+    $block_manager = \Drupal::service('plugin.manager.block');
+    $skeletonLoader = $block_manager->createInstance('skeleton_load_block')->build();
+
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['academic-calendar', 'content']],
+      'content' => [
+        $skeletonLoader,
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function trustedCallbacks() {
+    return ['lazyBuilder'];
   }
 
 }


### PR DESCRIPTION
Closes #4967 

# How to test
- `ddev blt ds --site=registrar.uiowa.edu && ddev drush @registrar.local uli`
- add/edit a page and add the Final Exam Schedule block via Layout Builder
- try to save as-is and see that you cannot save unless a session and last updated date is set. 
- Save again with a session and date chosen. 
- Block should now display the selected session, a legacyCode, and the date last updated. You can check https://api.maui.uiowa.edu/maui/api/pub/registrar/sessions/bounded to see that the output legacyCode matches the selected session (aka shortDescription).
