### PR TITLE
Add rel=”nofollow” to footer login link

### DIFF
--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -1112,6 +1112,7 @@ function uiowa_core_preprocess_block(&$variables) {
               'bttn--primary',
               'bttn--caps',
             ],
+            'rel' => 'nofollow',
           ],
           '#cache' => [
             'max-age' => 0,

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -369,6 +369,9 @@ function uids_base_preprocess_page(&$variables) {
         '#type' => 'link',
         '#title' => t('Admin Login'),
         '#url' => $login_url,
+        '#attributes' => [
+          'rel' => 'nofollow',
+        ]
       ];
     }
   }


### PR DESCRIPTION
Resolves #3057 

# How to test
- Sync a standard site, like `ddev blt ds --site=sandbox.uiowa.edu`
- go to the site without logging in - https://sandbox.uiowa.ddev.site/
- Inspect the Admin Login link in the footer. The `<a href>` tag should now include `rel="nofollow"`
- Sync an intranet site, like `ddev blt ds --site=docs.uiowa.edu`
- Again go to the site without logging in - https://docs.uiowa.ddev.site/
- Inspect the HawkID Login button. The `<a href>` tag should now include `rel="nofollow"`
