### PR TITLE
Ignore field teaser in Find Text

### DIFF
--- a/config/default/find_text.settings.yml
+++ b/config/default/find_text.settings.yml
@@ -50,4 +50,5 @@ tables_to_skip:
   - block_content_field_data
   - node_revision
   - paragraphs_item_field_data
+  - node__field_teaser
 save_as_csv: 0

--- a/config/features/sitenow_v2/config_split.patch.find_text.settings.yml
+++ b/config/features/sitenow_v2/config_split.patch.find_text.settings.yml
@@ -1,0 +1,4 @@
+adding: {  }
+removing:
+  tables_to_skip:
+    - node__field_teaser

--- a/config/features/sitenow_v2/config_split.patch.user.role.editor.yml
+++ b/config/features/sitenow_v2/config_split.patch.user.role.editor.yml
@@ -2,14 +2,8 @@ adding: {  }
 removing:
   dependencies:
     config:
-      - core.entity_view_display.fragment.region_item.default
       - core.entity_view_display.node.page.default
   permissions:
-    - 'access fragments overview'
     - 'configure editable page node layout overrides'
-    - 'configure editable region_item fragment layout overrides'
     - 'create and edit custom blocks'
-    - 'create region_item fragments'
-    - 'update own region_item fragments'
-    - 'update region_item fragments'
     - 'view region_item fragments'


### PR DESCRIPTION
Resolves #8594 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

Field Teasers are still showing up in Find Text results, though the field is no longer used nor accessible by webmasters in V3

# How to test

<!-- Include detailed steps for how to test this PR. -->
On main, sync a site and do a Find Text search for something that will match a field teaser (pharmacy.uiowa.edu, search for "diversity"), and see a "Teaser" result
Check out this branch, do a config import
Repeat the search, and no longer see a "Teaser" result

Sync a V2 site and perform a Find Text search for something that will match a field teaser, and see that a "Teaser" result still appears
(Example: `ddev blt ds --site=hawkeyemarchingband.uiowa.edu && ddev drush @hawkeyemarchingband.local uli /node/1/edit`
Add a unique text string to Content Description, search for it in Find Text, and see that you get a result)