### PR TITLE
[ Bug ] Fullcalendar: only rebuild if AJAX is from views.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -263,6 +263,9 @@
             "drupal/fragments": {
                 "remove_views_data_type": "https://www.drupal.org/files/issues/2022-08-24/3305851-remove_views_data_type-6.patch"
             },
+            "drupal/fullcalendar_view": {
+                "only_rebuild_on_view_change": "patches/fullcalendar_only_rebuild_on_view_change.patch"
+            },
             "drupal/google_analytics": {
                 "[3373921] Cannot install from existing config": "patches/3373921.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f3f702ead915bf33bf5ab2a663ce3e9",
+    "content-hash": "8568732f7cc7994c7ecf27f980d72697",
     "packages": [
         {
             "name": "acquia/blt",
@@ -8316,6 +8316,10 @@
             ],
             "authors": [
                 {
+                    "name": "andrii momotov",
+                    "homepage": "https://www.drupal.org/user/3706092"
+                },
+                {
                     "name": "drubb",
                     "homepage": "https://www.drupal.org/user/69706"
                 },
@@ -11370,7 +11374,7 @@
                     "homepage": "https://www.drupal.org/u/graber"
                 },
                 {
-                    "name": "Graber",
+                    "name": "graber",
                     "homepage": "https://www.drupal.org/user/1599440"
                 },
                 {

--- a/patches/fullcalendar_only_rebuild_on_view_change.patch
+++ b/patches/fullcalendar_only_rebuild_on_view_change.patch
@@ -1,0 +1,14 @@
+diff --git a/js/fullcalendar_view.js b/js/fullcalendar_view.js
+index 01f60b5475157d774b83ff8b59de55768b07da0e..7b0fe02a48988f32028899447a0bf71d2acc5c95 100644
+--- a/js/fullcalendar_view.js
++++ b/js/fullcalendar_view.js
+@@ -441,7 +441,8 @@
+     if (
+         drupalSettings.calendar &&
+         settings.url !== '/fullcalendar-view-event-update' &&
+-        settings.url.indexOf('_wrapper_format=drupal_modal') < 0
++        settings.url.indexOf('_wrapper_format=drupal_modal') < 0 &&
++        settings.url.indexOf('/views/ajax?_wrapper_format=drupal_ajax') >= 0
+         ) {
+       // Rebuild the calendars.
+       drupalSettings.calendar.forEach(function(calendar) {


### PR DESCRIPTION
[Copying my comment from D.O:](https://www.drupal.org/project/fullcalendar_view/issues/3323399#comment-15778682)
> "I made a change in the fork here to try and ensure that the only ajax that changes the calendar view comes from views ajax. I don't think it covers the entirety of the need here considering other views on the page sending ajax requests will still reload the calendar, but it's a start!"

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
