### PR TITLE
Configuration schema fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -178,7 +178,7 @@
         "drupal/responsive_table_filter": "^2.0",
         "drupal/robotstxt": "^1.2",
         "drupal/scheduler": "^2.0",
-        "drupal/scheduler_content_moderation_integration": "^2.0@beta",
+        "drupal/scheduler_content_moderation_integration": "^3.0",
         "drupal/schema_metatag": "^3.0",
         "drupal/search_api": "^1.35",
         "drupal/search_api_autocomplete": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "29e44eb0aeb5487df37ac3b3cdf37bfa",
+    "content-hash": "006171fd61f5fc6d6b07cb10533c39de",
     "packages": [
         {
             "name": "acquia/blt",
@@ -10290,30 +10290,33 @@
         },
         {
             "name": "drupal/scheduler_content_moderation_integration",
-            "version": "2.0.0-beta2",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/scheduler_content_moderation_integration.git",
-                "reference": "2.0.0-beta2"
+                "reference": "3.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/scheduler_content_moderation_integration-2.0.0-beta2.zip",
-                "reference": "2.0.0-beta2",
-                "shasum": "669c62fa4f82b84f38bcf416286c753abb8b1f3e"
+                "url": "https://ftp.drupal.org/files/projects/scheduler_content_moderation_integration-3.0.2.zip",
+                "reference": "3.0.2",
+                "shasum": "a8f2131b808dddd232dfa476382711a5c80ba1f4"
             },
             "require": {
-                "drupal/core": "^8.7.7 || ^9 || ^10",
+                "drupal/core": "^10.3",
                 "drupal/scheduler": "^2"
+            },
+            "require-dev": {
+                "drupal/commerce": "^3.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0-beta2",
-                    "datestamp": "1695918977",
+                    "version": "3.0.2",
+                    "datestamp": "1725377292",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -23644,7 +23647,6 @@
         "drupal/menu_link_weight": 10,
         "drupal/node_revision_delete": 15,
         "drupal/rabbit_hole": 10,
-        "drupal/scheduler_content_moderation_integration": 10,
         "drupal/taxonomy_path_breadcrumb": 10,
         "drupal/tvi": 15,
         "drupal/ui_icons": 10,

--- a/docroot/modules/custom/layout_builder_custom/config/schema/layout_builder_custom.schema.yml
+++ b/docroot/modules/custom/layout_builder_custom/config/schema/layout_builder_custom.schema.yml
@@ -1,0 +1,22 @@
+field.value.uiowa_headline:
+  type: mapping
+  label: 'Headline'
+  mapping:
+    headline:
+      type: string
+      label: 'Headline'
+    child_heading_size:
+      type: string
+      label: 'Child content headline size'
+    heading_size:
+      type: string
+      label: 'Headline size'
+    hide_headline:
+      type: integer
+      label: 'Hide headline'
+    headline_style:
+      type: string
+      label: 'Headline style'
+    headline_alignment:
+      type: string
+      label: 'Headline alignment'

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -3520,3 +3520,16 @@ function sitenow_update_10015() {
     $component->set('layout_builder_styles_style', $styles);
   });
 }
+
+/**
+ * Update field_uiowa_headline due to mismatched field definition.
+ */
+function sitenow_update_10016() {
+  $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+  $changes = $entity_definition_update_manager->getChangeList();
+
+  if (isset($changes['block_content']['field_storage_definitions']['field_uiowa_headline'])) {
+    $field_definition = $entity_definition_update_manager->getFieldStorageDefinition('field_uiowa_headline', 'block_content');
+    $entity_definition_update_manager->updateFieldStorageDefinition($field_definition);
+  }
+}


### PR DESCRIPTION
Relates to https://github.com/uiowa/uiowa/issues/8606
Resolves https://github.com/uiowa/uiowa/issues/6679

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

Checkout `main`

```
ddev drush @sandbox.local sql-drop -y && ddev drush @sandbox.local cr && ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli admin/reports/config-inspector#schema-filter-text
```

Search for _headline_ and see errors associated with headline fields.

```
ddev drush @home.local sql-drop -y && ddev drush @home.local cr && ddev blt ds --site=uiowa.edu && ddev drush @home.local uli admin/reports/status#error
```

Scroll down and see a mismatch definition errors for the headline field and taxonomy.

Checkout `config_schema_fixes`

```
ddev drush @sandbox.local sql-drop -y && ddev drush @sandbox.local cr && ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli admin/reports/config-inspector#schema-filter-text
```

Search for _headline_ and see "Correct" associated with headline fields.

```
ddev drush @home.local sql-drop -y && ddev drush @home.local cr && ddev blt ds --site=uiowa.edu && ddev drush @home.local uli admin/reports/status#error
```

Scroll down and the mismatch section no longer returns.

## Confirm article scheduling with moderation still works as expected

I don't think the module update should affect any of this, but...

- As a webmaster/publisher, you should now see "Scheduling options" for publish on within the node article form. Editors should still be able to set for article for review but cannot see the scheduling options fieldset.
- Though there is a new "publish_state" field, at no point in the form editing process is that field visible to the publisher/webmaster.
- Select a date and time to publish the article (a minute or so) and keep the article in a draft or needs review state.
- On save, note that the content is still unpublished logged in and as an anonymous user. As authenticated, you should see messages that the content has been scheduled and with moderation involved, additional text about Editors being restricted until after the scheduled date.
- Since you are local, manually trigger cron after reaching the time set within scheduling options. (e.g. `ddev drush @default.local cron`)
- You should see a message in the terminal saying that the content is being published and upon refreshing the browser you should see that it is published.
- Create a new article and this time in addition to setting a publish on date/time, try to set the moderation state to published and save the node. You should see that scheduling is still set but that the moderation state has been moved back to draft. Go to /admin/content and try to bulk publish the same article. Again you should see a message saying that the two settings conflict and that the moderation state has been set back to the previous state.

