### PR TITLE
[CLAS] Added view config split back into clas split

### DIFF
--- a/config/sites/clas.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/clas.uiowa.edu/config_split.config_split.site.yml
@@ -16,4 +16,4 @@ theme: {  }
 complete_list:
   - config_split.config_split.site
 partial_list:
-  - uiowa_area_of_study.settings.yml
+  - views.view.areas_of_study

--- a/config/sites/clas.uiowa.edu/config_split.patch.views.view.areas_of_study.yml
+++ b/config/sites/clas.uiowa.edu/config_split.patch.views.view.areas_of_study.yml
@@ -1,0 +1,98 @@
+adding:
+  dependencies:
+    config:
+      - field.storage.node.field_area_of_study_degree_types
+  display:
+    areas_of_study_block:
+      display_options:
+        fields:
+          body:
+            exclude: true
+            settings:
+              more:
+                display_link: false
+                target_blank: false
+                link_trim_only: false
+                class: more-link
+                text: More
+                aria_label: 'Read more about [node:title]'
+                token_browser: ''
+          field_area_of_study_degree_types:
+            id: field_area_of_study_degree_types
+            table: node__field_area_of_study_degree_types
+            field: field_area_of_study_degree_types
+            relationship: none
+            group_type: group
+            admin_label: ''
+            plugin_id: field
+            label: 'Degree Types'
+            exclude: false
+            alter:
+              alter_text: false
+              text: ''
+              make_link: false
+              path: ''
+              absolute: false
+              external: false
+              replace_spaces: false
+              path_case: none
+              trim_whitespace: false
+              alt: ''
+              rel: ''
+              link_class: ''
+              prefix: ''
+              suffix: ''
+              target: ''
+              nl2br: false
+              max_length: 0
+              word_boundary: true
+              ellipsis: true
+              more_link: false
+              more_link_text: ''
+              more_link_path: ''
+              strip_tags: false
+              trim: false
+              preserve_tags: ''
+              html: false
+            element_type: ''
+            element_class: ''
+            element_label_type: ''
+            element_label_class: ''
+            element_label_colon: true
+            element_wrapper_type: ''
+            element_wrapper_class: ''
+            element_default_classes: true
+            empty: ''
+            hide_empty: false
+            empty_zero: false
+            hide_alter_empty: true
+            click_sort_column: target_id
+            type: entity_reference_label
+            settings:
+              link: false
+            group_column: target_id
+            group_columns: {  }
+            group_rows: true
+            delta_limit: 0
+            delta_offset: 0
+            delta_reversed: false
+            delta_first_last: false
+            multi_type: separator
+            separator: ', '
+            field_api_classes: false
+      cache_metadata:
+        tags:
+          - 'config:field.storage.node.field_area_of_study_degree_types'
+removing:
+  display:
+    areas_of_study_block:
+      display_options:
+        fields:
+          body:
+            exclude: false
+            settings:
+              more_link: false
+              more_class: more-link
+              more_text: More
+              more_aria_label: 'Read more about [node:title]'
+              token_browser: ''

--- a/config/sites/clas.uiowa.edu/uiowa_area_of_study.settings.yml
+++ b/config/sites/clas.uiowa.edu/uiowa_area_of_study.settings.yml
@@ -1,1 +1,0 @@
-locations: 'Areas of Study'


### PR DESCRIPTION
Adds view config split back that was accidentally removed in https://github.com/uiowa/uiowa/pull/8538 and removes label override config. 

# How to test

```
ddev blt ds --site=clas.uiowa.edu && ddev drush @clas.local config:import --source ../config/sites/clas.uiowa.edu --partial -y && ddev drush @clas.local cim -y && ddev drush @clas.local uli /academics-student-success/clas-areas-study/undergraduate-majors-minors-certificates
```

1. Compare against https://clas.uiowa.edu/academics/undergraduate-majors-minors-certificates
2. Confirm "Locations" label is now "Area of Study" without config override. 
3. In the table, confirm "Summary" is gone and confirm "Degree Types" is there instead.
