### PR TITLE
[a11y] Academic dates card field fix

### DIFF
--- a/docroot/modules/custom/uiowa_maui/css/session-dates.css
+++ b/docroot/modules/custom/uiowa_maui/css/session-dates.css
@@ -1,7 +1,8 @@
 .hide-session-badges .card span.session {
   display: none;
 }
-
-.card span.badge {
-  margin-left: 0.5rem;
+.card .session span.badge {
+  margin: .3rem 0 .5rem;
+  display: block;
+  width: fit-content;
 }

--- a/docroot/modules/custom/uiowa_maui/src/Form/AcademicDatesForm.php
+++ b/docroot/modules/custom/uiowa_maui/src/Form/AcademicDatesForm.php
@@ -157,7 +157,7 @@ class AcademicDatesForm extends FormBase {
 
         // Group items by date.
         if (isset($form['dates-wrapper']['dates'][$key])) {
-          $form['dates-wrapper']['dates'][$key]['#subtitle'][] = $item;
+          $form['dates-wrapper']['dates'][$key]['#content'][] = $item;
         }
         else {
           $form['dates-wrapper']['dates'][$key] = [
@@ -167,7 +167,7 @@ class AcademicDatesForm extends FormBase {
               '@start' => date('F j, Y', $start),
               '@end' => $end === $start ? '' : ' - ' . date('F j, Y', $end),
             ]),
-            '#subtitle' => [$item],
+            '#content' => [$item],
           ];
         }
       }

--- a/docroot/modules/custom/uiowa_maui/uiowa_maui.module
+++ b/docroot/modules/custom/uiowa_maui/uiowa_maui.module
@@ -10,6 +10,6 @@
  */
 function uiowa_maui_preprocess_block(&$variables) {
   if ($variables['elements']['#plugin_id'] === 'uiowa_maui_academic_dates') {
-    $variables['attributes']['class'][] = 'list-container';
+    $variables['attributes']['class'][] = 'list-container list-container--list';
   }
 }


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/8495. 

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test
```
 ddev blt ds --site=grad.uiowa.edu && ddev drush @grad.local uli /node/1581      
```
1. Compare against https://github.com/uiowa/uiowa/issues/8495 and that it is using the card content slot for the date information.
2. Confirm there is space between each entry.
