### PR TITLE
[Commencement] Skip deleting imported events

### DIFF
--- a/docroot/modules/custom/uiowa_core/src/EntityProcessorBase.php
+++ b/docroot/modules/custom/uiowa_core/src/EntityProcessorBase.php
@@ -69,6 +69,13 @@ abstract class EntityProcessorBase implements EntityProcessorInterface {
   protected $skipped = 0;
 
   /**
+   * Whether to skip deletion of entities.
+   *
+   * @var bool
+   */
+  protected $skipDelete = FALSE;
+
+  /**
    * The entity field/property that is used to match records to entities.
    *
    * @var string
@@ -204,7 +211,7 @@ abstract class EntityProcessorBase implements EntityProcessorInterface {
     }
 
     // Loop through to remove nodes that no longer exist in API data.
-    if ($this->getEntityIds()) {
+    if (!$this->skipDelete && $this->getEntityIds()) {
       foreach ($this->keyMap as $name => $nid) {
         if (!in_array($name, $this->processedRecords)) {
           $entity = $this->existingNodes[$nid] ?? $storage->load($nid);

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventsProcessor.php
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventsProcessor.php
@@ -28,6 +28,8 @@ class EventsProcessor extends EntityProcessorBase {
    */
   protected $apiRecordSyncKey = 'id';
 
+  protected $skipDelete = TRUE;
+
   /**
    * A reusable timezone object.
    *

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventsProcessor.php
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventsProcessor.php
@@ -28,6 +28,9 @@ class EventsProcessor extends EntityProcessorBase {
    */
   protected $apiRecordSyncKey = 'id';
 
+  /**
+   * {@inheritdoc}
+   */
   protected $skipDelete = TRUE;
 
   /**


### PR DESCRIPTION
Related to #8358 

# How to test
- Check that this resolves the issue with events being deleted on the commencement site.
- Check that this change does not prevent other importers from deleting imported content. Spot checking (vs checking every importer) is fine.
