### PR TITLE
[Featured content] Background colors

### DIFF
--- a/config/default/layout_builder_styles.style.block_background_style_black.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_black.yml
@@ -14,6 +14,7 @@ block_restrictions:
   - 'inline_block:uiowa_cta'
   - 'inline_block:uiowa_card'
   - 'inline_block:uiowa_events'
+  - 'inline_block:featured_content'
   - 'inline_block:uiowa_aggregator'
   - 'views_block:article_list_block-list_article'
   - 'views_block:page_list_block-list_page'

--- a/config/default/layout_builder_styles.style.block_background_style_gold.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_gold.yml
@@ -14,6 +14,7 @@ block_restrictions:
   - 'inline_block:uiowa_cta'
   - 'inline_block:uiowa_card'
   - 'inline_block:uiowa_events'
+  - 'inline_block:featured_content'
   - 'inline_block:uiowa_aggregator'
   - 'views_block:article_list_block-list_article'
   - 'views_block:page_list_block-list_page'

--- a/config/default/layout_builder_styles.style.block_background_style_gray.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_gray.yml
@@ -14,6 +14,7 @@ block_restrictions:
   - 'inline_block:uiowa_cta'
   - 'inline_block:uiowa_card'
   - 'inline_block:uiowa_events'
+  - 'inline_block:featured_content'
   - 'inline_block:uiowa_aggregator'
   - 'inline_block:uiowa_text_area'
   - 'views_block:article_list_block-list_article'

--- a/config/default/layout_builder_styles.style.block_background_style_light.yml
+++ b/config/default/layout_builder_styles.style.block_background_style_light.yml
@@ -11,6 +11,7 @@ block_restrictions:
   - 'inline_block:uiowa_banner'
   - 'inline_block:uiowa_card'
   - 'inline_block:uiowa_events'
+  - 'inline_block:featured_content'
   - 'inline_block:uiowa_aggregator'
   - 'inline_block:uiowa_text_area'
   - 'views_block:article_list_block-list_article'


### PR DESCRIPTION
Related to https://github.com/uiowa/uiowa/issues/5180. 

Stories has requested background color options for featured content. 

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt ds --site=stories.uiowa.edu && ddev drush @stories.local uli /template-01
```

1. Confirm that you can add a background color the the featured content block at the bottom of the page and it only adds background color to the card. 
2. Add multiple pieces of featured content and confirm grid and list versions show cards with background colors. 
3. Confirm default setting for featured content is still no background color. 
