### PR TITLE
[Bug] Added workaround leaflet init library to pharmacy and admissions maps

### DIFF
--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
@@ -788,7 +788,6 @@ function admissions_core_views_pre_render(ViewExecutable $view) {
       case 'block_counselors':
       case 'page_counselors':
         $view->element['#attached']['library'][] = 'admissions_core/person';
-        $view->element['#attached']['library'][] = 'uids_base/leaflet_attach';
         break;
     }
   }

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/admissions_core.module
@@ -788,6 +788,7 @@ function admissions_core_views_pre_render(ViewExecutable $view) {
       case 'block_counselors':
       case 'page_counselors':
         $view->element['#attached']['library'][] = 'admissions_core/person';
+        $view->element['#attached']['library'][] = 'uids_base/leaflet_attach';
         break;
     }
   }

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/js/counselors-map.js
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/js/counselors-map.js
@@ -12,7 +12,7 @@
         let geojson;
 
         // Establish map and prevent scrollwheel zooming.
-        let map = L.map("admissions-counselors-map").setView([37.8, -96], 4);
+        let map = L.map("leaflet-map-admissions-counselors-map").setView([37.8, -96], 4);
         map.scrollWheelZoom.disable();
 
         // Check for counselor data.

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/counselors-map.scss
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/sass/counselors-map.scss
@@ -1,9 +1,9 @@
-#admissions-counselors-map {
+#leaflet-map-admissions-counselors-map {
   min-height: 400px;
   width: 100%;
   height: 100%;
 }
-#admissions-counselors-map .info {
+#leaflet-map-admissions-counselors-map .info {
   padding: 1rem;
   background: white;
 }

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/src/Plugin/Block/AdmissionsCounselorsMapBlock.php
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/src/Plugin/Block/AdmissionsCounselorsMapBlock.php
@@ -77,7 +77,7 @@ class AdmissionsCounselorsMapBlock extends BlockBase implements ContainerFactory
 
     return [
       '#type' => 'markup',
-      '#markup' => $this->t('<div id="admissions-counselors-map">&nbsp;</div>'),
+      '#markup' => $this->t('<div id="leaflet-map-admissions-counselors-map">&nbsp;</div>'),
       '#cache' => [
         'tags' => ['node_type:person'],
       ],

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/src/Plugin/Block/AdmissionsCounselorsMapBlock.php
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/src/Plugin/Block/AdmissionsCounselorsMapBlock.php
@@ -85,6 +85,7 @@ class AdmissionsCounselorsMapBlock extends BlockBase implements ContainerFactory
         'library' => [
           'leaflet/leaflet',
           'admissions_core/counselors-map',
+          'uids_base/leaflet_attach',
         ],
         'drupalSettings' => [
           'admissions_core' => [

--- a/docroot/sites/pharmacy.uiowa.edu/modules/pharmacy_core/js/palliative-grad-map.js
+++ b/docroot/sites/pharmacy.uiowa.edu/modules/pharmacy_core/js/palliative-grad-map.js
@@ -12,7 +12,7 @@
         let geojson;
 
         // Establish map and prevent scrollwheel zooming.
-        let map = L.map("pharmacy-palliative-grad-map", {
+        let map = L.map("leaflet-map-pharmacy-palliative-grad-map", {
           zoomSnap: 0.25
         }).setView([37.8, -96], 3.75);
         map.scrollWheelZoom.disable();

--- a/docroot/sites/pharmacy.uiowa.edu/modules/pharmacy_core/pharmacy_core.module
+++ b/docroot/sites/pharmacy.uiowa.edu/modules/pharmacy_core/pharmacy_core.module
@@ -65,6 +65,7 @@ function pharmacy_core_views_pre_render(ViewExecutable $view) {
         // Case 'page_palliative_grad':
         $view->element['#attached']['library'][] = 'pharmacy_core/palliative-grad-list';
         $view->element['#attached']['library'][] = 'pharmacy_core/person';
+        $view->element['#attached']['library'][] = 'uids_base/leaflet_attach';
         break;
     }
   }

--- a/docroot/sites/pharmacy.uiowa.edu/modules/pharmacy_core/sass/palliative-grad-map.scss
+++ b/docroot/sites/pharmacy.uiowa.edu/modules/pharmacy_core/sass/palliative-grad-map.scss
@@ -1,7 +1,7 @@
 @use "../../../../../themes/custom/uids_base/uids/scss/abstracts/_variables.scss";
 @use "../../../../../themes/custom/uids_base/uids/scss/abstracts/_utilities.scss";
 
-#pharmacy-palliative-grad-map {
+#leaflet-map-pharmacy-palliative-grad-map {
   min-height: 400px;
   width: 100%;
   height: 100%;
@@ -9,7 +9,7 @@
     height: 700px;
   }
 }
-#pharmacy-palliative-grad-map .info {
+#leaflet-map-pharmacy-palliative-grad-map .info {
   padding: 1rem;
   background: white;
 }

--- a/docroot/sites/pharmacy.uiowa.edu/modules/pharmacy_core/src/Plugin/Block/PalliativeGradMapBlock.php
+++ b/docroot/sites/pharmacy.uiowa.edu/modules/pharmacy_core/src/Plugin/Block/PalliativeGradMapBlock.php
@@ -77,7 +77,7 @@ class PalliativeGradMapBlock extends BlockBase implements ContainerFactoryPlugin
 
     return [
       '#type' => 'markup',
-      '#markup' => $this->t('<div id="pharmacy-palliative-grad-map">&nbsp;</div>'),
+      '#markup' => $this->t('<div id="leaflet-map-pharmacy-palliative-grad-map">&nbsp;</div>'),
       '#cache' => [
         'tags' => ['node_type:person'],
       ],


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt frontend && ddev blt ds --site=admissions.uiowa.edu && ddev drush @admissions.local uli /counselors
```
1. In Chrome, open page in incognito window and compare to prod.  Confirm that map is loading with no console errors. Test other browsers and confirm they are working as well. 

```
ddev blt frontend && ddev blt ds --site=pharmacy.uiowa.edu && ddev drush @pharmacy.local uli /pharmd/dual_cert/palliative/certificate_graduates
```
1. In Chrome, open page in incognito window and compare to prod.  Confirm that map is loading with no console errors.  Test other browsers and confirm they are working as well. 