### PR TITLE
[Bug] Fix webform data export

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -326,6 +326,9 @@
             "drupal/smart_date": {
                 "Strict equality check in setInitialDuration causes end date/time fields to not hide": "patches/3452796.patch",
                 "Return type declaration for extension of diff plugin base": "patches/3463447.patch"
+            },
+            "drupal/webform": {
+                "Webform export separate option doesn't show values for specific options": "https://www.drupal.org/files/issues/2024-07-22/3462726-optionbase-1.patch"
             }
         },
         "installer-types": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "47501ca782d8f1a11ee05155092c094f",
+    "content-hash": "8cbb33b64ad3681ee2b958d207b51528",
     "packages": [
         {
             "name": "acquia/blt",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87105e931aa901eaffabe9d944411e8a",
+    "content-hash": "9cbd3a388996e25559b8ca776e7a1354",
     "packages": [
         {
             "name": "acquia/blt",
@@ -504,12 +504,12 @@
             "version": "v1.8.7",
             "source": {
                 "type": "git",
-                "url": "git@github.com:harvesthq/bower-chosen.git",
+                "url": "https://github.com/harvesthq/chosen-package.git",
                 "reference": "ad86732b668627c131e61ee8f0e6e9ed52e4db8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/harvesthq/bower-chosen/zipball/ad86732b668627c131e61ee8f0e6e9ed52e4db8d",
+                "url": "https://api.github.com/repos/harvesthq/chosen-package/zipball/ad86732b668627c131e61ee8f0e6e9ed52e4db8d",
                 "reference": "ad86732b668627c131e61ee8f0e6e9ed52e4db8d"
             },
             "type": "bower-asset",
@@ -522,7 +522,7 @@
             "version": "6.x-dev",
             "source": {
                 "type": "git",
-                "url": "git@github.com:FortAwesome/Font-Awesome.git",
+                "url": "https://github.com/FortAwesome/Font-Awesome.git",
                 "reference": "d19ab26a33b4d80f9af604e85d4194757276f01d"
             },
             "dist": {
@@ -11523,7 +11523,7 @@
                     "datestamp": "1733928451",
                     "security-coverage": {
                         "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
+                        "message": "Beta releases are not covered by Drupal security advisories."
                     }
                 }
             },


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
On `main`
```
ddev composer install && ddev blt ds --site=engineering.uiowa.edu && ddev drush @engineering.local uli /webform/mechanical_engineering_teaching_/test
```
Create a test submission or two or three

Go to /admin/structure/webform/manage/mechanical_engineering_teaching_/results/download and export data with the "options single value format" as separate (should be the default option)
Export
Open the downloaded file and see that there is no data in the expected year columns.
Check out this branch and `ddev composer install`
Re-export and see that there is now data in the expected year columns, and that the other columns' data remains unchanged.