### PR TITLE
[Bug] Layout containment fix for older browsers

### DIFF
--- a/docroot/themes/custom/uids_base/scss/admin.scss
+++ b/docroot/themes/custom/uids_base/scss/admin.scss
@@ -81,7 +81,6 @@
 // @todo remove when https://github.com/uiowa/uiowa/issues/8617 is ready.
 // Unset container-type for regions that use absolute positioning.
 // Horizontal navigation, timeline block, lb-direct-add.
-.layout__region--unset-type .column-container,
 .layout-builder .column-container {
   container-type: unset;
 }

--- a/docroot/themes/custom/uids_base/scss/admin.scss
+++ b/docroot/themes/custom/uids_base/scss/admin.scss
@@ -80,7 +80,7 @@
 // Overrides for older browsers until https://github.com/w3c/csswg-drafts/issues/10544 is the standard.
 // @todo remove when https://github.com/uiowa/uiowa/issues/8617 is ready.
 // Unset container-type for regions that use absolute positioning.
-// Horizontal navigation, timeline block, lb-direct-add.
+// lb-direct-add.
 .layout-builder .column-container {
   container-type: unset;
 }

--- a/docroot/themes/custom/uids_base/scss/global.scss
+++ b/docroot/themes/custom/uids_base/scss/global.scss
@@ -2,6 +2,14 @@
 @use '../uids/scss/abstracts/_variables.scss';
 @use '../uids/scss/abstracts/_utilities.scss';
 
+// Overrides for older browsers until https://github.com/w3c/csswg-drafts/issues/10544 is the standard.
+// @todo remove when https://github.com/uiowa/uiowa/issues/8617 is ready.
+// Unset container-type for regions that use absolute positioning.
+// Horizontal navigation, timeline block.
+.layout__region--unset-type .column-container {
+  container-type: unset;
+}
+
 // @todo remove when https://github.com/uiowa/uiowa/issues/8617 is ready.
 .node__content:has(.layout--onecol--background.banner),
 .list-container__inner .views-row {


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/8671. 

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt frontend && ddev blt ds --site=hr.uiowa.edu && ddev drush @hr.local uli //pay/workforce-operations
```

1. Open Browserstack
2. Use Chrome 116 and compare with prod
3. Confirm that menus are visible and not sitting behind the body text
