### PR TITLE
emergency_website_cache_control_part_deux

### DIFF
--- a/docroot/modules/custom/uiowa_alerts/es6/alerts.es6
+++ b/docroot/modules/custom/uiowa_alerts/es6/alerts.es6
@@ -13,6 +13,7 @@
         const updateAlerts = () => {
           // Get the alerts feed and track IDs as "new" alerts.
           $.ajax({
+            cache: false,
             url: settings.uiowaAlerts.source,
             dataType: "json",
             success: (response) => {

--- a/docroot/sites/emergency.uiowa.edu/modules/emergency_core/src/EventSubscriber/CacheControlSubscriber.php
+++ b/docroot/sites/emergency.uiowa.edu/modules/emergency_core/src/EventSubscriber/CacheControlSubscriber.php
@@ -33,7 +33,7 @@ class CacheControlSubscriber implements EventSubscriberInterface {
     // Check the path and modify headers accordingly.
     if (str_starts_with($request->getPathInfo(), '/api/active')) {
       // Reduce cache, leaving some DoS protection.
-      $response->headers->set('Cache-Control', 'max-age=30, public');
+      $response->headers->set('Cache-Control', 'max-age=30, must-revalidate, public');
     }
   }
 


### PR DESCRIPTION
Relates to https://github.com/uiowa/uiowa/issues/8336
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

Based on https://github.com/uiowa/uiowa/issues/8336#issuecomment-2556936671, I'd like to send this change out for live testing. I have deployed this out to develop, but unless your browser is still caching the old cache-control header, this near impossible to test.

Otherwise, I have fairly high confidence that this will resolve itself on Signage and SiteNow v2/v3 in less than a month as cache/varnish clears on websites and the previous max-age expires. Adding the must-revalidate though will help us in the future if there are further endpoint changes and we want consumers to get the latest.

My understanding is that this change will enforce stricter revalidation rules to reduce the risk of stale data on the consumer end. If it has the max-age, it will respect that. If it sees must-revalidate it will look at the rest of the response to see if there is a change (e.g. etag, last-updated, new content in the json array).

<img width="1279" alt="Screenshot 2024-12-20 at 6 30 40 AM" src="https://github.com/user-attachments/assets/12af10f6-2070-4797-a313-601cff821a98" />
<img width="1280" alt="Screenshot 2024-12-20 at 10 46 36 AM" src="https://github.com/user-attachments/assets/71338fa9-1d9a-49a2-86a6-cedc14cce34e" />

