### PR TITLE
[Facilities] Hide energy dashboard

### DIFF
--- a/docroot/sites/facilities.uiowa.edu/modules/facilities_core/src/Plugin/Block/AccessibilityLinks.php
+++ b/docroot/sites/facilities.uiowa.edu/modules/facilities_core/src/Plugin/Block/AccessibilityLinks.php
@@ -62,9 +62,10 @@ class AccessibilityLinks extends BlockBase {
       $url = 'https://uiadmin.maps.arcgis.com/apps/webappviewer/index.html?id=' . $link['id'] . '&query=Buildings,BuildingNumber,' . $building_number;
       $list_markup .= '<a class="bttn bttn--transparent bttn--tertiary bttn--small" href="' . $url . '">' . $link['label'] . '<i class="fa-solid fa-' . $link['icon'] . ' "></i></a>';
     }
-    if (!empty($energy_dashboard)) {
-      $list_markup .= '<a class="bttn bttn--transparent bttn--tertiary bttn--small" href="' . $energy_dashboard . '" aria-label="Energy Dashboard (Login Required)">' . 'Energy Dashboard' . '<i class="fa-solid fa-bolt-lightning"></i></a>';
-    }
+    // @todo Remove this completely or add back in as needed.
+    // if (!empty($energy_dashboard)) {
+    // $list_markup .= '<a class="bttn bttn--transparent bttn--tertiary bttn--small" href="' . $energy_dashboard . '" aria-label="Energy Dashboard (Login Required)">' . 'Energy Dashboard' . '<i class="fa-solid fa-bolt-lightning"></i></a>';
+    // }
     $list_markup .= '</div>';
 
     $build = [];


### PR DESCRIPTION
Resolves #8444

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

Code review

```
ddev blt ds --site=facilities.uiowa.edu && ddev drush @facilities.local uli /building/0001
```
See that there isn't an energy dashboard link, as compared to https://facilities.uiowa.edu/building/0001
Edit the Building and see that the energy dashboard link field is still present and filled with a value