### PR TITLE
[Decorative images] Added decorative image widget module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,6 +101,7 @@
         "drupal/cshs": "^4.0",
         "drupal/ctools": "^4.0",
         "drupal/date_popup": "^2.0",
+        "drupal/decorative_image_widget": "^1.0",
         "drupal/default_content": "^2.0@alpha",
         "drupal/devel": "^5.1",
         "drupal/diff": "^2.0@beta",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b015ced1afe836ffe2571a36fafbef0a",
+    "content-hash": "20d85226c11faf8f3e2eae1b8c223942",
     "packages": [
         {
             "name": "acquia/blt",
@@ -4798,6 +4798,55 @@
             "homepage": "https://www.drupal.org/project/date_popup",
             "support": {
                 "source": "https://git.drupalcode.org/project/date_popup"
+            }
+        },
+        {
+            "name": "drupal/decorative_image_widget",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/decorative_image_widget.git",
+                "reference": "1.0.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/decorative_image_widget-1.0.2.zip",
+                "reference": "1.0.2",
+                "shasum": "cdd16e48141343fe76429aee0efca9a09e782610"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.2",
+                    "datestamp": "1729870701",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "bkosborne",
+                    "homepage": "https://www.drupal.org/user/788032"
+                },
+                {
+                    "name": "mably",
+                    "homepage": "https://www.drupal.org/user/3375160"
+                }
+            ],
+            "description": "Modifies image widgets to require alt text OR be marked as decorative.",
+            "homepage": "https://drupal.org/project/decorative_image_widget",
+            "support": {
+                "source": "https://git.drupalcode.org/project/decorative_image_widget",
+                "issues": "https://www.drupal.org/project/issues/decorative_image_widget"
             }
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20d85226c11faf8f3e2eae1b8c223942",
+    "content-hash": "fb1553bcd0dffdcc572fb4e20ea56384",
     "packages": [
         {
             "name": "acquia/blt",
@@ -23799,9 +23799,9 @@
         "ext-json": "*",
         "ext-simplexml": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/default/core.entity_form_display.media.image.default.yml
+++ b/config/default/core.entity_form_display.media.image.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - image.style.thumbnail
     - media.type.image
   module:
+    - decorative_image_widget
     - focal_point
     - path
     - text
@@ -42,7 +43,9 @@ content:
       preview_image_style: thumbnail
       preview_link: true
       offsets: '50,50'
-    third_party_settings: {  }
+    third_party_settings:
+      decorative_image_widget:
+        use_decorative_checkbox: true
   field_tags:
     type: entity_reference_autocomplete
     weight: 4

--- a/config/default/core.entity_form_display.media.image.media_browsers.yml
+++ b/config/default/core.entity_form_display.media.image.media_browsers.yml
@@ -10,6 +10,7 @@ dependencies:
     - image.style.thumbnail
     - media.type.image
   module:
+    - decorative_image_widget
     - focal_point
     - text
 _core:
@@ -36,7 +37,9 @@ content:
       preview_image_style: thumbnail
       preview_link: true
       offsets: '50,50'
-    third_party_settings: {  }
+    third_party_settings:
+      decorative_image_widget:
+        use_decorative_checkbox: true
   field_tags:
     type: entity_reference_autocomplete_tags
     weight: 3

--- a/config/default/core.entity_form_display.media.image.media_library.yml
+++ b/config/default/core.entity_form_display.media.image.media_library.yml
@@ -10,6 +10,7 @@ dependencies:
     - image.style.thumbnail
     - media.type.image
   module:
+    - decorative_image_widget
     - focal_point
     - text
 _core:
@@ -36,7 +37,9 @@ content:
       preview_image_style: thumbnail
       preview_link: true
       offsets: '50,50'
-    third_party_settings: {  }
+    third_party_settings:
+      decorative_image_widget:
+        use_decorative_checkbox: true
   field_tags:
     type: entity_reference_autocomplete_tags
     weight: 3

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -26,6 +26,7 @@ module:
   ctools: 0
   ctools_views: 0
   datetime: 0
+  decorative_image_widget: 0
   default_content: 0
   diff: 0
   draggableviews: 0

--- a/config/default/field.field.media.image.field_media_image.yml
+++ b/config/default/field.field.media.image.field_media_image.yml
@@ -31,7 +31,7 @@ settings:
   max_resolution: 2952x2952
   min_resolution: ''
   alt_field: true
-  alt_field_required: true
+  alt_field_required: false
   title_field: false
   title_field_required: false
   default_image:

--- a/config/default/field.storage.media.field_media_image.yml
+++ b/config/default/field.storage.media.field_media_image.yml
@@ -21,7 +21,7 @@ settings:
   display_default: false
   uri_scheme: public
   default_image:
-    uuid: null
+    uuid: ''
     alt: ''
     title: ''
     width: null


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/8711. 


<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

- Review draft of https://sitenow.uiowa.edu/node/326/latest.  Added a section under "Alternative text" on the decorative images. 

- Only intranet sites are splitting https://github.com/uiowa/uiowa/blob/main/config/features/sitenow_intranet/config_split.patch.field.storage.media.field_media_image.yml.  Can you think of anywhere else this is split?

```
ddev composer install && ddev blt ds --site=connect.studentlife.uiowa.edu && ddev drush @studentlifeconnect.local uli /media/add/image
```
1. Add an image. 
2. Confirm you can check the box to make decorative. 
3. Confirm you can override alt text on that image when embedding the image in a page by clicking on the "eye" icon when you click on the embedded image. 
4. Test other places you can think of like a text area block, etc. 
5. Try editing an existing image alt text by turning it decorative under ` /media/` and you will get an error.  I've tested this on `main` and get the same issue. `Source image at [path] not found while trying to generate derivative image at [path].` 

```
ddev composer install && ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli /media/add/image
```
1. Add an image. 
2. Confirm you can check the box to make decorative. 
3. Confirm you can override alt text on that image when embedding the image in a page by clicking on the "eye" icon when you click on the embedded image. 
4. Test other places you can think of like a text area block, etc. 
5. Try editing an existing image alt text by turning it decorative under ` /media/` and you will get an error.  I've tested this on `main` and get the same issue. `Source image at [path] not found while trying to generate derivative image at [path].` 

