### PR TITLE
[Pinned] Added style to hide pre-title with element-invisible styling for people

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/card.scss
+++ b/docroot/themes/custom/uids_base/scss/components/card.scss
@@ -273,6 +273,7 @@
 }
 
 // Hide card pre-title for people lists.
-[class*="view-people"] .card__pre-title {
+[class*="view-people"] .card__pre-title,
+.view-counselors .card__pre-title {
   @include element-invisible;
 }

--- a/docroot/themes/custom/uids_base/scss/components/card.scss
+++ b/docroot/themes/custom/uids_base/scss/components/card.scss
@@ -271,3 +271,8 @@
     }
   }
 }
+
+// Hide card pre-title for people lists.
+[class*="view-people"] .card__pre-title {
+  @include element-invisible;
+}


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test
```
ddev blt frontend && ddev blt ds --site=hawkeyemarchingband.uiowa.edu && ddev drush @hawkeyemarchingband.local uli
```
1. Add a people paragraph to a page
2. Save page
3. Edit a person in the list and make them sticky
4. Go back to the page and confirm that they are listed without "pinned" style. Inspect source and look for pre_title. 

```
ddev blt frontend && ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli /people-directory
```
1. Confirm "pinned" style is hidden but still reads on Voiceover when it reads the page `Control and Option + A`
2. Confirm people page does not list "pinned" style nor is it in the markup: https://sandbox.uiowa.ddev.site/people

Any other People list spots that are missed besides counselors?

I checked:
- ighn
- grad
- pharmacy
- Iowa summer writing
- now.uiowa.edu
- facilities
- admissions
- amcs