### PR TITLE
Adjust caching method on footer login link

### DIFF
--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -1130,9 +1130,6 @@ function uiowa_core_preprocess_block(&$variables) {
             ],
             'rel' => 'nofollow',
           ],
-          '#cache' => [
-            'max-age' => 0,
-          ],
         ];
       }
       break;

--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -1111,6 +1111,8 @@ function uiowa_core_preprocess_block(&$variables) {
             // Exit without adding the login link.
             break;
           }
+          // Add cache tag for this node.
+          $variables['#cache']['tags'][] = 'node:' . $node->id();
         }
 
         // Add the login link if we didn't break out.
@@ -1131,6 +1133,10 @@ function uiowa_core_preprocess_block(&$variables) {
             'rel' => 'nofollow',
           ],
         ];
+
+        // Try cache contexts instead of max-age=0.
+        $variables['#cache']['contexts'][] = 'user.roles';
+        $variables['#cache']['contexts'][] = 'url.path';
       }
       break;
   }

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -22,6 +22,14 @@ use Drupal\uiowa_core\LinkHelper;
 use Drupal\views\Plugin\views\field\EntityField;
 
 /**
+ * Implements template_preprocess_block().
+ */
+function uids_base_preprocess_block__system_messages_block(&$variables) {
+  $variables['content'] = StatusMessages::renderMessages();
+  $variables['#cache']['max-age'] = 0;
+}
+
+/**
  * Implements hook_form_alter().
  */
 function uids_base_form_alter(&$form, $form_state, $form_id) {

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -22,14 +22,6 @@ use Drupal\uiowa_core\LinkHelper;
 use Drupal\views\Plugin\views\field\EntityField;
 
 /**
- * Implements template_preprocess_block().
- */
-function uids_base_preprocess_block__system_messages_block(&$variables) {
-  $variables['content'] = StatusMessages::renderMessages();
-  $variables['#cache']['max-age'] = 0;
-}
-
-/**
  * Implements hook_form_alter().
  */
 function uids_base_form_alter(&$form, $form_state, $form_id) {


### PR DESCRIPTION
We went back and forth on this max-age=0 on the footer link with a note to revisit.

https://github.com/uiowa/uiowa/pull/6040#pullrequestreview-1232019447

The solution for now is to get caching back with cache contexts!

# How to test

On education.dev.drupal.uiowa.edu navigate around the website anonymously and see that the login link in the footer is updated with the destination parameter.

Login and change one of the page URL paths. As an anonymous user again. View the page and see the login link is accurate for the path.

Note that subsequent hits to the page without changes to the node are `x-cache` hit meaning not only drupal is cached but that varnish is serving from a cached version. `age` and `x-cache-hits` should also increment.

<img width="448" alt="Screenshot 2025-04-11 at 10 44 04 AM" src="https://github.com/user-attachments/assets/ee8fd9b1-9381-4c4e-9e90-bde4f629f3f4" />

