### PR TITLE
Academic Dates Block - updating to filter on print and review dates

### DIFF
--- a/docroot/modules/custom/uiowa_maui/src/Form/AcademicDatesForm.php
+++ b/docroot/modules/custom/uiowa_maui/src/Form/AcademicDatesForm.php
@@ -112,12 +112,16 @@ class AcademicDatesForm extends FormBase {
       ],
     ];
 
-    $data = $this->maui->searchSessionDates($current, $category);
+    $data = $this->maui->searchSessionDates($current, $category, TRUE);
 
     if (!empty($data)) {
       $data = ((int) $limit_dates === 1) ? array_slice($data, 0, $items_to_display, TRUE) : $data;
 
       foreach ($data as $date) {
+        // Skip dates that are not reviewed.
+        if ($date->reviewed !== TRUE) {
+          continue;
+        }
         $start = strtotime($date->beginDate);
         $end = strtotime($date->endDate);
         $key = $start . $end;

--- a/docroot/modules/custom/uiowa_maui/tests/src/Kernel/AcademicDatesFormTest.php
+++ b/docroot/modules/custom/uiowa_maui/tests/src/Kernel/AcademicDatesFormTest.php
@@ -82,6 +82,7 @@ class AcademicDatesFormTest extends KernelTestBase {
             'description' => 'A description',
             'webDescription' => 'A description',
           ],
+          'reviewed' => TRUE,
         ],
         (object) [
           'name' => 'bar',
@@ -94,6 +95,7 @@ class AcademicDatesFormTest extends KernelTestBase {
             'description' => 'A description',
             'webDescription' => 'A description',
           ],
+          'reviewed' => TRUE,
         ],
       ]));
 


### PR DESCRIPTION
Fixes https://github.com/uiowa/uiowa/issues/7962

# To test

1.  Sync commencement and registrar
2.  Compare the filtered down academic calendar on register with the filtered commencement home page block (current session, graduation and commencement)
3. "on Oct 4 there should be one degree application deadline. Oct 5 there should be one degree application late fee rather than 4"

There isn't an easy date to point out that is not reviewed but isn't also printdate false when looking at the current session/category. If you were to remove the printdate argument and filter on student registration, there would be a couple dates where reviewed is null.