### PR TITLE
[Registrar] Add additional correspondence mappings

### DIFF
--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/registrar_core.module
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/registrar_core.module
@@ -279,10 +279,13 @@ function registrar_core_correspondence_tags(string $tag = '') {
     '- any -' => '- Any -',
     'classroom scheduling' => 'Classrooms',
     'commencement' => 'Commencement',
+    'courses' => 'Courses',
     'grad_analysis' => 'Degrees',
     'exam' => 'Exams',
+    'general catalog' => 'General Catalog',
     'grades' => 'Grades',
     'registration' => 'Registration',
+    'sample plans' => 'Sample Plans',
   ];
   if (empty($tag)) {
     return $mapping;


### PR DESCRIPTION
Closes #8287 

# How to test

- `ddev blt ds --site=registrar.uiowa.edu && ddev drush @registrar.local uli correspondence`
- Check that Courses, Sample Plans, and General Catalog are all now options in the Topic dropdown and that they work correctly when selected.
