### PR TITLE
update honeypot settings and update module as instructed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,7 @@
         "drupal/gpa_calculator": "^2.0",
         "drupal/hcaptcha": "^1.2",
         "drupal/heading": "^1.4",
-        "drupal/honeypot": "^2.1",
+        "drupal/honeypot": "2.1.4",
         "drupal/iframe_title_filter": "^2.0",
         "drupal/imagecache_external": "^3.0",
         "drupal/imagemagick": "^3.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "29e44eb0aeb5487df37ac3b3cdf37bfa",
+    "content-hash": "87105e931aa901eaffabe9d944411e8a",
     "packages": [
         {
             "name": "acquia/blt",
@@ -6433,29 +6433,29 @@
         },
         {
             "name": "drupal/honeypot",
-            "version": "2.1.3",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/honeypot.git",
-                "reference": "2.1.3"
+                "reference": "2.1.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/honeypot-2.1.3.zip",
-                "reference": "2.1.3",
-                "shasum": "101105029a10a574ef6017824182500ab9905856"
+                "url": "https://ftp.drupal.org/files/projects/honeypot-2.1.4.zip",
+                "reference": "2.1.4",
+                "shasum": "adf76c3520c0e458177dbe6d638aa2d6ae40a95b"
             },
             "require": {
                 "drupal/core": "^9.2 || ^10"
             },
             "require-dev": {
-                "drupal/rules": "^3.0"
+                "drupal/rules": "^3.x-dev"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.1.3",
-                    "datestamp": "1695604754",
+                    "version": "2.1.4",
+                    "datestamp": "1739061992",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/config/default/honeypot.settings.yml
+++ b/config/default/honeypot.settings.yml
@@ -8,8 +8,8 @@ unprotected_forms:
   - views_exposed_form
   - honeypot_settings_form
 log: false
-element_name: link
-time_limit: 5
+element_name: homepage
+time_limit: 0
 expire: 300
 form_settings:
   user_register_form: false


### PR DESCRIPTION
Relates to #8606 
Resolves https://github.com/uiowa/uiowa/issues/7247

>Note: Upgrading to 2.2.2 is only supported for sites running Honeypot 2.1.4 and above. If you are running a lower version, upgrade to 2.1.4 first.

# How to test

`ddev composer install && ddev blt ds --site=default`
See that honeypot is updated to 2.1.4 the update hooks are related to adding a hostname col to the database and flushing caches for the tour module.
Go to https://default.uiowa.ddev.site/form/contact without logging in and inspect the markup. You should see an input with the name `homepage` but that there is no time limit that is tripping up the user as it relates to https://github.com/uiowa/uiowa/issues/7247

# Follow-up

composer require 'drupal/honeypot:^2.2'
https://www.drupal.org/project/honeypot/releases/2.2.2
