### PR TITLE
Added area of study to config ignore settings

### DIFF
--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -49,6 +49,7 @@ ignored_config_entities:
   - uids_base.settings
   - uiowa_alerts.settings
   - uiowa_apr.settings
+  - uiowa_area_of_study.settings
   - 'uiowa_auth.settings:role_mappings'
   - uiowa_core.settings
   - uiowa_hours.settings


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

## CLAS
```
ddev blt ds --site=clas.uiowa.edu && ddev drush @clas.local uli /academics/undergraduate-majors-minors-certificates
```
1. Change the label at https://clas.uiowa.ddev.site/admin/config/sitenow/uiowa-areas-of-study and confirm `drush @clas.local cex` deletes `config/sites/clas.uiowa.edu/uiowa_area_of_study.settings.yml`

## Education
```
ddev blt ds --site=education.uiowa.edu && ddev drush @education.local uli  /areas-study/program-finder
```
1. Change the label at https://education.uiowa.ddev.site/admin/config/sitenow/uiowa-areas-of-study and confirm `drush @education.local cex` does not export any config. 