### PR TITLE
hotfix - updated config ignore setting for webform ais rfi

### DIFF
--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -24,6 +24,7 @@ ignored_config_entities:
   - 'config_split.config_split.sitenow_intranet:status'
   - 'config_split.config_split.sitenow_migrate:status'
   - 'config_split.config_split.sitenow_v2:status'
+  - 'config_split.config_split.sitenow_webform_ais_rfi:status'
   - 'config_split.config_split.thesis_defense:status'
   - 'config_split.config_split.topic_page:status'
   - 'config_split.config_split.uiowa_graph:status'


### PR DESCRIPTION
# How to test

- Sync any site. 
- Turn on site now webform AIS RFI feature split. 
- Try  `drush cim` on the site. 
- See if feature stay enabled.
