### PR TITLE
Back to top - accessible name

### DIFF
--- a/docroot/themes/custom/uids_base/templates/navigation/top-scroll.html.twig
+++ b/docroot/themes/custom/uids_base/templates/navigation/top-scroll.html.twig
@@ -3,7 +3,7 @@
     <ul>
       <li>
         <a class="v-dot-link" href="#" aria-labelledby="top-scroll">
-          <span class="fas fa-arrow-up"></span>
+          <span role="presentation" class="fas fa-arrow-up"></span>
         </a>
       </li>
     </ul>

--- a/docroot/themes/custom/uids_base/templates/navigation/top-scroll.html.twig
+++ b/docroot/themes/custom/uids_base/templates/navigation/top-scroll.html.twig
@@ -2,7 +2,7 @@
   <nav class="top-scroll-container js-scroll" id="top-scroll" role="navigation" aria-label="Back to top of page">
     <ul>
       <li>
-        <a class="v-dot-link" href="#" aria-labelledby="v-dot-nav-section">
+        <a class="v-dot-link" href="#" aria-labelledby="top-scroll">
           <span class="fas fa-arrow-up"></span>
         </a>
       </li>


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

Fixes accessible name and the icon requiring alt text.

Sync sandbox and use the SiteImprove accessibility extension for chrome based browsers. Noticed the issues related to the back to top button are fixed locally compared to PROD.

<img width="294" alt="Screenshot 2024-10-30 at 4 59 49 PM" src="https://github.com/user-attachments/assets/35807981-7001-4955-8b50-c2dc2bfaa778">
<img width="300" alt="Screenshot 2024-10-30 at 4 59 59 PM" src="https://github.com/user-attachments/assets/293eee7a-83c6-4b77-9272-6fc25d4b8004">

