### PR TITLE
ITS - Only send ITS alert digest if there are alerts

### DIFF
--- a/docroot/sites/its.uiowa.edu/modules/its_core/src/Commands/ITSCoreCommands.php
+++ b/docroot/sites/its.uiowa.edu/modules/its_core/src/Commands/ITSCoreCommands.php
@@ -47,22 +47,20 @@ class ITSCoreCommands extends DrushCommands {
     $this->accountSwitcher->switchTo(new UserSession(['uid' => 1]));
 
     $views = [];
-    $views['outages_degradations'] = [
-      'title' => 'Alerts',
-      'view' => views_get_view_result('alerts_list_block', 'outages_degradations'),
-    ];
-    $views['planned_maintenance'] = [
-      'title' => 'Planned Maintenance',
-      'view' => views_get_view_result('alerts_list_block', 'planned_maintenance'),
-    ];
-    $views['service_announcements'] = [
-      'title' => 'Service Announcements',
-      'view' => views_get_view_result('alerts_list_block', 'service_announcements'),
-    ];
-    $views['ongoing'] = [
-      'title' => 'Ongoing Maintenance',
-      'view' => views_get_view_result('alerts_list_block', 'ongoing'),
-    ];
+    foreach ([
+      'outages_degradations' => 'Alerts',
+      'planned_maintenance' => 'Planned Maintenance',
+      'service_announcements' => 'Service Announcements',
+      'ongoing' => 'Ongoing Maintenance',
+    ] as $key => $title) {
+      $view = views_get_view_result('alerts_list_block', $key);
+      if (!empty($view)) {
+        $views[$key] = [
+          'title' => $title,
+          'view' => $view,
+        ];
+      }
+    }
     $content = [];
 
     if (!empty($views)) {


### PR DESCRIPTION
Resolves #8689 

# How to test
The testing instructions assume that there are currently no alerts. If a new alert gets created before this gets tested, then you'll be first confirming that the alert digest sent, logging in and removing the alert, then confirming that the alert digest didn't send.
```
ddev blt ds --site its.uiowa.edu && ddev drush @its.local its_core:alerts-digest && ddev drush @its.local uli node/add/alert
```
- Confirm that you see the `Alerts Digest - No items to send` message.
- Add an alert.
```
ddev drush @its.local its_core:alerts-digest
```
- Confirm you see the `Alerts Digest sent` messgae.
- You can also check Mailpit to see the email: https://uiowa.ddev.site:8026/