### PR TITLE
Removed `Layout: 3x2`, `Layout 3x2 stacked` , `Layout: 1x3` styles for new layouts 

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -185,11 +185,6 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
         switch ($block->getPluginId()) {
           case 'inline_block:uiowa_banner':
 
-            // Hide content position style until it can be removed.
-            if (isset($form['layout_builder_style_banner_type'])) {
-              $form['layout_builder_style_banner_type']['#access'] = FALSE;
-            }
-
             // We provide a field that provides background options, so
             // this is hidden.
             if (isset($form['layout_builder_style_background'])) {

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -184,6 +184,12 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
         // Form modifications per block plugin and bundle.
         switch ($block->getPluginId()) {
           case 'inline_block:uiowa_banner':
+
+            // Hide content position style until it can be removed.
+            if (isset($form['layout_builder_style_banner_type'])) {
+              $form['layout_builder_style_banner_type']['#access'] = FALSE;
+            }
+
             // We provide a field that provides background options, so
             // this is hidden.
             if (isset($form['layout_builder_style_background'])) {
@@ -541,6 +547,26 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
       break;
 
     case 'layout_builder_configure_section':
+
+      $current_url = \Drupal::request()->getRequestUri();
+
+      // Check if the URL ends with a layout type for new layouts.
+      $is_new_layout_url = (preg_match('/\/layout_[^\/]*$/', $current_url) === 1);
+      // Remove grid classes for new layouts.
+      if ($is_new_layout_url) {
+        if (!empty($form['layout_builder_style_default']['#options'])) {
+          $options = $form['layout_builder_style_default']['#options'];
+
+          // Keep only the 'section_alignment_start' option.
+          $filtered_options = [];
+          if (isset($options['section_alignment_start'])) {
+            $filtered_options['section_alignment_start'] = $options['section_alignment_start'];
+          }
+
+          $form['layout_builder_style_default']['#options'] = $filtered_options;
+        }
+      }
+
       // Remove container settings - None - empty option.
       unset($form['layout_builder_style_container']['#empty_option']);
       // Add (Default) after Normal option.


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/8643. 



# How to test
```
ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli /
```

1. Edit layout
2. Try adding a new layout section and confirm that you don't see the `3x2` and `1x3` options available. 
3. Edit an existing layout section and confirm that you can still see the options available. 