### PR TITLE
Remove "Add Views EntityReference filter to be available for all entity reference fields" patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -242,7 +242,6 @@
                 "Site extensions don't get rediscovered after drush cr": "https://www.drupal.org/files/issues/2018-07-11/specify_sitepath_cache_rebuild_extension_discovery-2985199-3.patch",
                 "[PP-1] Reverting entity revisions that contain custom blocks erroneously triggers EntityChangedConstraint": "https://www.drupal.org/files/issues/2021-01-27/3053881-42.patch",
                 "Expose Layout Builder data to REST and JSON:API": "https://www.drupal.org/files/issues/2024-09-06/2942975-10.3.x.patch",
-                "Add Views EntityReference filter to be available for all entity reference fields": "https://www.drupal.org/files/issues/2024-08-19/2429699-546-10.3.x.patch",
                 "Views Block Display skips preBlockBuild() call on ajax rebuild": "https://www.drupal.org/files/issues/2024-06-13/2605218-135.patch",
                 "Periods in query strings are replaced by underscores": "https://www.drupal.org/files/issues/2020-06-25/fix-mangled-query-parameter-names-2984272-36.patch",
                 "Fix LB contextual links after dragging block to new section": "https://www.drupal.org/files/issues/2023-06-09/3160785-uuid_0.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb1553bcd0dffdcc572fb4e20ea56384",
+    "content-hash": "c25e1a5be8071313b8928da1c15898bd",
     "packages": [
         {
             "name": "acquia/blt",


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/6039

# How to test

```
ddev composer install && ddev blt frontend && ddev drush @admissions.local sql-drop -y && ddev drush @admissions.local cr && ddev blt ds --site=admissions.uiowa.edu && ddev drush @admissions.local uli areas-of-study
```

Test to make sure the filtering still work as https://admissions.uiowa.edu/areas-of-study does
