### PR TITLE
Events single page multiple-dates dropdown color contrast fix

### DIFF
--- a/docroot/modules/custom/sitenow_events/css/single-event.css
+++ b/docroot/modules/custom/sitenow_events/css/single-event.css
@@ -50,10 +50,13 @@
   font-weight: bold;
 }
 .date-instance__past {
-  color: #999;
+  color: #737373;
 }
-.date-instance__next-upcoming {
-  font-weight: bold;
+.event-field.event-time .date-instance:nth-child(2) {
+  margin-top: 1rem;
+}
+.date-instance__next-upcoming .date-instance__date {
+  font-weight: 600;
 }
 
 .sitenow-event .svg-inline--fa {


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/5495. 


<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli /event/31316/21
```
1. Confirm that first date has more space between it and the remaining dates
2. Confirm new gray color passes AA validation: https://webaim.org/resources/contrastchecker/?fcolor=737373&bcolor=FFFFFF. 
