### PR TITLE
[Contact feature] Adjusted contact teaser to display email format instead of plain text

### DIFF
--- a/config/features/contact/core.entity_view_display.node.contact.teaser.yml
+++ b/config/features/contact/core.entity_view_display.node.contact.teaser.yml
@@ -29,6 +29,11 @@ content:
     third_party_settings: {  }
     weight: 4
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   field_contact_address:
     type: address_default
     label: visually_hidden
@@ -37,7 +42,7 @@ content:
     weight: 3
     region: content
   field_contact_email:
-    type: basic_string
+    type: email_mailto
     label: visually_hidden
     settings: {  }
     third_party_settings: {  }


### PR DESCRIPTION
Josh pointed out that on the featured content/contact content types the email address wasn't generating a hyperlink. This pr fixes that. 


<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt ds --site=registrar.uiowa.edu && ddev drush @registrar.local uli /students/registration
```
1. Confirm email is clickable and is in `mailto:` format. 
2. Compare against prod: https://registrar.prod.drupal.uiowa.edu/students/registration
