### PR TITLE
[Card] Hotfix for card styles not set in P2LB conversion

### DIFF
--- a/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
+++ b/docroot/modules/custom/sitenow_p2lb/sitenow_p2lb.module
@@ -1225,10 +1225,9 @@ function _sitenow_p2lb_block_styles($block_type, $paragraph = NULL) {
 
     case 'uiowa_card':
       return [
-        'block_background_style_light',
-        'card_image_large',
+        'media_size_small',
+        'card_headline_style_serif',
         'card_media_position_stacked',
-        'content_alignment_left',
         'media_format_widescreen',
       ];
 

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -3283,22 +3283,54 @@ function sitenow_update_10011() {
 function sitenow_update_10012() {
   $block_plugin_id = 'inline_block:uiowa_card';
 
-  _update_all_blocks_by_plugin_id($block_plugin_id, function (&$component, $block) {
-    $styles = $component->get('layout_builder_styles_style');
+  /** @var \Drupal\config_split\Entity\ConfigSplitEntity $sitenow_v2 */
+  $sitenow_v2 = \Drupal::entityTypeManager()->getStorage('config_split')->load('sitenow_v2');
+  $sitenow_v2_enabled = $sitenow_v2 && $sitenow_v2->get('status');
 
-    // Add headline style if it doesn't exist.
-    if (!in_array('card_headline_style_serif', $styles) &&
-      !in_array('card_headline_style_sans_serif', $styles)) {
-      $styles[] = 'card_headline_style_serif';
-    }
+  $known_site_paths = [
+    'sites/staff-council.uiowa.edu',
+    'sites/lgbtq-council.org.uiowa.edu',
+    'sites/latinxcouncil.uiowa.edu',
+    'sites/faculty-senate.uiowa.edu',
+    'sites/meyerholz.lab.uiowa.edu',
+    'sites/yangs.lab.uiowa.edu',
+    'sites/lentz.lab.uiowa.edu',
+    'sites/brand.uiowa.edu',
+    'sites/uiadvise.sites.uiowa.edu',
+    'sites/wu.lab.uiowa.edu',
+    'sites/engagement.uiowa.edu',
+    'sites/our.research.uiowa.edu',
+    'sites/law.uiowa.edu',
+    'sites/printmail.fo.uiowa.edu',
+    'sites/billing.uiowa.edu',
+    'sites/talbert.lab.uiowa.edu',
+    'sites/miles.lab.uiowa.edu',
+    'sites/labmichaelson.prod.drupal.uiowa.edu',
+    'sites/michaelewright.lab.uiowa.edu',
+  ];
 
-    // Add media size if it doesn't exist.
-    if (!in_array('media_size_large', $styles) &&
-      !in_array('media_size_medium', $styles) &&
-      !in_array('media_size_small', $styles)) {
-      $styles[] = 'media_size_small';
-    }
+  $current_site_path = \Drupal::getContainer()->getParameter('site.path');
 
-    $component->set('layout_builder_styles_style', $styles);
-  });
+  $site_path_match = in_array($current_site_path, $known_site_paths, TRUE);
+
+  if ($sitenow_v2_enabled || $site_path_match) {
+    _update_all_blocks_by_plugin_id($block_plugin_id, function (&$component, $block) {
+      $styles = $component->get('layout_builder_styles_style');
+
+      // Add headline style if it doesn't exist.
+      if (!in_array('card_headline_style_serif', $styles) &&
+        !in_array('card_headline_style_sans_serif', $styles)) {
+        $styles[] = 'card_headline_style_serif';
+      }
+
+      // Add media size if it doesn't exist.
+      if (!in_array('media_size_large', $styles) &&
+        !in_array('media_size_medium', $styles) &&
+        !in_array('media_size_small', $styles)) {
+        $styles[] = 'media_size_small';
+      }
+
+      $component->set('layout_builder_styles_style', $styles);
+    });
+  }
 }

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -3278,7 +3278,7 @@ function sitenow_update_10011() {
 }
 
 /**
- * Update Card block with new default styles missed in P2LB conversion.
+ * Update card block with new default styles missed in P2LB conversion.
  */
 function sitenow_update_10012() {
   $block_plugin_id = 'inline_block:uiowa_card';
@@ -3292,7 +3292,7 @@ function sitenow_update_10012() {
       $styles[] = 'card_headline_style_serif';
     }
 
-    // Add headline style if it doesn't exist.
+    // Add media size if it doesn't exist.
     if (!in_array('media_size_large', $styles) &&
       !in_array('media_size_medium', $styles) &&
       !in_array('media_size_small', $styles)) {

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -3276,3 +3276,29 @@ function sitenow_update_10011() {
   $config->set('uiowa_core.ga', $value)
     ->save();
 }
+
+/**
+ * Update Card block with new default styles missed in P2LB conversion.
+ */
+function sitenow_update_10012() {
+  $block_plugin_id = 'inline_block:uiowa_card';
+
+  _update_all_blocks_by_plugin_id($block_plugin_id, function (&$component, $block) {
+    $styles = $component->get('layout_builder_styles_style');
+
+    // Add headline style if it doesn't exist.
+    if (!in_array('card_headline_style_serif', $styles) &&
+      !in_array('card_headline_style_sans_serif', $styles)) {
+      $styles[] = 'card_headline_style_serif';
+    }
+
+    // Add headline style if it doesn't exist.
+    if (!in_array('media_size_large', $styles) &&
+      !in_array('media_size_medium', $styles) &&
+      !in_array('media_size_small', $styles)) {
+      $styles[] = 'media_size_small';
+    }
+
+    $component->set('layout_builder_styles_style', $styles);
+  });
+}

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -3283,22 +3283,54 @@ function sitenow_update_10011() {
 function sitenow_update_10012() {
   $block_plugin_id = 'inline_block:uiowa_card';
 
-  _update_all_blocks_by_plugin_id($block_plugin_id, function (&$component, $block) {
-    $styles = $component->get('layout_builder_styles_style');
+  /** @var \Drupal\config_split\Entity\ConfigSplitEntity $sitenow_v2 */
+  $sitenow_v2 = \Drupal::entityTypeManager()->getStorage('config_split')->load('sitenow_v2');
+  $sitenow_v2_enabled = $sitenow_v2 && $sitenow_v2->get('status');
 
-    // Add headline style if it doesn't exist.
-    if (!in_array('card_headline_style_serif', $styles) &&
-      !in_array('card_headline_style_sans_serif', $styles)) {
-      $styles[] = 'card_headline_style_serif';
-    }
+  $known_site_paths = [
+    'sites/staff-council.uiowa.edu',
+    'sites/lgbtq-council.org.uiowa.edu',
+    'sites/latinxcouncil.uiowa.edu',
+    'sites/faculty-senate.uiowa.edu',
+    'sites/meyerholz.lab.uiowa.edu',
+    'sites/yangs.lab.uiowa.edu',
+    'sites/lentz.lab.uiowa.edu',
+    'sites/brand.uiowa.edu',
+    'sites/uiadvise.sites.uiowa.edu',
+    'sites/wu.lab.uiowa.edu',
+    'sites/engagement.uiowa.edu',
+    'sites/our.research.uiowa.edu',
+    'sites/law.uiowa.edu',
+    'sites/printmail.fo.uiowa.edu',
+    'sites/billing.uiowa.edu',
+    'sites/talbert.lab.uiowa.edu',
+    'sites/miles.lab.uiowa.edu',
+    'sites/michaelson.lab.uiowa.edu',
+    'sites/michaelewright.lab.uiowa.edu',
+  ];
 
-    // Add media size if it doesn't exist.
-    if (!in_array('media_size_large', $styles) &&
-      !in_array('media_size_medium', $styles) &&
-      !in_array('media_size_small', $styles)) {
-      $styles[] = 'media_size_small';
-    }
+  $current_site_path = \Drupal::getContainer()->getParameter('site.path');
 
-    $component->set('layout_builder_styles_style', $styles);
-  });
+  $site_path_match = in_array($current_site_path, $known_site_paths, TRUE);
+
+  if ($sitenow_v2_enabled || $site_path_match) {
+    _update_all_blocks_by_plugin_id($block_plugin_id, function (&$component, $block) {
+      $styles = $component->get('layout_builder_styles_style');
+
+      // Add headline style if it doesn't exist.
+      if (!in_array('card_headline_style_serif', $styles) &&
+        !in_array('card_headline_style_sans_serif', $styles)) {
+        $styles[] = 'card_headline_style_serif';
+      }
+
+      // Add media size if it doesn't exist.
+      if (!in_array('media_size_large', $styles) &&
+        !in_array('media_size_medium', $styles) &&
+        !in_array('media_size_small', $styles)) {
+        $styles[] = 'media_size_small';
+      }
+
+      $component->set('layout_builder_styles_style', $styles);
+    });
+  }
 }


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

## Converted Law P2LB site:
```
ddev blt ds --site=law.uiowa.edu && ddev drush @law.local uli /node/9386/layout
```
1. Confirm you can update a card and that the headline style and card image size values are set in the update hook to the defaults. 

## Test P2LB updates:
```
ddev blt sync --site hawkeyemarchingband.uiowa.edu --define drush.aliases.remote=hawkeyemarchingband.test && ddev drush @hawkeyemarchingband.local config-split:activate p2lb -y && ddev drush @hawkeyemarchingband.local uli admin/content/sitenow-converter
```
1. Convert the home page to v3.  Edit the home page layout and confirm you can update a card and that the headline style and card image size values are set in the conversion. 

### Question
- Should this be scoped to the 20 sites listed to https://iowa.sharepoint.com/:x:/r/sites/CSI-Drupal2/_layouts/15/Doc.aspx?sourcedoc=%7B70998683-29FC-4A9B-8CBD-D99D0CEEA75F%7D&file=P2LB%20Site%20Status.xlsx&action=default&mobileredirect=true? 