### PR TITLE
[Photoswipe] Added fix for image gallery stretching.

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/image-gallery-block.scss
+++ b/docroot/themes/custom/uids_base/scss/components/image-gallery-block.scss
@@ -6,12 +6,18 @@
     color: variables.$light;
   }
 }
+
 .pswp__button {
   z-index: 1;
 }
+
 .pswp__caption__center {
   text-align: center;
   max-width: 80%;
+}
+
+.pswp img {
+  object-fit: contain;
 }
 
 // Masonry


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/8616


<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt frontend && ddev blt ds --site=chem.uiowa.edu && ddev drush @chem.local uli /glass-facility
```
1. Check out the stretched images on https://github.com/uiowa/uiowa/issues/8616
2. Confirm this fix stops the stretching
3. Approve