### PR TITLE
[Bug Hotfix] Image block caption bug fix

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/image.scss
+++ b/docroot/themes/custom/uids_base/scss/components/image.scss
@@ -1,3 +1,6 @@
+@import "uids/scss/abstracts/_variables.scss";
+@import "uids/scss/abstracts/_utilities.scss";
+
 .block-inline-blockuiowa-image {
   img {
     width: 100%;

--- a/docroot/themes/custom/uids_base/scss/components/image.scss
+++ b/docroot/themes/custom/uids_base/scss/components/image.scss
@@ -10,3 +10,9 @@
     opacity: .6;
   }
 }
+
+figure.block-inline-blockuiowa-image.caption {
+  @include breakpoint(sm) {
+    width: 100%;
+  }
+}

--- a/docroot/themes/custom/uids_base/scss/media/media--type-image.scss
+++ b/docroot/themes/custom/uids_base/scss/media/media--type-image.scss
@@ -76,6 +76,12 @@
   }
 }
 
+figure.caption {
+  @include breakpoint(sm) {
+    width: 100%;
+  }
+}
+
 // Absolutely position caption if cover option is selected on image block.
 figure.element--cover {
   position: relative;


### PR DESCRIPTION
Fixes an issue where the image block was not filling the container when a caption is used. 

# How to test
```
ddev blt frontend && ddev blt ds --site=stories.uiowa.edu   && ddev drush @stories.local uli /node/46/layout
```

1. Set the container for the section with the large horizontal image to "Full width" and confirm that the image block and caption appear to stretch the entire width of the page. 


<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->


<!-- Include detailed steps for how to test this PR. -->
