### PR TITLE
Config split 2.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,7 @@
         "drupal/classy": "^1.0",
         "drupal/config_ignore": "3.0.0-beta2",
         "drupal/config_inspector": "^2.1",
-        "drupal/config_split": "^2.0@RC",
+        "drupal/config_split": "^2.0",
         "drupal/core-composer-scaffold": "^10.3",
         "drupal/core-recommended": "^10.3",
         "drupal/crop": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d0e5bf6e588e2adbe685ff23ababd323",
+    "content-hash": "29e44eb0aeb5487df37ac3b3cdf37bfa",
     "packages": [
         {
             "name": "acquia/blt",
@@ -4047,20 +4047,20 @@
         },
         {
             "name": "drupal/config_split",
-            "version": "2.0.0-rc4",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/config_split.git",
-                "reference": "2.0.0-rc4"
+                "reference": "2.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/config_split-2.0.0-rc4.zip",
-                "reference": "2.0.0-rc4",
-                "shasum": "d4c06efbadd34793b0c9b71772162057afa58111"
+                "url": "https://ftp.drupal.org/files/projects/config_split-2.0.2.zip",
+                "reference": "2.0.2",
+                "shasum": "efde01f790ca6f6023982e918fe51740da931d3e"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9 || ^10"
+                "drupal/core": "^8.8 || ^9 || ^10 || ^11"
             },
             "conflict": {
                 "drush/drush": "<10"
@@ -4075,11 +4075,11 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0-rc4",
-                    "datestamp": "1662235380",
+                    "version": "2.0.2",
+                    "datestamp": "1739381800",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "RC releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 },
                 "drush": {
@@ -23650,7 +23650,6 @@
         "acquia/blt-multisite": 20,
         "bower-asset/fontawesome": 20,
         "drupal/bigmenu": 5,
-        "drupal/config_split": 5,
         "drupal/default_content": 15,
         "drupal/diff": 10,
         "drupal/entity_usage": 10,

--- a/config/default/config_split.config_split.additional_person_types.yml
+++ b/config/default/config_split.config_split.additional_person_types.yml
@@ -7,6 +7,7 @@ label: 'Additional Person Types'
 description: 'Adding additional person types beyond standard types.'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/additional_person_types
 module: {  }

--- a/config/default/config_split.config_split.advanced_webform.yml
+++ b/config/default/config_split.config_split.advanced_webform.yml
@@ -7,6 +7,7 @@ label: 'Advanced Webform'
 description: 'Advanced webform settings.'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/advanced_webform
 module:

--- a/config/default/config_split.config_split.areas_of_study.yml
+++ b/config/default/config_split.config_split.areas_of_study.yml
@@ -7,6 +7,7 @@ label: 'Areas of Study'
 description: 'Areas of Study content type, views and related configuration.'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/areas_of_study
 module:

--- a/config/default/config_split.config_split.articles_narrow.yml
+++ b/config/default/config_split.config_split.articles_narrow.yml
@@ -7,6 +7,7 @@ label: 'Narrow Article'
 description: 'Enables the narrow article feature split'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/articles_narrow
 module: {  }

--- a/config/default/config_split.config_split.bigmenu.yml
+++ b/config/default/config_split.config_split.bigmenu.yml
@@ -7,6 +7,7 @@ label: Bigmenu
 description: Bigmenu
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/bigmenu
 module:

--- a/config/default/config_split.config_split.ccom.yml
+++ b/config/default/config_split.config_split.ccom.yml
@@ -7,6 +7,7 @@ label: CCOM
 description: ''
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/ccom
 module:

--- a/config/default/config_split.config_split.ccom_migrate.yml
+++ b/config/default/config_split.config_split.ccom_migrate.yml
@@ -7,6 +7,7 @@ label: 'CCOM Migrate'
 description: 'Content and files migrations for D7 CCOM sites.'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/ccom_migrate
 module:

--- a/config/default/config_split.config_split.ci.yml
+++ b/config/default/config_split.config_split.ci.yml
@@ -7,6 +7,7 @@ label: CI
 description: ''
 weight: 90
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/envs/ci
 module: {  }

--- a/config/default/config_split.config_split.contact.yml
+++ b/config/default/config_split.config_split.contact.yml
@@ -7,6 +7,7 @@ label: Contact
 description: 'Contact content type.'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/contact
 module: {  }

--- a/config/default/config_split.config_split.dev.yml
+++ b/config/default/config_split.config_split.dev.yml
@@ -7,6 +7,7 @@ label: Dev
 description: ''
 weight: 90
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/envs/dev
 module:

--- a/config/default/config_split.config_split.event.yml
+++ b/config/default/config_split.config_split.event.yml
@@ -7,6 +7,7 @@ label: Event
 description: 'Event content type.'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/event
 module:

--- a/config/default/config_split.config_split.grad_person_extended.yml
+++ b/config/default/config_split.config_split.grad_person_extended.yml
@@ -7,6 +7,7 @@ label: 'Grad - Person extended'
 description: 'Additional fields and functionality for the person content type on Grad websites.'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/grad_person_extended
 module:

--- a/config/default/config_split.config_split.local.yml
+++ b/config/default/config_split.config_split.local.yml
@@ -7,6 +7,7 @@ label: Local
 description: ''
 weight: 90
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/envs/local
 module:

--- a/config/default/config_split.config_split.p2lb.yml
+++ b/config/default/config_split.config_split.p2lb.yml
@@ -7,6 +7,7 @@ label: P2LB
 description: ''
 weight: 75
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/p2lb
 module:

--- a/config/default/config_split.config_split.periodical.yml
+++ b/config/default/config_split.config_split.periodical.yml
@@ -7,6 +7,7 @@ label: Periodical
 description: ''
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/periodical
 module:

--- a/config/default/config_split.config_split.prod.yml
+++ b/config/default/config_split.config_split.prod.yml
@@ -7,6 +7,7 @@ label: Prod
 description: ''
 weight: 90
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/envs/prod
 module:

--- a/config/default/config_split.config_split.profiles.yml
+++ b/config/default/config_split.config_split.profiles.yml
@@ -7,6 +7,7 @@ label: Profiles
 description: 'Profiles module and configuration. This feature requires an API key and previous data setup with Profiles team.'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/profiles
 module:

--- a/config/default/config_split.config_split.scholarship.yml
+++ b/config/default/config_split.config_split.scholarship.yml
@@ -7,6 +7,7 @@ label: Scholarship
 description: 'Scholarship content type.'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/scholarship
 module: {  }

--- a/config/default/config_split.config_split.sitenow_alerts.yml
+++ b/config/default/config_split.config_split.sitenow_alerts.yml
@@ -7,6 +7,7 @@ label: 'Sitenow Alerts'
 description: 'Alert content type.'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/sitenow_alerts
 module:

--- a/config/default/config_split.config_split.sitenow_intranet.yml
+++ b/config/default/config_split.config_split.sitenow_intranet.yml
@@ -7,6 +7,7 @@ label: Intranet
 description: 'Restrict access to entire bootstraped site via the sitenow_intranet module'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/sitenow_intranet
 module:

--- a/config/default/config_split.config_split.sitenow_migrate.yml
+++ b/config/default/config_split.config_split.sitenow_migrate.yml
@@ -7,6 +7,7 @@ label: 'SiteNow Migrate'
 description: 'Content and files migrations for D7 standard sites. Not required for custom site migrations.'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/sitenow_migrate
 module:

--- a/config/default/config_split.config_split.sitenow_v2.yml
+++ b/config/default/config_split.config_split.sitenow_v2.yml
@@ -7,6 +7,7 @@ label: 'SiteNow V2'
 description: 'Features related to Paragraph-based layout functionality.'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/sitenow_v2
 module:

--- a/config/default/config_split.config_split.sitenow_webform_ais_rfi.yml
+++ b/config/default/config_split.config_split.sitenow_webform_ais_rfi.yml
@@ -7,6 +7,7 @@ label: 'SiteNow Webform AIS RFI'
 description: 'Configuration for the SiteNow Webform AIS RFI module.'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/sitenow_webform_ais_rfi
 module:

--- a/config/default/config_split.config_split.stage.yml
+++ b/config/default/config_split.config_split.stage.yml
@@ -7,6 +7,7 @@ label: Stage
 description: ''
 weight: 90
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/envs/stage
 module:

--- a/config/default/config_split.config_split.thesis_defense.yml
+++ b/config/default/config_split.config_split.thesis_defense.yml
@@ -7,6 +7,7 @@ label: 'Grad - Thesis defense'
 description: 'Thesis defense content type.'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/thesis_defense
 module:

--- a/config/default/config_split.config_split.topic_page.yml
+++ b/config/default/config_split.config_split.topic_page.yml
@@ -7,6 +7,7 @@ label: 'Topic page'
 description: ''
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/topic_page
 module:

--- a/config/default/config_split.config_split.uiowa_graph.yml
+++ b/config/default/config_split.config_split.uiowa_graph.yml
@@ -7,6 +7,7 @@ label: Graph
 description: 'Enables the uiowa graph module'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/uiowa_graph
 module:

--- a/config/default/config_split.config_split.uiowa_hours.yml
+++ b/config/default/config_split.config_split.uiowa_hours.yml
@@ -7,6 +7,7 @@ label: 'Resource Hours'
 description: 'Resource Hours module and configuration.'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/features/uiowa_hours
 module:

--- a/config/default/config_split.config_split.uiowa_maui.yml
+++ b/config/default/config_split.config_split.uiowa_maui.yml
@@ -7,6 +7,7 @@ label: MAUI
 description: 'Enables the uiowa maui module'
 weight: 80
 stackable: false
+no_patching: false
 storage: folder
 folder: ../config/features/uiowa_maui
 module:

--- a/config/sites/admissions.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/admissions.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The admissions.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/admissions.uiowa.edu
 module:

--- a/config/sites/afr.fo.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/afr.fo.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: afr.fo.uiowa.edu
 description: 'The afr.fo.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/afr.fo.uiowa.edu
 module: {  }

--- a/config/sites/amcs.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/amcs.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: amcs.uiowa.edu
 description: 'The amcs.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/amcs.uiowa.edu
 module: {  }

--- a/config/sites/brand.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/brand.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The brand.uiowa.edu site split.'
 weight: 110
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/brand.uiowa.edu
 module:

--- a/config/sites/careers.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/careers.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: ''
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/careers.uiowa.edu
 module: {  }

--- a/config/sites/clas.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/clas.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: ''
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/clas.uiowa.edu
 module:

--- a/config/sites/classrooms.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/classrooms.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The classrooms.uiowa.edu site split.'
 weight: 67
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/classrooms.uiowa.edu
 module:

--- a/config/sites/commencement.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/commencement.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: commencement.uiowa.edu
 description: 'Site split for commencement.uiowa.edu'
 weight: 70
 stackable: false
+no_patching: false
 storage: folder
 folder: ../config/sites/commencement.uiowa.edu
 module:

--- a/config/sites/dentistry.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/dentistry.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The dentistry.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/dentistry.uiowa.edu
 module:

--- a/config/sites/emergency.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/emergency.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The emergency.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/emergency.uiowa.edu
 module:

--- a/config/sites/environmentalsciences.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/environmentalsciences.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: environmentalsciences.uiowa.edu
 description: 'Adding additional person types for Advisory Committee, Affiliated Faculty, and Directors.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/environmentalsciences.uiowa.edu
 module: {  }

--- a/config/sites/facilities.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/facilities.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: facilities.uiowa.edu
 description: 'Site split for facilities.uiowa.edu'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/facilities.uiowa.edu
 module:

--- a/config/sites/genetics.grad.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/genetics.grad.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The genetics.grad.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/genetics.grad.uiowa.edu
 module: {  }

--- a/config/sites/grad.admissions.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/grad.admissions.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The grad.admissions.uiowa.edu site split'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/grad.admissions.uiowa.edu
 module:

--- a/config/sites/grad.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/grad.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The grad.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/grad.uiowa.edu
 module:

--- a/config/sites/housing.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/housing.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The housing.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/housing.uiowa.edu
 module:

--- a/config/sites/hr.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/hr.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The hr.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/hr.uiowa.edu
 module:

--- a/config/sites/icsa.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/icsa.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The icsa.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/icsa.uiowa.edu
 module:

--- a/config/sites/ighn.international.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/ighn.international.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The ighn.international.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/ighn.international.uiowa.edu
 module:

--- a/config/sites/iisc.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/iisc.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: iisc.uiowa.edu
 description: 'Custom settings for iisc.uiowa.edu.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/iisc.uiowa.edu
 module:

--- a/config/sites/immuno.grad.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/immuno.grad.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The immuno.grad.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/immuno.grad.uiowa.edu
 module: {  }

--- a/config/sites/inrc.law.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/inrc.law.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The inrc.law.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/inrc.law.uiowa.edu
 module:

--- a/config/sites/iowasummerwritingfestival.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/iowasummerwritingfestival.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The iowasummerwritingfestival.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/iowasummerwritingfestival.uiowa.edu
 module:

--- a/config/sites/isa.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/isa.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: isa.uiowa.edu
 description: 'Adding additional person types for Directors, Mentors, Advisory Board, Executive Committee, and Alumni. Add additional fields to profiles for mentor entity reference and program year.'
 weight: 70
 stackable: false
+no_patching: false
 storage: folder
 folder: ../config/sites/isa.uiowa.edu
 module: {  }

--- a/config/sites/its.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/its.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The its.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/its.uiowa.edu
 module:

--- a/config/sites/iwp.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/iwp.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The iwp.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/iwp.uiowa.edu
 module:

--- a/config/sites/neuroscience.grad.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/neuroscience.grad.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: neuroscience.grad.uiowa.edu
 description: ''
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/neuroscience.grad.uiowa.edu
 module: {  }

--- a/config/sites/now.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/now.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The now.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/now.uiowa.edu
 module:

--- a/config/sites/oniowa.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/oniowa.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The oniowa.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/oniowa.uiowa.edu
 module:

--- a/config/sites/pharmacy.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/pharmacy.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The pharmacy.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/pharmacy.uiowa.edu
 module:

--- a/config/sites/policy.clas.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/policy.clas.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The policy.clas.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/policy.clas.uiowa.edu
 module:

--- a/config/sites/presidentialsearch.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/presidentialsearch.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The presidentialsearch.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/presidentialsearch.uiowa.edu
 module: {  }

--- a/config/sites/registrar.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/registrar.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: registrar.uiowa.edu
 description: 'Custom functionality for registrar.uiowa.edu.'
 weight: 70
 stackable: false
+no_patching: false
 storage: folder
 folder: ../config/sites/registrar.uiowa.edu
 module:

--- a/config/sites/sitenow.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/sitenow.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The sitenow.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/sitenow.uiowa.edu
 module:

--- a/config/sites/sppa.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/sppa.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The sppa.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/sppa.uiowa.edu
 module:

--- a/config/sites/tippie.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/tippie.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The tippie.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/tippie.uiowa.edu
 module:

--- a/config/sites/transportation.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/transportation.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The transportation.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/transportation.uiowa.edu
 module:

--- a/config/sites/uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/uiowa.edu
 module:

--- a/config/sites/uipress.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/uipress.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: uipress.uiowa.edu
 description: 'Custom settings for uipress.uiowa.edu.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/uipress.uiowa.edu
 module:

--- a/config/sites/wellbeing.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/wellbeing.uiowa.edu/config_split.config_split.site.yml
@@ -7,6 +7,7 @@ label: Site
 description: 'The wellbeing.uiowa.edu site split.'
 weight: 70
 stackable: true
+no_patching: false
 storage: folder
 folder: ../config/sites/wellbeing.uiowa.edu
 module:

--- a/docroot/modules/custom/engineering_migrate/config/split/config_split.config_split.engineering_migrate.yml
+++ b/docroot/modules/custom/engineering_migrate/config/split/config_split.config_split.engineering_migrate.yml
@@ -7,6 +7,7 @@ label: 'Engineering Migrate'
 description: 'Migrations for Engineering'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./modules/custom/engineering_migrate/config/split
 module:

--- a/docroot/modules/custom/grad_custom/grad_migrate/config/split/config_split.config_split.grad_migrate.yml
+++ b/docroot/modules/custom/grad_custom/grad_migrate/config/split/config_split.config_split.grad_migrate.yml
@@ -7,6 +7,7 @@ label: 'Grad Migrate'
 description: 'Migrations for the Grad College'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./modules/custom/grad_custom/grad_migrate/config/split
 module:

--- a/docroot/modules/custom/studentlife_migrate/config/split/config_split.config_split.studentlife_migrate.yml
+++ b/docroot/modules/custom/studentlife_migrate/config/split/config_split.config_split.studentlife_migrate.yml
@@ -7,6 +7,7 @@ label: 'Studentlife Migrate'
 description: 'Migrations for Student Life'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./modules/custom/studentlife_migrate/config/split
 module:

--- a/docroot/modules/custom/writinguniversity_migrate/config/split/config_split.config_split.writinguniversity_migrate.yml
+++ b/docroot/modules/custom/writinguniversity_migrate/config/split/config_split.config_split.writinguniversity_migrate.yml
@@ -7,6 +7,7 @@ label: 'Writing University Migrate'
 description: 'Migrations for the Writing University'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./modules/custom/writinguniversity_migrate/config/split
 module:

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_migrate/config/split/config_split.config_split.admissions_migrate.yml
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_migrate/config/split/config_split.config_split.admissions_migrate.yml
@@ -7,6 +7,7 @@ label: 'Admissions Migrate'
 description: 'Migrations for Admissions'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/admissions.uiowa.edu/modules/admissions_migrate/config/split
 module:

--- a/docroot/sites/classrooms.uiowa.edu/modules/classrooms_migrate/config/split/config_split.config_split.classrooms_migrate.yml
+++ b/docroot/sites/classrooms.uiowa.edu/modules/classrooms_migrate/config/split/config_split.config_split.classrooms_migrate.yml
@@ -6,6 +6,7 @@ label: 'Classrooms Migrate'
 description: 'Migrations for Classrooms'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/classrooms.uiowa.edu/modules/classrooms_migrate/config/split
 module:

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_migrate/config/split/config_split.config_split.commencement_migrate.yml
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_migrate/config/split/config_split.config_split.commencement_migrate.yml
@@ -6,6 +6,7 @@ label: 'Commencement Migrate'
 description: 'Migrations for Commencement'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/commencement.uiowa.edu/modules/commencement_migrate/config/split
 module:

--- a/docroot/sites/cs.uiowa.edu/modules/cs_migrate/config/split/config_split.config_split.cs_migrate.yml
+++ b/docroot/sites/cs.uiowa.edu/modules/cs_migrate/config/split/config_split.config_split.cs_migrate.yml
@@ -7,6 +7,7 @@ label: 'CS Migrate'
 description: 'Migrations for CS'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/cs.uiowa.edu/modules/cs_migrate/config/split
 module:

--- a/docroot/sites/education.uiowa.edu/modules/education_migrate/config/split/config_split.config_split.education_migrate.yml
+++ b/docroot/sites/education.uiowa.edu/modules/education_migrate/config/split/config_split.config_split.education_migrate.yml
@@ -7,6 +7,7 @@ label: 'Education Migrate'
 description: 'Migrations for Education'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/education.uiowa.edu/modules/education_migrate/config/split
 module:

--- a/docroot/sites/grad.admissions.uiowa.edu/modules/grad_admissions_migrate/config/split/config_split.config_split.grad_admissions_migrate.yml
+++ b/docroot/sites/grad.admissions.uiowa.edu/modules/grad_admissions_migrate/config/split/config_split.config_split.grad_admissions_migrate.yml
@@ -7,6 +7,7 @@ label: 'Graduate Admissions Migrate'
 description: ''
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/grad.admissions.uiowa.edu/modules/grad_admissions_migrate/config/split
 module:

--- a/docroot/sites/iisc.uiowa.edu/modules/iisc_migrate/config/split/config_split.config_split.iisc_migrate.yml
+++ b/docroot/sites/iisc.uiowa.edu/modules/iisc_migrate/config/split/config_split.config_split.iisc_migrate.yml
@@ -6,6 +6,7 @@ label: 'IISC Migrate'
 description: 'Migrations for IISC'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/iisc.uiowa.edu/modules/iisc_migrate/config/split
 module:

--- a/docroot/sites/inrc.law.uiowa.edu/modules/inrc_migrate/config/split/config_split.config_split.inrc_migrate.yml
+++ b/docroot/sites/inrc.law.uiowa.edu/modules/inrc_migrate/config/split/config_split.config_split.inrc_migrate.yml
@@ -6,6 +6,7 @@ label: 'INRC Migrate'
 description: 'Migrations for INRC'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/inrc.uiowa.edu/modules/inrc_migrate/config/split
 module:

--- a/docroot/sites/international.uiowa.edu/modules/international_migrate/config/split/config_split.config_split.international_migrate.yml
+++ b/docroot/sites/international.uiowa.edu/modules/international_migrate/config/split/config_split.config_split.international_migrate.yml
@@ -7,6 +7,7 @@ label: 'International Migrate'
 description: 'Migrations for International'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/international.uiowa.edu/modules/international_migrate/config/split
 module:

--- a/docroot/sites/iowajpec.org/modules/iowajpec_migrate/config/split/config_split.config_split.iowajpec_migrate.yml
+++ b/docroot/sites/iowajpec.org/modules/iowajpec_migrate/config/split/config_split.config_split.iowajpec_migrate.yml
@@ -6,6 +6,7 @@ label: 'Iowa JPEC Migrate'
 description: 'Migrations for Iowa JPEC'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/iowajpec.org/modules/iowajpec_migrate/config/split
 module:

--- a/docroot/sites/its.uiowa.edu/modules/its_migrate/config/split/config_split.config_split.its_migrate.yml
+++ b/docroot/sites/its.uiowa.edu/modules/its_migrate/config/split/config_split.config_split.its_migrate.yml
@@ -6,6 +6,7 @@ label: 'ITS Migrate'
 description: 'Migrations for ITS'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/its.uiowa.edu/modules/its_migrate/config/split
 module:

--- a/docroot/sites/itu.physics.uiowa.edu/modules/itu_physics_migrate/config/split/config_split.config_split.itu_physics_migrate.yml
+++ b/docroot/sites/itu.physics.uiowa.edu/modules/itu_physics_migrate/config/split/config_split.config_split.itu_physics_migrate.yml
@@ -7,6 +7,7 @@ label: 'ITU Physics Migrate'
 description: 'Migrations for ITU Physics'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/itu.physics.uiowa.edu/modules/itu_physics_migrate/config/split
 module:

--- a/docroot/sites/iwp.uiowa.edu/modules/iwp_migrate/config/split/config_split.config_split.iwp_migrate.yml
+++ b/docroot/sites/iwp.uiowa.edu/modules/iwp_migrate/config/split/config_split.config_split.iwp_migrate.yml
@@ -6,6 +6,7 @@ label: 'IWP Migrate'
 description: 'Migrations for IWP'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/iwp.uiowa.edu/modules/iwp_migrate/config/split
 module:

--- a/docroot/sites/neuroscience.grad.uiowa.edu/modules/gradneuroscience_migrate/config/split/config_split.config_split.gradneuroscience_migrate.yml
+++ b/docroot/sites/neuroscience.grad.uiowa.edu/modules/gradneuroscience_migrate/config/split/config_split.config_split.gradneuroscience_migrate.yml
@@ -7,6 +7,7 @@ label: 'gradneuroscience Migrate'
 description: 'Migrations for gradneuroscience'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/neuroscience.grad.uiowa.edu/modules/gradneuroscience_migrate/config/split
 module:

--- a/docroot/sites/now.uiowa.edu/modules/now_migrate/config/split/config_split.config_split.now_migrate.yml
+++ b/docroot/sites/now.uiowa.edu/modules/now_migrate/config/split/config_split.config_split.now_migrate.yml
@@ -6,6 +6,7 @@ label: 'Iowa Now Migrate'
 description: 'Migrations for Iowa Now'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/now.uiowa.edu/modules/now_migrate/config/split
 module:

--- a/docroot/sites/obermann.uiowa.edu/modules/obermann_migrate/config/split/config_split.config_split.obermann_migrate.yml
+++ b/docroot/sites/obermann.uiowa.edu/modules/obermann_migrate/config/split/config_split.config_split.obermann_migrate.yml
@@ -7,6 +7,7 @@ label: 'Obermann Migrate'
 description: 'Migrations for Obermann'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/obermann.uiowa.edu/modules/obermann_migrate/config/split
 module:

--- a/docroot/sites/pharmacy.uiowa.edu/modules/pharmacy_migrate/config/split/config_split.config_split.pharmacy_migrate.yml
+++ b/docroot/sites/pharmacy.uiowa.edu/modules/pharmacy_migrate/config/split/config_split.config_split.pharmacy_migrate.yml
@@ -7,6 +7,7 @@ label: 'Pharmacy Migrate'
 description: 'Migrations for Pharmacy'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/pharmacy.uiowa.edu/modules/pharmacy_migrate/config/split
 module:

--- a/docroot/sites/physics.uiowa.edu/modules/physics_migrate/config/split/config_split.config_split.physics_migrate.yml
+++ b/docroot/sites/physics.uiowa.edu/modules/physics_migrate/config/split/config_split.config_split.physics_migrate.yml
@@ -7,6 +7,7 @@ label: 'Physics Migrate'
 description: 'Migrations for Physics'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/physics.uiowa.edu/modules/physics_migrate/config/split
 module:

--- a/docroot/sites/research.uiowa.edu/modules/research_migrate/config/split/config_split.config_split.research_migrate.yml
+++ b/docroot/sites/research.uiowa.edu/modules/research_migrate/config/split/config_split.config_split.research_migrate.yml
@@ -6,6 +6,7 @@ label: 'Research Migrate'
 description: 'Migrations for Research'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/research.uiowa.edu/modules/research_migrate/config/split
 module:

--- a/docroot/sites/slis.uiowa.edu/modules/slis_migrate/config/split/config_split.config_split.slis_migrate.yml
+++ b/docroot/sites/slis.uiowa.edu/modules/slis_migrate/config/split/config_split.config_split.slis_migrate.yml
@@ -7,6 +7,7 @@ label: 'SLIS Migrate'
 description: 'Migrations for SLIS'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/slis.uiowa.edu/modules/slis_migrate/config/split
 module:

--- a/docroot/sites/sppa.uiowa.edu/modules/sppa_migrate/config/split/config_split.config_split.sppa_migrate.yml
+++ b/docroot/sites/sppa.uiowa.edu/modules/sppa_migrate/config/split/config_split.config_split.sppa_migrate.yml
@@ -7,6 +7,7 @@ label: 'SPPA Migrate'
 description: 'Migrations for SPPA'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/sppa.uiowa.edu/modules/sppa_migrate/config/split
 module:

--- a/docroot/sites/tippie.uiowa.edu/modules/tippie_migrate/config/split/config_split.config_split.tippie_migrate.yml
+++ b/docroot/sites/tippie.uiowa.edu/modules/tippie_migrate/config/split/config_split.config_split.tippie_migrate.yml
@@ -6,6 +6,7 @@ label: 'Tippie Migrate'
 description: 'Migrations for Tippie'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/tippie.uiowa.edu/modules/tippie_migrate/config/split
 module:

--- a/docroot/sites/transportation.uiowa.edu/modules/transportation_migrate/config/split/config_split.config_split.transportation_migrate.yml
+++ b/docroot/sites/transportation.uiowa.edu/modules/transportation_migrate/config/split/config_split.config_split.transportation_migrate.yml
@@ -7,6 +7,7 @@ label: 'Parking and Transportation Migrate'
 description: 'Migrations for Transportation'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/transportation.uiowa.edu/modules/transportation_migrate/config/split
 module:

--- a/docroot/sites/uipress.uiowa.edu/modules/uipress_migrate/config/split/config_split.config_split.uipress_migrate.yml
+++ b/docroot/sites/uipress.uiowa.edu/modules/uipress_migrate/config/split/config_split.config_split.uipress_migrate.yml
@@ -6,6 +6,7 @@ label: 'UI Press Migrate'
 description: 'Migrations for UI Press'
 weight: 80
 stackable: true
+no_patching: false
 storage: folder
 folder: ./sites/uipress.uiowa.edu/modules/uipress_migrate/config/split
 module:


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test
- Code review
I've ran a `blt dsa` on these sites with no errors.

<details>

```
  - default # v3 default
#  - 91stmeridian.iwp.uiowa.edu # v3 custom, periodical
  - accreditation.uiowa.edu
#  - admissions.uiowa.edu # v3 custom, scholarships, AoS, event, student profiles
  - afr.fo.uiowa.edu # v3 custom, media path.
  - amcs.uiowa.edu # v3 custom CLAS
  - brand.uiowa.edu # Previously v2 custom, lockup generator, workbench_email
  - careers.uiowa.edu # v3 custom aggregator settings
  - clas.uiowa.edu # v3 custom AoS modifications.
  - connect.studentlife.uiowa.edu # v3 default, intranet feature split
  - classrooms.uiowa.edu # v3 custom
  - commencement.uiowa.edu # v3 custom
  - cs.uiowa.edu
#  - coronavirus.uiowa.edu # v3 custom? after being a hybrid v2/v3.
  - dentistry.uiowa.edu # v3 uiowa_profiles
  - distance.uiowa.edu # v3 default, AoS feature split
  - diversity.uiowa.edu # v3 default, complex webforms
  - docs.uiowa.edu # v3 sitenow_intranet, documentation site.
  - education.uiowa.edu # v3 default, AoS, uiowa_profiles feature splits.
  - emergency.uiowa.edu # v3 custom hawk alerts endpoint.
  - environmentalsciences.uiowa.edu # v3 custom CLAS
  - facilities.uiowa.edu # v3 custom
  - genetics.grad.uiowa.edu # v3 custom
  - gis.sites.uiowa.edu # v2 default (joe's site)
  - grad.admissions.uiowa.edu # v3 custom, estimated costs, AoS
  - grad.uiowa.edu # v3 custom, thesis defense calendar, custom person, maui
  - hawkeyemarchingband.uiowa.edu # v2 default but used a lot of components, highly visual
  - housing.uiowa.edu # v3 custom, res_hall content type
  - hr.uiowa.edu # v2 custom, related content, unit contacts, old uiowa_bootstrap site now on uids_base.
  - icsa.uiowa.edu # v3 custom CLAS
  - ighn.international.uiowa.edu # v2 custom, ighn_person
  - iisc.uiowa.edu # v3 custom
  - ilr.law.uiowa.edu # v3, article_narrow
  - immuno.grad.uiowa.edu # v3 custom, person_extended
  - inrc.law.uiowa.edu # v3 custom, local events modified.
  - iowasummerwritingfestival.uiowa.edu # v3 custom, event feature extended.
  - international.uiowa.edu
  - isa.uiowa.edu # v3 custom, CLAS
  - its.uiowa.edu # v3 custom
  - iwp.uiowa.edu # v3 custom writer bio
  - law.uiowa.edu # v3 standard?
  - iowajpec.org
  - inrc.law.uiowa.edu
  - library.law.uiowa.edu # v3 default, hours and search block
  - miles.lab.uiowa.edu
  - neuroscience.grad.uiowa.edu # v3 custom
  - now.uiowa.edu # v3 custom article content type
  - obermann.uiowa.edu
  - oniowa.uiowa.edu # event feature
  - physics.uiowa.edu
  - pharmacy.uiowa.edu # v3 custom, uiowa_profiles
  - policy.clas.uiowa.edu # v3 custom, book CLAS
  - presidentialsearch.uiowa.edu # v3 custom, restricted webforms
  - research.uiowa.edu
  - recserv.uiowa.edu # v3 custom uiowa_hours
  - registrar.uiowa.edu # v3 custom
  - sandbox.uiowa.edu # v3 default kitchen sink
  - slis.uiowa.edu
  - sitenow.uiowa.edu # v3 custom, dispatch sign-up form, webform logic
  - sppa.uiowa.edu # v3 custom CLAS
  - tippie.uiowa.edu # v3 custom remote_post/pardot
  - transportation.uiowa.edu # v3 custom, calculator
  - uiowa.edu # v3 custom
  - uipress.uiowa.edu # v3 custom, books/tabs
  - webcommunity.sites.uiowa.edu # v3 default
  - whitmanweb.iwp.uiowa.edu # v3 default, large menu.
  - writinguniversity.org
  - wellbeing.uiowa.edu
 ```
</details>

- Review the items with today's date on them after I ran `ddev blt uiowa:usplits:site` and `ddev blt uiowa:usplits:site`: https://github.com/uiowa/uiowa/issues/8137
