### PR TITLE
Default Content - go back to old patch, re-export node 1 and 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -261,7 +261,7 @@
                 "Changing an existing embedded media's alignment or alt data attributes does not get saved with CKEditor": "https://www.drupal.org/files/issues/2023-01-03/3330723-3.patch"
             },
             "drupal/default_content": {
-                "Add a Normalizer and Denormalizer to support Layout Builder": "https://www.drupal.org/files/issues/2025-01-28/default_content-3160146-layout-builder-support-MR-15-87.patch",
+                "Add a Normalizer and Denormalizer to support Layout Builder": "https://www.drupal.org/files/issues/2022-12-06/default_content-3160146-53.patch",
                 "Predictable order of content import": "https://www.drupal.org/files/issues/2020-10-08/3175870.patch"
             },
             "drupal/editor_advanced_link": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b015ced1afe836ffe2571a36fafbef0a",
+    "content-hash": "dc24398bde2701a386961493bfb19d5b",
     "packages": [
         {
             "name": "acquia/blt",
@@ -504,12 +504,12 @@
             "version": "v1.8.7",
             "source": {
                 "type": "git",
-                "url": "git@github.com:harvesthq/bower-chosen.git",
+                "url": "https://github.com/harvesthq/chosen-package.git",
                 "reference": "ad86732b668627c131e61ee8f0e6e9ed52e4db8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/harvesthq/bower-chosen/zipball/ad86732b668627c131e61ee8f0e6e9ed52e4db8d",
+                "url": "https://api.github.com/repos/harvesthq/chosen-package/zipball/ad86732b668627c131e61ee8f0e6e9ed52e4db8d",
                 "reference": "ad86732b668627c131e61ee8f0e6e9ed52e4db8d"
             },
             "type": "bower-asset",

--- a/docroot/profiles/custom/sitenow/content/block_content/41c43a1b-0473-45b1-b799-2b235c3904fb.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/41c43a1b-0473-45b1-b799-2b235c3904fb.yml
@@ -13,9 +13,6 @@ default:
   reusable:
     -
       value: false
-  revision_translation_affected:
-    -
-      value: true
   field_uiowa_card_button_display:
     -
       value: '1'

--- a/docroot/profiles/custom/sitenow/content/block_content/5026fa65-d6f5-464b-820b-e1cca3ff6be3.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/5026fa65-d6f5-464b-820b-e1cca3ff6be3.yml
@@ -16,7 +16,7 @@ default:
       value: true
   field_uiowa_card_button_display:
     -
-      value: 'Use site default'
+      value: '1'
   field_uiowa_card_excerpt:
     -
       value: "<p>Site support, feature questions, and general requests.</p>\r\n"
@@ -25,7 +25,11 @@ default:
     -
       uri: 'https://sitenow.uiowa.edu/contact-us'
       title: 'Contact Us'
-      options: {  }
+      options:
+        href: 'https://sitenow.uiowa.edu/contact-us'
+        data-entity-type: ''
+        data-entity-uuid: ''
+        data-entity-substitution: ''
   field_uiowa_card_title:
     -
       size: h2

--- a/docroot/profiles/custom/sitenow/content/block_content/5294fe6f-aad8-46ab-8b48-f98d11e41818.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/5294fe6f-aad8-46ab-8b48-f98d11e41818.yml
@@ -16,7 +16,7 @@ default:
       value: true
   field_uiowa_card_button_display:
     -
-      value: 'Use site default'
+      value: '1'
   field_uiowa_card_excerpt:
     -
       value: "<p>Consultations on site content, web strategy, and what to put on your website.&nbsp;</p>\r\n"
@@ -25,7 +25,11 @@ default:
     -
       uri: 'mailto:UI-web-strategy@uiowa.edu'
       title: 'Email UI Web Strategy'
-      options: {  }
+      options:
+        href: 'mailto:UI-web-strategy@uiowa.edu'
+        data-entity-type: ''
+        data-entity-uuid: ''
+        data-entity-substitution: ''
   field_uiowa_card_title:
     -
       size: h2

--- a/docroot/profiles/custom/sitenow/content/block_content/81baa7ae-8510-4cec-ad00-c29e95098229.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/81baa7ae-8510-4cec-ad00-c29e95098229.yml
@@ -16,7 +16,7 @@ default:
       value: true
   field_uiowa_card_button_display:
     -
-      value: 'Use site default'
+      value: '1'
   field_uiowa_card_excerpt:
     -
       value: "<p>Updates, feature info, and Help documents for the SiteNow service.</p>\r\n"
@@ -25,7 +25,11 @@ default:
     -
       uri: 'https://sitenow.uiowa.edu/'
       title: 'SiteNow Help'
-      options: {  }
+      options:
+        href: 'https://sitenow.uiowa.edu/'
+        data-entity-type: ''
+        data-entity-uuid: ''
+        data-entity-substitution: ''
   field_uiowa_card_title:
     -
       size: h2

--- a/docroot/profiles/custom/sitenow/content/block_content/e8a1a5d7-a7c6-4b59-a13d-ee498ec7232c.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/e8a1a5d7-a7c6-4b59-a13d-ee498ec7232c.yml
@@ -13,9 +13,6 @@ default:
   reusable:
     -
       value: false
-  revision_translation_affected:
-    -
-      value: true
   field_uiowa_card_button_display:
     -
       value: '1'

--- a/docroot/profiles/custom/sitenow/content/block_content/e92499d4-4692-4937-882f-4abb975e6e85.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/e92499d4-4692-4937-882f-4abb975e6e85.yml
@@ -11,9 +11,6 @@ default:
   reusable:
     -
       value: false
-  revision_translation_affected:
-    -
-      value: true
   field_uiowa_cta_link:
     -
       uri: 'internal:/admin/content'

--- a/docroot/profiles/custom/sitenow/content/block_content/ecb118da-056e-4ebc-8492-315b526d0534.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/ecb118da-056e-4ebc-8492-315b526d0534.yml
@@ -14,14 +14,6 @@ default:
   revision_translation_affected:
     -
       value: true
-  field_uiowa_headline:
-    -
-      headline: ''
-      heading_size: h2
-      hide_headline: '0'
-      headline_style: default
-      headline_alignment: default
-      child_heading_size: h2
   field_uiowa_text_area:
     -
       value: "<p class=\"uids-component--light-intro\">If you have questions about using your SiteNow site, we're here to help.</p>\r\n"

--- a/docroot/profiles/custom/sitenow/content/node/922b3b26-306a-457c-ba18-2c00966f81cf.yml
+++ b/docroot/profiles/custom/sitenow/content/node/922b3b26-306a-457c-ba18-2c00966f81cf.yml
@@ -53,6 +53,15 @@ default:
       alias: /home
       langcode: en
       pathauto: 1
+  rh_action:
+    -
+      value: bundle_default
+  rh_redirect_response:
+    -
+      value: 301
+  rh_redirect_fallback_action:
+    -
+      value: bundle_default
   field_publish_options:
     -
       value: title_hidden
@@ -228,7 +237,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '19'
-              block_revision_id: '36'
+              block_revision_id: '21'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_banner
@@ -268,7 +277,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '14'
-              block_revision_id: '37'
+              block_revision_id: '22'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_text_area
@@ -302,7 +311,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '4'
-              block_revision_id: '38'
+              block_revision_id: '23'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_card
@@ -332,7 +341,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '10'
-              block_revision_id: '39'
+              block_revision_id: '24'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_card
@@ -377,7 +386,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '12'
-              block_revision_id: '40'
+              block_revision_id: '25'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_image
@@ -398,7 +407,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '1'
-              block_revision_id: '41'
+              block_revision_id: '26'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_statistic
@@ -420,7 +429,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '13'
-              block_revision_id: '42'
+              block_revision_id: '27'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_image
@@ -456,7 +465,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '9'
-              block_revision_id: '43'
+              block_revision_id: '28'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_statistic
@@ -478,7 +487,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '6'
-              block_revision_id: '44'
+              block_revision_id: '29'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_image
@@ -499,7 +508,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '15'
-              block_revision_id: '45'
+              block_revision_id: '30'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_statistic
@@ -535,7 +544,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '3'
-              block_revision_id: '46'
+              block_revision_id: '31'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_text_area
@@ -557,7 +566,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '17'
-              block_revision_id: '47'
+              block_revision_id: '32'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_card
@@ -587,7 +596,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '5'
-              block_revision_id: '48'
+              block_revision_id: '33'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_card
@@ -701,7 +710,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '16'
-              block_revision_id: '49'
+              block_revision_id: '34'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_events
@@ -743,7 +752,7 @@ default:
               provider: layout_builder
               view_mode: full
               block_id: '18'
-              block_revision_id: '50'
+              block_revision_id: '35'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_cta

--- a/docroot/profiles/custom/sitenow/content/node/f44a17cb-a187-4286-ad9f-aae44a8e9f85.yml
+++ b/docroot/profiles/custom/sitenow/content/node/f44a17cb-a187-4286-ad9f-aae44a8e9f85.yml
@@ -43,6 +43,15 @@ default:
       alias: /about
       langcode: en
       pathauto: 1
+  rh_action:
+    -
+      value: bundle_default
+  rh_redirect_response:
+    -
+      value: 301
+  rh_redirect_fallback_action:
+    -
+      value: bundle_default
   layout_builder__layout:
     -
       section:
@@ -213,15 +222,17 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '20'
+              block_id: '20'
+              block_revision_id: '36'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_text_area
               uuid: ecb118da-056e-4ebc-8492-315b526d0534
             weight: 0
             additional:
-              layout_builder_styles_style: {  }
+              layout_builder_styles_style:
+                - ''
+                - ''
               target_uuid: ecb118da-056e-4ebc-8492-315b526d0534
             third_party_settings: {  }
         third_party_settings:
@@ -246,8 +257,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '11'
+              block_id: '11'
+              block_revision_id: '37'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_card
@@ -255,13 +266,18 @@ default:
             weight: 0
             additional:
               layout_builder_styles_style:
-                - block_background_style_light
-                - media_format_widescreen
-                - card_media_position_stacked
-                - media_size_large
-                - card_style_button_position
+                0: block_background_style_light
+                1: ''
+                2: card_headline_style_sans_serif
+                3: card_media_position_stacked
+                4: media_format_widescreen
+                5: media_size_large
+                no_border: 0
+                card_style_button_position: card_style_button_position
               target_uuid: 81baa7ae-8510-4cec-ad00-c29e95098229
-            third_party_settings: {  }
+            third_party_settings:
+              layout_builder_custom:
+                media_types: image
           -
             uuid: 42b7bd3d-2a24-4fb0-baa5-1be042ab2555
             region: second
@@ -271,8 +287,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '7'
+              block_id: '7'
+              block_revision_id: '38'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_card
@@ -280,13 +296,18 @@ default:
             weight: 0
             additional:
               layout_builder_styles_style:
-                - block_background_style_light
-                - media_format_widescreen
-                - card_media_position_stacked
-                - media_size_large
-                - card_style_button_position
+                0: block_background_style_light
+                1: ''
+                2: card_headline_style_sans_serif
+                3: card_media_position_stacked
+                4: media_format_widescreen
+                5: media_size_large
+                no_border: 0
+                card_style_button_position: card_style_button_position
               target_uuid: 5026fa65-d6f5-464b-820b-e1cca3ff6be3
-            third_party_settings: {  }
+            third_party_settings:
+              layout_builder_custom:
+                media_types: image
           -
             uuid: 3d411f17-e776-42d2-a7bd-5334f18cb3be
             region: third
@@ -296,8 +317,8 @@ default:
               label_display: null
               provider: layout_builder
               view_mode: full
-              block_id: null
-              block_revision_id: '8'
+              block_id: '8'
+              block_revision_id: '39'
               block_serialized: null
               context_mapping: {  }
               type: uiowa_card
@@ -305,13 +326,18 @@ default:
             weight: 0
             additional:
               layout_builder_styles_style:
-                - block_background_style_light
-                - media_format_widescreen
-                - card_media_position_stacked
-                - media_size_large
-                - card_style_button_position
+                0: block_background_style_light
+                1: ''
+                2: card_headline_style_sans_serif
+                3: card_media_position_stacked
+                4: media_format_widescreen
+                5: media_size_large
+                no_border: 0
+                card_style_button_position: card_style_button_position
               target_uuid: 5294fe6f-aad8-46ab-8b48-f98d11e41818
-            third_party_settings: {  }
+            third_party_settings:
+              layout_builder_custom:
+                media_types: image
         third_party_settings:
           layout_builder_lock:
             lock: {  }


### PR DESCRIPTION
Background: https://iowaweb.slack.com/archives/C0164FNN1PV/p1746117287134089

Attempt to go back to the patch that was working for the most part. I _didn't_ get the `Object support when dumping a YAML file has been disabled.` error this time.

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

gut the files directory except for .htaccess - `docroot/sites/default/files`
```
ddev drush @default.local sql-drop -y && ddev drush @default.local cr && ddev blt di --site=default
```
Login and try to resave /node/1/layout

"_Everything in Its Right Place_" 🎶 
