### PR TITLE
[Bug Hotfix] Fix for chrome and edge modal

### DIFF
--- a/docroot/themes/custom/uids_base/scss/admin.scss
+++ b/docroot/themes/custom/uids_base/scss/admin.scss
@@ -74,6 +74,6 @@ $imgpath: '../../uids/assets/images';
 
 // Set minimum height for edge and chrome browsers.
 .ui-dialog #drupal-modal.ui-dialog-content.ui-widget-content {
-  min-height: 500px !important;
+  min-height: 70vh!important;
 }
 

--- a/docroot/themes/custom/uids_base/scss/admin.scss
+++ b/docroot/themes/custom/uids_base/scss/admin.scss
@@ -71,3 +71,9 @@ $imgpath: '../../uids/assets/images';
 .layout-builder .layout-builder-block.block-inline-blockuiowa-card .card.borderless:not([class*="bg--"]) {
   min-height: 120px;
 }
+
+// Set minimum height for edge and chrome browsers.
+.ui-dialog #drupal-modal.ui-dialog-content.ui-widget-content {
+  min-height: 500px !important;
+}
+


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/8442. 

# How to test
```
ddev blt frontend && ddev blt ds --site=international.uiowa.edu && ddev drush @international.local uli /
```

- Try removing image from card on home page and add a new one.  Compare against prod and confirm that media modal is similar size.  
- Resize browser to all sorts of widths and compare against prod.  Make sure they look relatively similar in size. 

# Test on Windows

1. Download Windows App from Self Service
2. Start Remote Desktop Connection for vper-osc-100.iowa.uiowa.edu
3. Open Edge or Chrome and try adding media to a card on the home page of https://international.uiowa.edu/node/1/layout
4. Confirm that Media Library Modal is sitting below the viewport and that you can't move the modal or get to the insert media buttons
5. Try to upload a new image and confirm that the Media Library Modal collapses to 14px in height. 
6. Open devtools and with devtools inspect modal and click into modal CSS and add 
```
.ui-dialog #drupal-modal.ui-dialog-content.ui-widget-content {
  min-height: 70vh!important;
}
```
7. Close x on modal and close devtools and click "Add Media" again and run through the steps above.  Confirm that modal is centered and visible and does not look like screenshots on issue: https://github.com/uiowa/uiowa/issues/8442. 
