### PR TITLE
[Registrar] Remove 'last updated' final exam block

### DIFF
--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Form/FinalExamScheduleForm.php
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Form/FinalExamScheduleForm.php
@@ -77,11 +77,10 @@ class FinalExamScheduleForm extends FormBase {
     }
 
     $session_name = $session_info['session_name'];
-    $last_updated = date('F j, Y', strtotime($session_info['last_updated']));
 
     $form['final_exam']['intro'] = [
       '#type' => 'markup',
-      '#markup' => "<p><strong>Session:</strong> {$session_name}<br><strong>Last updated:</strong> {$last_updated}</p>",
+      '#markup' => "<p><strong>Session:</strong> {$session_name}</p>",
     ];
 
     $data = $this->maui->getFinalExamSchedule($session_info['session_id']);

--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/src/Plugin/Block/FinalExamScheduleBlock.php
@@ -86,13 +86,6 @@ class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPlugin
       '#required' => TRUE,
     ];
 
-    $form['last_updated'] = [
-      '#type' => 'date',
-      '#title' => $this->t('Last Updated'),
-      '#default_value' => $this->configuration['last_updated'] ?? NULL,
-      '#required' => TRUE,
-    ];
-
     return $form;
   }
 
@@ -103,7 +96,6 @@ class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPlugin
     parent::blockSubmit($form, $form_state);
     $this->configuration['session'] = $form_state->getValue('session');
     $this->configuration['session_name'] = $form['settings']['session']['#options'][$form_state->getValue('session')];
-    $this->configuration['last_updated'] = $form_state->getValue('last_updated');
   }
 
   /**
@@ -113,7 +105,6 @@ class FinalExamScheduleBlock extends BlockBase implements ContainerFactoryPlugin
     $build['form'] = $this->formBuilder->getForm('Drupal\registrar_core\Form\FinalExamScheduleForm', [
       'session_id' => $this->configuration['session'],
       'session_name' => $this->configuration['session_name'],
-      'last_updated' => $this->configuration['last_updated'],
     ]);
     return $build;
   }


### PR DESCRIPTION
Relates to #8185 
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

```
ddev blt ds --site=registrar.uiowa.edu && ddev drush @registrar.local uli /exams
```

See that the page loads fine, doesn't have a 'last updated' displayed.
Edit layout, edit the block and try adding a new final exams schedule block, and see there is no 'last updated' option.

Note: Existing blocks still have the value in their block config, and re-saving the block does not remove it. As there are very few instances of this block, I think we're fine to remove and re-add the block in prod after this code is released to clear it out, rather than the otherwise necessary update hook. The block loads and displays fine even with the unused value in place.