### PR TITLE
[Icons] Updated brand icons version

### DIFF
--- a/docroot/themes/custom/uids_base/package.json
+++ b/docroot/themes/custom/uids_base/package.json
@@ -4,7 +4,7 @@
   "license": "ISC",
   "dependencies": {
     "@uiowa/uids4": "https://github.com/uiowa/uids.git#2276de0",
-    "@uiowa/brand-icons": "https://github.com/uiowa/brand-icons.git#4befd4a",
+    "@uiowa/brand-icons": "https://github.com/uiowa/brand-icons.git#95911bc",
     "autoprefixer": "^9.8.8",
     "cssnano": "^7.0.6",
     "postcss": "^8.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1270,9 +1270,9 @@
   dependencies:
     "@types/node" "*"
 
-"@uiowa/brand-icons@https://github.com/uiowa/brand-icons.git#4befd4a":
+"@uiowa/brand-icons@https://github.com/uiowa/brand-icons.git#95911bc":
   version "1.0.0"
-  resolved "https://github.com/uiowa/brand-icons.git#4befd4ab59adf4b6c00fda60ee3fee41bb4777ba"
+  resolved "https://github.com/uiowa/brand-icons.git#95911bc3c2e54594247d2fb97c0edd4b449f0164"
   dependencies:
     core-js "^3.8.3"
     fs "0.0.1-security"


### PR DESCRIPTION
Updating the icons that were changed in https://github.com/uiowa/brand-icons/pull/38. 

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

- Confirm commit hash matches latest commit in https://github.com/uiowa/brand-icons. 
- Delete `assets/icons/` directory
```
ddev blt frontend && ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli /
```
- Add a card, add a icon, search for removed icons. 
