### PR TITLE
hotfix - update events_load to include a timeout and error handling

### DIFF
--- a/docroot/modules/custom/sitenow_events/modules/sitenow_events_paragraph/sitenow_events_paragraph.module
+++ b/docroot/modules/custom/sitenow_events/modules/sitenow_events_paragraph/sitenow_events_paragraph.module
@@ -138,8 +138,14 @@ function sitenow_events_paragraph_preprocess_paragraph(&$variables) {
           }
         }
         else {
+          if (isset($data['error'])) {
+            $message = '<div class="events-empty"><p>Unable to fetch events at this time.</p></div>';
+          }
+          else {
+            $message = '<div class="events-empty"><p>There are currently no events to display.</p></div>';
+          }
           $variables['list'] = [
-            '#markup' => '<div class="events-empty"><p>There are currently no results to display.</p></div>',
+            '#markup' => $message,
           ];
         }
 

--- a/docroot/modules/custom/sitenow_events/modules/sitenow_events_paragraph/sitenow_events_paragraph.module
+++ b/docroot/modules/custom/sitenow_events/modules/sitenow_events_paragraph/sitenow_events_paragraph.module
@@ -145,6 +145,7 @@ function sitenow_events_paragraph_preprocess_paragraph(&$variables) {
             $message = '<div class="events-empty"><p>There are currently no events to display.</p></div>';
           }
           $variables['list'] = [
+            '#type' => 'markup',
             '#markup' => $message,
           ];
         }

--- a/docroot/modules/custom/sitenow_events/sitenow_events.module
+++ b/docroot/modules/custom/sitenow_events/sitenow_events.module
@@ -437,6 +437,7 @@ function sitenow_events_preprocess_block(&$variables) {
           $message = '<div class="events-empty"><p>There are currently no events to display.</p></div>';
         }
         $variables['content']['no_results'] = [
+          '#type' => 'markup',
           '#markup' => $message,
         ];
       }

--- a/docroot/modules/custom/sitenow_events/sitenow_events.module
+++ b/docroot/modules/custom/sitenow_events/sitenow_events.module
@@ -19,7 +19,9 @@ use Drupal\sitenow_events\Entity\Event;
 use Drupal\smart_trim\TruncateHTML;
 use Drupal\uiowa_core\HeadlineHelper;
 use Drupal\views\ViewExecutable;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 
 /**
  * Implements hook_entity_bundle_info_alter().
@@ -428,8 +430,14 @@ function sitenow_events_preprocess_block(&$variables) {
         }
       }
       else {
+        if (isset($data['error'])) {
+          $message = '<div class="events-empty"><p>Unable to fetch events at this time.</p></div>';
+        }
+        else {
+          $message = '<div class="events-empty"><p>There are currently no events to display.</p></div>';
+        }
         $variables['content']['no_results'] = [
-          '#markup' => '<div class="events-empty"><p>There are currently no events to display.</p></div>',
+          '#markup' => $message,
         ];
       }
 
@@ -750,14 +758,10 @@ function sitenow_events_load(
   }
   else {
     try {
-      $request = \Drupal::httpClient()->get($endpoint);
-    }
-    catch (RequestException $e) {
-      $logger = \Drupal::logger('sitenow_events');
-      Error::logException($logger, $e);
-    }
-
-    if (isset($request)) {
+      // Set a timeout (e.g., 10 seconds).
+      $request = \Drupal::httpClient()->get($endpoint, [
+        'timeout' => 10.0,
+      ]);
       $data = json_decode($request->getBody()->getContents(), TRUE);
 
       // Create a cache item set to 5 minutes.
@@ -766,10 +770,27 @@ function sitenow_events_load(
         \Drupal::cache('uievents')->set($endpoint, $data, $request_time + 300);
       }
     }
-    else {
-      $data = [];
+    catch (ConnectException $e) {
+      \Drupal::logger('sitenow_events')->error('Connection timed out when reaching @endpoint: @message', [
+        '@endpoint' => $endpoint,
+        '@message' => $e->getMessage(),
+      ]);
+      $data['error'] = TRUE;
     }
-
+    catch (RequestException $e) {
+      \Drupal::logger('sitenow_events')->error('Request error on @endpoint: @message', [
+        '@endpoint' => $endpoint,
+        '@message' => $e->getMessage(),
+      ]);
+      $data['error'] = TRUE;
+    }
+    catch (TransferException $e) {
+      \Drupal::logger('sitenow_events')->error('Transfer exception on @endpoint: @message', [
+        '@endpoint' => $endpoint,
+        '@message' => $e->getMessage(),
+      ]);
+      $data['error'] = TRUE;
+    }
   }
 
   return $data;


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

Temporarily change docroot/modules/custom/sitenow_events/sitenow_events.module#L764:

```php
      $request = \Drupal::httpClient()->get($endpoint, [
        'timeout' => 10.0,
      ]);
```
to
```php
      $request = \Drupal::httpClient()->get($endpoint, [
        'timeout' => 0.1,
      ]);
```

Make sure to clear caches `ddev drush @sitename.local cc bin uievents`

Try to load a page with an events block. See that error handling/message occur. Change back to 10.0 seconds and try again. It will either error again for a complex uncached queries or successfully pass and display events.

Connection issues (timeouts, network failures) via ConnectException.
HTTP-related errors (status codes or response-related issues) via RequestException.

I don't think we need the TransferException. "lower-level transport errors ... though these are rare in well-maintained HTTP requests"

You should also be able to load the field options within the block configuration under normal circumstances. If the timeout occurs, you won't be able to open and configure the block.
