### PR TITLE
[Events] Increase timeout

### DIFF
--- a/docroot/modules/custom/sitenow_events/sitenow_events.module
+++ b/docroot/modules/custom/sitenow_events/sitenow_events.module
@@ -760,7 +760,7 @@ function sitenow_events_load(
     try {
       // Set a timeout (e.g., 10 seconds).
       $request = \Drupal::httpClient()->get($endpoint, [
-        'timeout' => 10.0,
+        'timeout' => 20.0,
       ]);
       $data = json_decode($request->getBody()->getContents(), TRUE);
 


### PR DESCRIPTION
Resolves #8255 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test
(note, there is some caching on the events side of things, so try to "save" some pages of the events block to test with. eg, don't click through all the pages initially, and go only far enough to have it error. Subsequent hits to that page of the block's events will likely load quickly and without error regardless of the local site's cache. If you run into the case that you need to continue testing, try editing the block and changing a filter, re-saving, and trying again. Alternatively, see the splunk link in the bottom notes and find another possibly troublesome page to test with)

<!-- Include detailed steps for how to test this PR. -->
With `main` checked out
```
ddev blt ds --site=uira.org.uiowa.edu && ddev drush @orguira.local en dblog && ddev drush @orguira.local uli /news-and-events/past-events-and-programs
```
Notice the events block doesn't load, but instead displays "Unable to fetch events at this time." (If it does load, try paging until you hit one that doesn't load.)
```
ddev drush @orguira.local watchdog-show --count=10
```
Verify that it was the expected `Connection timed out when reaching...` error.
```
git checkout sitenow_events_load_increase_timeout && git pull && ddev drush @orguira.local cr
```
Reload the page and page through the events block, and see that you can hit all the pages without hitting the timeout error. 

## Post-deployment
Keep an eye on logs, see if the number of events block related errors decrease, or if there is more work needed.

https://splunk.its.uiowa.edu/en-US/app/search/search?earliest=%40w0&latest=now&q=search%20index%3Duiowa-acquia%20content.uiowa.edu%20%22Operation%20timed%20out%22&sid=1732047035.263840&display.page.search.mode=smart&dispatch.sample_ratio=1