### PR TITLE
hotfix - resave default content after issues with new site installs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -161,7 +161,7 @@
         "drupal/migrate_plus": "^6.0",
         "drupal/migrate_tools": "^6.0",
         "drupal/moderated_content_bulk_publish": "^2.0",
-        "drupal/node_revision_delete": "^2.0@alpha",
+        "drupal/node_revision_delete": "^2.0",
         "drupal/node_view_permissions": "^1.5",
         "drupal/override_node_options": "^2.4",
         "drupal/paragraphs": "^1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "556ad8a88ebeda3e4363802af733fd6b",
+    "content-hash": "b015ced1afe836ffe2571a36fafbef0a",
     "packages": [
         {
             "name": "acquia/blt",
@@ -9111,34 +9111,34 @@
         },
         {
             "name": "drupal/node_revision_delete",
-            "version": "2.0.0-rc1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/node_revision_delete.git",
-                "reference": "2.0.0-rc1"
+                "reference": "2.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/node_revision_delete-2.0.0-rc1.zip",
-                "reference": "2.0.0-rc1",
-                "shasum": "7532c3c7c0f7bbaccf5a2721273a77cdca1b821b"
+                "url": "https://ftp.drupal.org/files/projects/node_revision_delete-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "3ab4174378475a22a0dab5fc77939bb75fecdfa8"
             },
             "require": {
-                "drupal/core": "^9.0 || ^10"
+                "drupal/core": "^10 || ^11"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0-rc1",
-                    "datestamp": "1709827878",
+                    "version": "2.0.0",
+                    "datestamp": "1738762680",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "RC releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 },
                 "drush": {
                     "services": {
-                        "drush.services.yml": "^9.0 || ^10 || ^11"
+                        "drush.services.yml": "^10 || ^11"
                     }
                 }
             },
@@ -23645,7 +23645,6 @@
         "drupal/masquerade": 10,
         "drupal/media_entity_file_replace": 10,
         "drupal/menu_link_weight": 10,
-        "drupal/node_revision_delete": 15,
         "drupal/rabbit_hole": 10,
         "drupal/taxonomy_path_breadcrumb": 10,
         "drupal/tvi": 15,

--- a/docroot/profiles/custom/sitenow/content/block_content/30a2799f-c1bf-4ce5-a8f3-0bd71141a580.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/30a2799f-c1bf-4ce5-a8f3-0bd71141a580.yml
@@ -11,9 +11,6 @@ default:
   reusable:
     -
       value: false
-  revision_translation_affected:
-    -
-      value: true
   field_uiowa_statistic_excerpt:
     -
       value: 'student-to-faculty ratio'

--- a/docroot/profiles/custom/sitenow/content/block_content/3e775397-cb1e-40de-9c53-f00e328edc2d.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/3e775397-cb1e-40de-9c53-f00e328edc2d.yml
@@ -16,9 +16,6 @@ default:
   revision_translation_affected:
     -
       value: true
-  field_uiowa_card_button_display:
-    -
-      value: 'Use site default'
   field_uiowa_card_excerpt:
     -
       value: "<p>Browse the service site or contact us with any questions you have about the SiteNow service.</p>\r\n"
@@ -30,7 +27,11 @@ default:
     -
       uri: 'https://sitenow.uiowa.edu/'
       title: ''
-      options: {  }
+      options:
+        href: 'https://sitenow.uiowa.edu/'
+        data-entity-type: ''
+        data-entity-uuid: ''
+        data-entity-substitution: ''
   field_uiowa_card_title:
     -
       size: h2

--- a/docroot/profiles/custom/sitenow/content/block_content/41c43a1b-0473-45b1-b799-2b235c3904fb.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/41c43a1b-0473-45b1-b799-2b235c3904fb.yml
@@ -18,7 +18,7 @@ default:
       value: true
   field_uiowa_card_button_display:
     -
-      value: 'Use site default'
+      value: '1'
   field_uiowa_card_excerpt:
     -
       value: "<p>Reach out directly to the team building the SiteNow service.</p>\r\n"
@@ -30,7 +30,11 @@ default:
     -
       uri: 'https://webcommunity.sites.uiowa.edu/contact-web-team'
       title: 'Contact us'
-      options: {  }
+      options:
+        href: 'https://webcommunity.sites.uiowa.edu/contact-web-team'
+        data-entity-type: ''
+        data-entity-uuid: ''
+        data-entity-substitution: ''
   field_uiowa_card_title:
     -
       size: h2

--- a/docroot/profiles/custom/sitenow/content/block_content/4b3a0581-6c84-4417-b6ea-3eb5e9bd9d50.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/4b3a0581-6c84-4417-b6ea-3eb5e9bd9d50.yml
@@ -13,9 +13,6 @@ default:
   reusable:
     -
       value: false
-  revision_translation_affected:
-    -
-      value: true
   field_uiowa_image_image:
     -
       entity: 67599837-9a35-4165-b0a6-2b5b0a87a61e

--- a/docroot/profiles/custom/sitenow/content/block_content/5fd3432c-7324-4dc5-bfa1-54d07b43da77.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/5fd3432c-7324-4dc5-bfa1-54d07b43da77.yml
@@ -11,9 +11,6 @@ default:
   reusable:
     -
       value: false
-  revision_translation_affected:
-    -
-      value: true
   field_uiowa_statistic_excerpt:
     -
       value: 'Graduate School Placement Rate'

--- a/docroot/profiles/custom/sitenow/content/block_content/631979b9-cf39-46d2-a357-e8857487fccd.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/631979b9-cf39-46d2-a357-e8857487fccd.yml
@@ -16,9 +16,6 @@ default:
   revision_translation_affected:
     -
       value: true
-  field_uiowa_card_button_display:
-    -
-      value: 'Use site default'
   field_uiowa_card_excerpt:
     -
       value: "<p>Attend or watch a recorded SiteNow/Layout Builder training session offered by the web team.</p>\r\n"
@@ -30,7 +27,11 @@ default:
     -
       uri: 'https://webcommunity.sites.uiowa.edu/training'
       title: ''
-      options: {  }
+      options:
+        href: 'https://webcommunity.sites.uiowa.edu/training'
+        data-entity-type: ''
+        data-entity-uuid: ''
+        data-entity-substitution: ''
   field_uiowa_card_title:
     -
       size: h2

--- a/docroot/profiles/custom/sitenow/content/block_content/8a740559-85c3-45d3-beb4-776806a82a79.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/8a740559-85c3-45d3-beb4-776806a82a79.yml
@@ -13,9 +13,6 @@ default:
   reusable:
     -
       value: false
-  revision_translation_affected:
-    -
-      value: true
   field_uiowa_image_image:
     -
       entity: 3d1939ab-0a2b-41da-910e-252aee65523a

--- a/docroot/profiles/custom/sitenow/content/block_content/ab5ad35a-4275-492b-aa5a-3c6a5f94ae9b.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/ab5ad35a-4275-492b-aa5a-3c6a5f94ae9b.yml
@@ -13,9 +13,6 @@ default:
   reusable:
     -
       value: false
-  revision_translation_affected:
-    -
-      value: true
   field_uiowa_image_image:
     -
       entity: 65f9eae1-f80b-4b14-b495-ff3bd2551762

--- a/docroot/profiles/custom/sitenow/content/block_content/b8aba3a5-10de-42ad-8cb1-dee195b4d540.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/b8aba3a5-10de-42ad-8cb1-dee195b4d540.yml
@@ -14,14 +14,6 @@ default:
   revision_translation_affected:
     -
       value: true
-  field_uiowa_headline:
-    -
-      headline: ''
-      heading_size: h2
-      hide_headline: '0'
-      headline_style: default
-      headline_alignment: default
-      child_heading_size: h2
   field_uiowa_text_area:
     -
       value: "<p class=\"uids-component--bold-intro\">You can use this page as a starting point for your site's front page.</p>\r\n\r\n<p>Below, you'll find some examples content blocks you can use to build web layouts in SiteNow v3. You can use this page as a template for the front page of your site and adjust as needed. Simply click the <strong>Layout</strong> button from this page while logged into the site and start building your page. You can also set a different page as your homepage from the <strong>Configuration</strong> menu above or delete this page from the&nbsp;<strong>Content&nbsp;</strong>menu.</p>\r\n"

--- a/docroot/profiles/custom/sitenow/content/block_content/c45277c6-60d5-44fb-9d00-689687a550ec.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/c45277c6-60d5-44fb-9d00-689687a550ec.yml
@@ -11,9 +11,6 @@ default:
   reusable:
     -
       value: false
-  revision_translation_affected:
-    -
-      value: true
   field_uiowa_statistic_excerpt:
     -
       value: 'Areas of Study'

--- a/docroot/profiles/custom/sitenow/content/block_content/e8a1a5d7-a7c6-4b59-a13d-ee498ec7232c.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/e8a1a5d7-a7c6-4b59-a13d-ee498ec7232c.yml
@@ -18,7 +18,7 @@ default:
       value: true
   field_uiowa_card_button_display:
     -
-      value: 'Use site default'
+      value: '1'
   field_uiowa_card_excerpt:
     -
       value: "<p>Stay up-to-date on upcoming features and the web team's current priorities.&nbsp;</p>\r\n"
@@ -30,7 +30,11 @@ default:
     -
       uri: 'https://webcommunity.sites.uiowa.edu/backlog'
       title: 'View Backlog'
-      options: {  }
+      options:
+        href: 'https://webcommunity.sites.uiowa.edu/backlog'
+        data-entity-type: ''
+        data-entity-uuid: ''
+        data-entity-substitution: ''
   field_uiowa_card_title:
     -
       size: h2

--- a/docroot/profiles/custom/sitenow/content/block_content/e92499d4-4692-4937-882f-4abb975e6e85.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/e92499d4-4692-4937-882f-4abb975e6e85.yml
@@ -18,7 +18,11 @@ default:
     -
       uri: 'internal:/admin/content'
       title: 'Add Content'
-      options: {  }
+      options:
+        href: 'internal:/admin/content'
+        data-entity-type: ''
+        data-entity-uuid: ''
+        data-entity-substitution: ''
   field_uiowa_cta_summary:
     -
       value: "Use the Content menu to create and manage your site's content. "

--- a/docroot/profiles/custom/sitenow/content/block_content/e9b591a5-24cf-45a7-aeba-334f82fd6549.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/e9b591a5-24cf-45a7-aeba-334f82fd6549.yml
@@ -13,9 +13,6 @@ default:
   reusable:
     -
       value: false
-  revision_translation_affected:
-    -
-      value: true
   field_uiowa_banner_autoplay:
     -
       value: false

--- a/docroot/profiles/custom/sitenow/content/media/0005b838-46f9-4c0f-a669-be81fa5bd03a.yml
+++ b/docroot/profiles/custom/sitenow/content/media/0005b838-46f9-4c0f-a669-be81fa5bd03a.yml
@@ -24,7 +24,7 @@ default:
       value: true
   path:
     -
-      alias: /media/image/2
+      alias: /media/image/9
       langcode: en
       pathauto: 1
   field_media_image:

--- a/docroot/profiles/custom/sitenow/content/media/3d1939ab-0a2b-41da-910e-252aee65523a.yml
+++ b/docroot/profiles/custom/sitenow/content/media/3d1939ab-0a2b-41da-910e-252aee65523a.yml
@@ -24,7 +24,7 @@ default:
       value: true
   path:
     -
-      alias: /media/image/9
+      alias: /media/image/5
       langcode: en
       pathauto: 1
   field_media_image:

--- a/docroot/profiles/custom/sitenow/content/media/65f9eae1-f80b-4b14-b495-ff3bd2551762.yml
+++ b/docroot/profiles/custom/sitenow/content/media/65f9eae1-f80b-4b14-b495-ff3bd2551762.yml
@@ -24,7 +24,7 @@ default:
       value: true
   path:
     -
-      alias: /media/image/10
+      alias: /media/image/6
       langcode: en
       pathauto: 1
   field_media_image:

--- a/docroot/profiles/custom/sitenow/content/media/67599837-9a35-4165-b0a6-2b5b0a87a61e.yml
+++ b/docroot/profiles/custom/sitenow/content/media/67599837-9a35-4165-b0a6-2b5b0a87a61e.yml
@@ -24,7 +24,7 @@ default:
       value: true
   path:
     -
-      alias: /media/image/11
+      alias: /media/image/3
       langcode: en
       pathauto: 1
   field_media_image:

--- a/docroot/profiles/custom/sitenow/content/media/99436d77-db6b-43b8-8e04-ea2f0e62b590.yml
+++ b/docroot/profiles/custom/sitenow/content/media/99436d77-db6b-43b8-8e04-ea2f0e62b590.yml
@@ -24,7 +24,7 @@ default:
       value: true
   path:
     -
-      alias: /media/image/6
+      alias: /media/image/10
       langcode: en
       pathauto: 1
   field_media_image:

--- a/docroot/profiles/custom/sitenow/content/media/be324113-25ee-43e3-b6f2-26ce619ce852.yml
+++ b/docroot/profiles/custom/sitenow/content/media/be324113-25ee-43e3-b6f2-26ce619ce852.yml
@@ -24,7 +24,7 @@ default:
       value: true
   path:
     -
-      alias: /media/image/12
+      alias: /media/image/2
       langcode: en
       pathauto: 1
   field_media_image:

--- a/docroot/profiles/custom/sitenow/content/media/c064e28e-aae9-42f5-bb15-f40fa1d8a3d7.yml
+++ b/docroot/profiles/custom/sitenow/content/media/c064e28e-aae9-42f5-bb15-f40fa1d8a3d7.yml
@@ -24,7 +24,7 @@ default:
       value: true
   path:
     -
-      alias: /media/image/8
+      alias: /media/image/4
       langcode: en
       pathauto: 1
   field_media_image:

--- a/docroot/profiles/custom/sitenow/content/media/c7ad7c5d-0097-43b9-bc22-b479b5d30ac1.yml
+++ b/docroot/profiles/custom/sitenow/content/media/c7ad7c5d-0097-43b9-bc22-b479b5d30ac1.yml
@@ -24,7 +24,7 @@ default:
       value: true
   path:
     -
-      alias: /media/image/7
+      alias: /media/image/11
       langcode: en
       pathauto: 1
   field_media_image:

--- a/docroot/profiles/custom/sitenow/content/media/d872b41f-45af-4c94-9054-56d249130203.yml
+++ b/docroot/profiles/custom/sitenow/content/media/d872b41f-45af-4c94-9054-56d249130203.yml
@@ -24,7 +24,7 @@ default:
       value: true
   path:
     -
-      alias: /media/image/3
+      alias: /media/image/7
       langcode: en
       pathauto: 1
   field_media_image:

--- a/docroot/profiles/custom/sitenow/content/media/e40c44de-579d-4b50-9e5e-5b0c304564ff.yml
+++ b/docroot/profiles/custom/sitenow/content/media/e40c44de-579d-4b50-9e5e-5b0c304564ff.yml
@@ -24,7 +24,7 @@ default:
       value: true
   path:
     -
-      alias: /media/image/4
+      alias: /media/image/8
       langcode: en
       pathauto: 1
   field_media_image:

--- a/docroot/profiles/custom/sitenow/content/media/fc23ffc0-95e1-45ff-ab07-b92464068d66.yml
+++ b/docroot/profiles/custom/sitenow/content/media/fc23ffc0-95e1-45ff-ab07-b92464068d66.yml
@@ -24,7 +24,7 @@ default:
       value: true
   path:
     -
-      alias: /media/image/5
+      alias: /media/image/1
       langcode: en
       pathauto: 1
   field_media_image:

--- a/docroot/profiles/custom/sitenow/content/node/922b3b26-306a-457c-ba18-2c00966f81cf.yml
+++ b/docroot/profiles/custom/sitenow/content/node/922b3b26-306a-457c-ba18-2c00966f81cf.yml
@@ -228,7 +228,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '19'
-              block_revision_id: '21'
+              block_revision_id: '36'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_banner
@@ -267,8 +267,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '30'
+              block_id: '14'
+              block_revision_id: '37'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_text_area
@@ -276,7 +276,9 @@ default:
             weight: 0
             additional:
               layout_builder_styles_style:
-                - block_margin_top
+                0: ''
+                block_margin_top: block_margin_top
+                1: ''
               target_uuid: b8aba3a5-10de-42ad-8cb1-dee195b4d540
             third_party_settings: {  }
         third_party_settings: {  }
@@ -299,8 +301,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '31'
+              block_id: '4'
+              block_revision_id: '38'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_card
@@ -308,15 +310,18 @@ default:
             weight: 0
             additional:
               layout_builder_styles_style:
-                - block_background_style_light
-                - media_format_circle
-                - card_media_position_right
-                - media_size_small
-                - card_style_button_position
-                - no_border
-                - card_headline_style_serif
+                0: block_background_style_light
+                1: ''
+                2: card_headline_style_serif
+                3: card_media_position_right
+                4: media_format_circle
+                5: media_size_small
+                no_border: no_border
+                card_style_button_position: card_style_button_position
               target_uuid: 3e775397-cb1e-40de-9c53-f00e328edc2d
-            third_party_settings: {  }
+            third_party_settings:
+              layout_builder_custom:
+                media_types: image
           -
             uuid: 931862bc-a2ad-4b39-80db-77de3b4ba337
             region: second
@@ -326,8 +331,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '32'
+              block_id: '10'
+              block_revision_id: '39'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_card
@@ -335,15 +340,18 @@ default:
             weight: 0
             additional:
               layout_builder_styles_style:
-                - block_background_style_light
-                - media_format_circle
-                - card_media_position_right
-                - media_size_small
-                - card_style_button_position
-                - no_border
-                - card_headline_style_serif
+                0: block_background_style_light
+                1: ''
+                2: card_headline_style_serif
+                3: card_media_position_right
+                4: media_format_circle
+                5: media_size_small
+                no_border: no_border
+                card_style_button_position: card_style_button_position
               target_uuid: 631979b9-cf39-46d2-a357-e8857487fccd
-            third_party_settings: {  }
+            third_party_settings:
+              layout_builder_custom:
+                media_types: image
         third_party_settings: {  }
     -
       section:
@@ -368,8 +376,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '33'
+              block_id: '12'
+              block_revision_id: '40'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_image
@@ -389,8 +397,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '34'
+              block_id: '1'
+              block_revision_id: '41'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_statistic
@@ -398,8 +406,8 @@ default:
             weight: 0
             additional:
               layout_builder_styles_style:
-                - block_alignment_flex_row_center
-                - stat_remove_hover_effect
+                0: block_alignment_flex_row_center
+                stat_remove_hover_effect: stat_remove_hover_effect
               target_uuid: 30a2799f-c1bf-4ce5-a8f3-0bd71141a580
             third_party_settings: {  }
           -
@@ -411,8 +419,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '35'
+              block_id: '13'
+              block_revision_id: '42'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_image
@@ -447,8 +455,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '36'
+              block_id: '9'
+              block_revision_id: '43'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_statistic
@@ -456,8 +464,8 @@ default:
             weight: 0
             additional:
               layout_builder_styles_style:
-                - block_alignment_flex_row_center
-                - stat_remove_hover_effect
+                0: block_alignment_flex_row_center
+                stat_remove_hover_effect: stat_remove_hover_effect
               target_uuid: 5fd3432c-7324-4dc5-bfa1-54d07b43da77
             third_party_settings: {  }
           -
@@ -469,8 +477,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '37'
+              block_id: '6'
+              block_revision_id: '44'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_image
@@ -490,8 +498,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '38'
+              block_id: '15'
+              block_revision_id: '45'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_statistic
@@ -499,8 +507,8 @@ default:
             weight: 0
             additional:
               layout_builder_styles_style:
-                - block_alignment_flex_row_center
-                - stat_remove_hover_effect
+                0: block_alignment_flex_row_center
+                stat_remove_hover_effect: stat_remove_hover_effect
               target_uuid: c45277c6-60d5-44fb-9d00-689687a550ec
             third_party_settings: {  }
         third_party_settings: {  }
@@ -526,15 +534,17 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '39'
+              block_id: '3'
+              block_revision_id: '46'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_text_area
               uuid: 3d24809e-7064-4859-934c-6d07cbb33ed9
             weight: 0
             additional:
-              layout_builder_styles_style: {  }
+              layout_builder_styles_style:
+                - ''
+                - ''
               target_uuid: 3d24809e-7064-4859-934c-6d07cbb33ed9
             third_party_settings: {  }
           -
@@ -546,8 +556,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '40'
+              block_id: '17'
+              block_revision_id: '47'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_card
@@ -555,13 +565,18 @@ default:
             weight: 0
             additional:
               layout_builder_styles_style:
-                - block_background_style_light
-                - media_format_widescreen
-                - card_media_position_stacked
-                - media_size_large
-                - card_style_button_position
+                0: block_background_style_light
+                1: ''
+                2: card_headline_style_sans_serif
+                3: card_media_position_stacked
+                4: media_format_widescreen
+                5: media_size_large
+                no_border: 0
+                card_style_button_position: card_style_button_position
               target_uuid: e8a1a5d7-a7c6-4b59-a13d-ee498ec7232c
-            third_party_settings: {  }
+            third_party_settings:
+              layout_builder_custom:
+                media_types: image
           -
             uuid: 01d1abbc-4a8c-4fb4-96f3-7ba480101c9d
             region: third
@@ -571,8 +586,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '41'
+              block_id: '5'
+              block_revision_id: '48'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_card
@@ -580,13 +595,18 @@ default:
             weight: 0
             additional:
               layout_builder_styles_style:
-                - block_background_style_light
-                - media_format_widescreen
-                - card_media_position_stacked
-                - media_size_large
-                - card_style_button_position
+                0: block_background_style_light
+                1: ''
+                2: card_headline_style_sans_serif
+                3: card_media_position_stacked
+                4: media_format_widescreen
+                5: media_size_large
+                no_border: 0
+                card_style_button_position: card_style_button_position
               target_uuid: 41c43a1b-0473-45b1-b799-2b235c3904fb
-            third_party_settings: {  }
+            third_party_settings:
+              layout_builder_custom:
+                media_types: image
         third_party_settings: {  }
     -
       section:
@@ -608,6 +628,7 @@ default:
               provider: views
               views_label: ''
               items_per_page: '3'
+              exposed: {  }
               pager_offset: '0'
               fields:
                 field_article_source_link:
@@ -640,29 +661,35 @@ default:
                 created:
                   order: DESC
                   weight: '0'
+                title:
+                  order: ASC
+                  weight: '0'
               exposed_filter_values:
                 field_tags_target_id: null
                 field_person_type_status_value: null
                 field_person_type_status_value_op: null
               layout_builder_styles:
-                - block_background_style_light
-                - list_format_list
-                - block_grid_threecol_33_34_33
-                - media_format_widescreen
-                - card_media_position_right
-                - media_size_small
-                - no_border
+                0: block_background_style_light
+                1: list_format_list
+                2: block_grid_threecol_33_34_33
+                3: card_headline_style_serif
+                4: card_media_position_right
+                5: media_format_widescreen
+                6: media_size_small
+                no_border: no_border
               context_mapping: {  }
             weight: 0
             additional:
               layout_builder_styles_style:
-                - block_background_style_light
-                - list_format_list
-                - block_grid_threecol_33_34_33
-                - media_format_widescreen
-                - card_media_position_right
-                - media_size_small
-                - no_border
+                0: block_background_style_light
+                1: ''
+                2: list_format_list
+                3: block_grid_threecol_33_34_33
+                4: card_headline_style_serif
+                5: card_media_position_right
+                6: media_format_widescreen
+                7: media_size_small
+                no_border: no_border
             third_party_settings: {  }
           -
             uuid: e1d1a3e0-8008-4131-8c7d-2f0216e54252
@@ -674,7 +701,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '16'
-              block_revision_id: '22'
+              block_revision_id: '49'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_events
@@ -715,8 +742,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '43'
+              block_id: '18'
+              block_revision_id: '50'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_cta
@@ -724,6 +751,7 @@ default:
             weight: 0
             additional:
               layout_builder_styles_style:
+                - ''
                 - block_background_style_gold
               target_uuid: e92499d4-4692-4937-882f-4abb975e6e85
             third_party_settings: {  }

--- a/docroot/profiles/custom/sitenow/content/node/f44a17cb-a187-4286-ad9f-aae44a8e9f85.yml
+++ b/docroot/profiles/custom/sitenow/content/node/f44a17cb-a187-4286-ad9f-aae44a8e9f85.yml
@@ -213,7 +213,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_revision_id: '23'
+              block_id: null
+              block_revision_id: '20'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_text_area
@@ -245,7 +246,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_revision_id: '13'
+              block_id: null
+              block_revision_id: '11'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_card
@@ -269,7 +271,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_revision_id: '5'
+              block_id: null
+              block_revision_id: '7'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_card
@@ -293,7 +296,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_revision_id: '6'
+              block_id: null
+              block_revision_id: '8'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_card


### PR DESCRIPTION
Two recent site installs (first since default content was updated) are erroring when trying to view node 1 or the layout.

`TypeError: Drupal\Core\Render\Element::children(): Argument #1 ($elements) must be of type array, null given, called in /var/www/html/docroot/modules/custom/layout_builder_custom/src/EventSubscriber/SectionComponentSubscriber.php on line 183`

https://github.com/uiowa/uiowa/blob/ce574f8e9f4c74f673fccac4714e0e6c767be69a/docroot/modules/custom/layout_builder_custom/src/EventSubscriber/SectionComponentSubscriber.php#L181-L187

When debugging, it thinks the plugin id is card but the content is statistic which then fails when it assumes the card image exists.

<img width="485" alt="Screenshot 2025-04-30 at 3 22 21 PM" src="https://github.com/user-attachments/assets/5681d2d7-1fce-44b6-a96d-bd5cf43e6f90" />
<img width="900" alt="Screenshot 2025-04-30 at 3 23 04 PM" src="https://github.com/user-attachments/assets/82099ca7-1518-4485-b21b-1431dbdadf95" />


<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

gut the files directory except for .htaccess - `docroot/sites/default/files`
```
ddev drush @default.local sql-drop -y && ddev drush @default.local cr && ddev blt di --site=default
```
Login and try to resave /node/1/layout

Node Revision Delete changelog: https://git.drupalcode.org/project/node_revision_delete/-/compare/2.0.0-rc1...2.0.0?from_project_id=49284