### PR TITLE
Fix config import errors related to `advanced_webform` split

### DIFF
--- a/docroot/modules/custom/sitenow_advanced_webform/sitenow_advanced_webform.info.yml
+++ b/docroot/modules/custom/sitenow_advanced_webform/sitenow_advanced_webform.info.yml
@@ -3,4 +3,3 @@ description: Temp hotfix module.
 type: module
 core_version_requirement: ^9.2 || ^10
 package: Custom - UIowa
-

--- a/docroot/modules/custom/sitenow_advanced_webform/sitenow_advanced_webform.info.yml
+++ b/docroot/modules/custom/sitenow_advanced_webform/sitenow_advanced_webform.info.yml
@@ -1,0 +1,6 @@
+name: "SiteNow Advanced Webform"
+description: Temp hotfix module.
+type: module
+core_version_requirement: ^9.2 || ^10
+package: Custom - UIowa
+

--- a/docroot/modules/custom/sitenow_advanced_webform/sitenow_advanced_webform.permissions.yml
+++ b/docroot/modules/custom/sitenow_advanced_webform/sitenow_advanced_webform.permissions.yml
@@ -1,0 +1,2 @@
+administer advanced webform settings:
+  title: 'Administer advanced webform settings'


### PR DESCRIPTION
Fixes issues that caused deployment errors on `uiowa02`.

# How to test

```
ddev blt ds --site sandbox.uiowa.edu
```
Confirm above command runs without errors.
