### PR TITLE
[IWP] Removed the sticky from resource content type

### DIFF
--- a/config/sites/iwp.uiowa.edu/config_split.patch.user.role.webmaster.yml
+++ b/config/sites/iwp.uiowa.edu/config_split.patch.user.role.webmaster.yml
@@ -33,6 +33,7 @@ adding:
     - 'edit terms in writer_bio_languages'
     - 'edit terms in writer_bio_session_status'
     - 'enter writer_bio revision log entry'
+    - 'override resource sticky option'
     - 'override writer_bio authored by option'
     - 'override writer_bio authored on option'
     - 'rabbit hole bypass taxonomy_term'

--- a/config/sites/iwp.uiowa.edu/core.base_field_override.node.resource.sticky.yml
+++ b/config/sites/iwp.uiowa.edu/core.base_field_override.node.resource.sticky.yml
@@ -14,7 +14,7 @@ required: false
 translatable: true
 default_value:
   -
-    value: 1
+    value: 0
 default_value_callback: ''
 settings:
   on_label: 'On'

--- a/config/sites/iwp.uiowa.edu/node.type.resource.yml
+++ b/config/sites/iwp.uiowa.edu/node.type.resource.yml
@@ -23,6 +23,10 @@ third_party_settings:
       status: false
       settings:
         age: 1
+    only_drafts:
+      status: false
+      settings:
+        age: 0
   scheduler:
     expand_fieldset: when_required
     fields_display_mode: vertical_tab


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt ds --site=iwp.uiowa.edu    && ddev drush @iwp.local uli /admin/structure/types/manage/resource
```

1. Confirm that sticky is not set by default on content type
