### PR TITLE
[Bug] Adjusted how banner is attached to slider component.

### DIFF
--- a/docroot/themes/custom/uids_base/uids_base.libraries.yml
+++ b/docroot/themes/custom/uids_base/uids_base.libraries.yml
@@ -120,10 +120,9 @@ slider:
   css:
     component:
       assets/css/components/slider.css: { preprocess: false }
+      assets/css/components/banner.css: { preprocess: false }
   js:
     uids/assets/js/slider.js: { preprocess: true }
-  dependencies:
-    - uids_base/banner
 remote-video:
   css:
     component:


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test
## theatre.uiowa.edu

```
ddev blt ds --site=theatre.uiowa.edu  && ddev drush @theatre.local uli /certificate-social-justice-and-performing-arts
```

1. Update https://github.com/uiowa/uiowa/blob/main/docroot/sites/theatre.uiowa.edu/settings/default.local.settings.php#L63 to `TRUE`. 
2. Go to `/certificate-social-justice-and-performing-arts` and confirm slider, horizontal menu, superfish menu toggle works and no console errors. 
3. Change https://github.com/uiowa/uiowa/blob/main/docroot/themes/custom/uids_base/uids_base.libraries.yml#L125 to include banner dependency that was removed and notice that the slider does not work and the horizontal menu does not have a toggle for the dropdown `ddev drush @theatre.local cr` and refreshing the page.  The console should show lots of "Resource blocked" messages. 

<img width="1933" alt="Screenshot 2025-05-08 at 1 23 53 PM" src="https://github.com/user-attachments/assets/a0917797-d2c6-4c32-8638-2ffb32276686" />
