### PR TITLE
AIS Middlware Typo

### DIFF
--- a/docroot/modules/custom/sitenow_webform_ais_rfi/src/Plugin/WebformHandler/AisRfiMiddlewareBaseWebformHandler.php
+++ b/docroot/modules/custom/sitenow_webform_ais_rfi/src/Plugin/WebformHandler/AisRfiMiddlewareBaseWebformHandler.php
@@ -112,7 +112,7 @@ abstract class AisRfiMiddlewareBaseWebformHandler extends WebformHandlerBase {
     // If not set, use the default URL based on environment.
     if (!$endpoint_url) {
       $env = getenv('AH_SITE_ENVIRONMENT') ?: 'local';
-      $endpoint_url = ($env === 'prod') ? 'https://app.its.uiowa.edu/prospect-api/api/prospect/submit' : 'https://test.its.uiowa.edu/prospect-api/api/prospect/submit';
+      $endpoint_url = ($env === 'prod') ? 'https://apps.its.uiowa.edu/prospect-api/api/prospect/submit' : 'https://test.its.uiowa.edu/prospect-api/api/prospect/submit';
     }
 
     if (!$auth) {


### PR DESCRIPTION
>there is a typo in the endpoint.
>You have https://app/ rather this should be https://apps/ (there is a ‘s’ after app)

# How to test

Review

If you want to, you can hit https://app.its.uiowa.edu/prospect-api/api/prospect/submit which won't be found whereas https://apps.its.uiowa.edu/prospect-api/api/prospect/submit will send you to idp and loop.
