### PR TITLE
ITS - update email template

### DIFF
--- a/config/sites/its.uiowa.edu/workbench_email.workbench_email_template.alert_created.yml
+++ b/config/sites/its.uiowa.edu/workbench_email.workbench_email_template.alert_created.yml
@@ -20,7 +20,7 @@ recipient_types:
 bundles:
   'node:alert': 'node:alert'
 body:
-  value: '<p>[node:title] alert has been created by [node:author]. <a href="[node:url]">Please review and publish the alert</a></p>'
+  value: '<p>[node:title] alert has been created by [node:author] ([node:author:mail]). <a href="[node:url]">Please review and publish the alert</a></p>'
   format: filtered_html
 replyTo: '[node:author:mail]'
 transitions:


### PR DESCRIPTION
By way of its-web, James H. requested the alert-notify email be updated to include the author email in the body as the HelpDesk interacts with the email only through Teams and can't see the reply-to information. Since we shouldn't send as the author, the value being in the body allows them to follow-up with the user once the alert has been published.

# How to test

- Sync ITS local and "submit" an alert. `ddev mailpit` to see that the following is printed:
```
[node:title] alert has been created by [node:author] ([node:author:mail]). Please review and publish the alert
```
