### PR TITLE
updated restroom terminology for facilities page.

### DIFF
--- a/config/sites/facilities.uiowa.edu/field.field.node.building.field_building_rr_single_neutral.yml
+++ b/config/sites/facilities.uiowa.edu/field.field.node.building.field_building_rr_single_neutral.yml
@@ -9,7 +9,7 @@ id: node.building.field_building_rr_single_neutral
 field_name: field_building_rr_single_neutral
 entity_type: node
 bundle: building
-label: 'Gender neutral restrooms'
+label: 'Single User Neutral'
 description: ''
 required: false
 translatable: false

--- a/config/sites/facilities.uiowa.edu/field.field.node.building.field_building_rr_single_neutral.yml
+++ b/config/sites/facilities.uiowa.edu/field.field.node.building.field_building_rr_single_neutral.yml
@@ -9,7 +9,7 @@ id: node.building.field_building_rr_single_neutral
 field_name: field_building_rr_single_neutral
 entity_type: node
 bundle: building
-label: 'Single User Neutral'
+label: 'Single user neutral'
 description: ''
 required: false
 translatable: false

--- a/config/sites/facilities.uiowa.edu/field.field.node.building.field_building_rr_single_neutral.yml
+++ b/config/sites/facilities.uiowa.edu/field.field.node.building.field_building_rr_single_neutral.yml
@@ -9,7 +9,7 @@ id: node.building.field_building_rr_single_neutral
 field_name: field_building_rr_single_neutral
 entity_type: node
 bundle: building
-label: 'Single user neutral'
+label: 'Single user restrooms'
 description: ''
 required: false
 translatable: false

--- a/docroot/sites/facilities.uiowa.edu/modules/facilities_core/src/Plugin/Block/AccessibilityLinks.php
+++ b/docroot/sites/facilities.uiowa.edu/modules/facilities_core/src/Plugin/Block/AccessibilityLinks.php
@@ -51,7 +51,7 @@ class AccessibilityLinks extends BlockBase {
         'id' => '7c639bd4000b4d34979a3a3a628d7180',
       ],
       'gender_inclusive_restroom' => [
-        'label' => 'Single use restrooms',
+        'label' => 'SSingle user restrooms',
         'icon' => 'person-half-dress',
         'id' => 'a787689a1da843018156b2f2e97da119',
       ],

--- a/docroot/sites/facilities.uiowa.edu/modules/facilities_core/src/Plugin/Block/AccessibilityLinks.php
+++ b/docroot/sites/facilities.uiowa.edu/modules/facilities_core/src/Plugin/Block/AccessibilityLinks.php
@@ -51,7 +51,7 @@ class AccessibilityLinks extends BlockBase {
         'id' => '7c639bd4000b4d34979a3a3a628d7180',
       ],
       'gender_inclusive_restroom' => [
-        'label' => 'Gender Inclusive Restrooms',
+        'label' => 'Single use restrooms',
         'icon' => 'person-half-dress',
         'id' => 'a787689a1da843018156b2f2e97da119',
       ],

--- a/docroot/sites/facilities.uiowa.edu/modules/facilities_core/src/Plugin/Block/AccessibilityLinks.php
+++ b/docroot/sites/facilities.uiowa.edu/modules/facilities_core/src/Plugin/Block/AccessibilityLinks.php
@@ -51,7 +51,7 @@ class AccessibilityLinks extends BlockBase {
         'id' => '7c639bd4000b4d34979a3a3a628d7180',
       ],
       'gender_inclusive_restroom' => [
-        'label' => 'SSingle user restrooms',
+        'label' => 'Single user restrooms',
         'icon' => 'person-half-dress',
         'id' => 'a787689a1da843018156b2f2e97da119',
       ],


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/8641. 

# How to test

```
ddev blt ds --site=facilities.uiowa.edu && ddev drush @facilities.local uli
```

- Go to pages and view  the items changed 
- https://facilities.uiowa.ddev.site/building/0003

<img width="375" alt="Screenshot 2025-04-22 at 2 22 16 PM" src="https://github.com/user-attachments/assets/934ca4f6-020f-4a3e-8f9b-58e20763c413" />

<img width="1844" alt="Screenshot 2025-04-22 at 2 21 50 PM" src="https://github.com/user-attachments/assets/2bebe587-7473-45bc-9b4c-06ab74044289" />
