### PR TITLE
Update uiowa_profiles.libraries.yml

### DIFF
--- a/docroot/modules/custom/uiowa_profiles/uiowa_profiles.libraries.yml
+++ b/docroot/modules/custom/uiowa_profiles/uiowa_profiles.libraries.yml
@@ -11,10 +11,10 @@ client.test:
     gpl-compatible: true
   js:
     js/uiowa-profiles.js: { preprocess: true }
-    https://cdn.jsdelivr.net/npm/vue@3.3/dist/vue.global.min.js: { type: external, minified: true }
-    https://cdn.jsdelivr.net/npm/vue-router@4.2/dist/vue-router.global.min.js: { type: external, minified: true }
+    https://cdn.jsdelivr.net/npm/vue@3.5/dist/vue.global.min.js: { type: external, minified: true }
+    https://cdn.jsdelivr.net/npm/vue-router@4.5/dist/vue-router.global.min.js: { type: external, minified: true }
     https://cdn.jsdelivr.net/npm/vue-demi@0.14/lib/index.iife.min.js: { type: external, minified: true }
-    https://cdn.jsdelivr.net/npm/pinia@2.1/dist/pinia.iife.min.js: { type: external, minified: true }
+    https://cdn.jsdelivr.net/npm/pinia@2.3/dist/pinia.iife.min.js: { type: external, minified: true }
     https://profiles-test.uiowa.edu/api/lib/profiles-client.umd.js: { type: external, minified: true }
   dependencies:
     - core/drupalSettings
@@ -32,10 +32,10 @@ client.prod:
     gpl-compatible: true
   js:
     js/uiowa-profiles.js: { preprocess: true }
-    https://cdn.jsdelivr.net/npm/vue@3.3/dist/vue.global.min.js: { type: external, minified: true }
-    https://cdn.jsdelivr.net/npm/vue-router@4.2/dist/vue-router.global.min.js: { type: external, minified: true }
+    https://cdn.jsdelivr.net/npm/vue@3.5/dist/vue.global.min.js: { type: external, minified: true }
+    https://cdn.jsdelivr.net/npm/vue-router@4.5/dist/vue-router.global.min.js: { type: external, minified: true }
     https://cdn.jsdelivr.net/npm/vue-demi@0.14/lib/index.iife.min.js: { type: external, minified: true }
-    https://cdn.jsdelivr.net/npm/pinia@2.1/dist/pinia.iife.min.js: { type: external, minified: true }
+    https://cdn.jsdelivr.net/npm/pinia@2.3/dist/pinia.iife.min.js: { type: external, minified: true }
     https://profiles.uiowa.edu/api/lib/profiles-client.umd.js: { type: external, minified: true }
   dependencies:
     - core/drupalSettings


### PR DESCRIPTION
Updating UI Profiles' library dependencies. 

- Vue 3.5
- Vue Router 4.5
- Pinia 2.3

# How to test

These changes will need to be coordinated with a UI Profiles deployment. The changes to profiles are live on profiles-test. I would like to test the change on a Drupal site before we move to production. I would be happy testing on [Education's dev site](https://education.dev.drupal.uiowa.edu/directory/) if possible.
