### PR TITLE
adding phpmyadmin to ddev uiowa

### DIFF
--- a/.ddev/addon-metadata/phpmyadmin/manifest.yaml
+++ b/.ddev/addon-metadata/phpmyadmin/manifest.yaml
@@ -1,0 +1,10 @@
+name: phpmyadmin
+repository: ddev/ddev-phpmyadmin
+version: v0.3.9
+install_date: "2024-12-06T11:01:41-06:00"
+project_files:
+    - docker-compose.phpmyadmin.yaml
+    - docker-compose.phpmyadmin_norouter.yaml
+    - commands/host/phpmyadmin
+global_files: []
+removal_actions: []

--- a/.ddev/commands/host/phpmyadmin
+++ b/.ddev/commands/host/phpmyadmin
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+## #ddev-generated: If you want to edit and own this file, remove this line.
+## Description: Launch a browser with PhpMyAdmin
+## Usage: phpmyadmin
+## Example: "ddev phpmyadmin"
+
+DDEV_PHPMYADMIN_PORT=8036
+DDEV_PHPMYADMIN_HTTPS_PORT=8037
+if [ ${DDEV_PRIMARY_URL%://*} = "http" ] || [ -n "${GITPOD_WORKSPACE_ID:-}" ] || [ "${CODESPACES:-}" = "true" ]; then
+    # Gitpod: "gp preview" opens a blank page for PhpMyAdmin, use "xdg-open" instead
+    if [ "${OSTYPE:-}" = "linux-gnu" ] && [ -n "${GITPOD_WORKSPACE_ID:-}" ] && [ -z "${DDEV_DEBUG:-}" ]; then
+        xdg-open "$(DDEV_DEBUG=true ddev launch :$DDEV_PHPMYADMIN_PORT | grep "FULLURL" | awk '{print $2}')"
+    else
+        ddev launch :$DDEV_PHPMYADMIN_PORT
+    fi
+else
+    ddev launch :$DDEV_PHPMYADMIN_HTTPS_PORT
+fi

--- a/.ddev/docker-compose.phpmyadmin.yaml
+++ b/.ddev/docker-compose.phpmyadmin.yaml
@@ -1,0 +1,30 @@
+#ddev-generated
+services:
+  phpmyadmin:
+    container_name: ddev-${DDEV_SITENAME}-phpmyadmin
+    image: phpmyadmin:5.2.0
+    working_dir: "/root"
+    restart: "no"
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    volumes:
+    - ".:/mnt/ddev_config"
+    - "ddev-global-cache:/mnt/ddev-global-cache"
+    expose:
+      - "80"
+    environment:
+    - PMA_USER=root
+    - PMA_PASSWORD=root
+    - PMA_HOST=db
+    - PMA_PORT=3306
+    - VIRTUAL_HOST=$DDEV_HOSTNAME
+    - UPLOAD_LIMIT=4000M
+    - HTTP_EXPOSE=8036:80
+    - HTTPS_EXPOSE=8037:80
+    healthcheck:
+      interval: 120s
+      timeout: 2s
+      retries: 1
+    depends_on:
+      - db

--- a/.ddev/docker-compose.phpmyadmin_norouter.yaml
+++ b/.ddev/docker-compose.phpmyadmin_norouter.yaml
@@ -1,0 +1,4 @@
+#ddev-generated
+# If omit_containers[ddev-router] then this file will be replaced
+# with another with a `ports` statement to directly expose port 80 to 8036
+services: {}


### PR DESCRIPTION
# Background

>ddev removed phpmyadmin from the default install, but I like that it is able to search all the things through a decent UI. AFAIK, sequelace doesn't offer this functionality

https://iowaweb.slack.com/archives/C8SM82ZFZ/p1733513899472289
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

- `ddev restart`
- `ddev phpmyadmin`
