### PR TITLE
Updated layout_builder_lock to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -138,7 +138,7 @@
         "drupal/jsonapi_extras": "^3.23",
         "drupal/jsonapi_include": "^1.6",
         "drupal/layout_builder_limit": "^1.0@beta",
-        "drupal/layout_builder_lock": "^1.1",
+        "drupal/layout_builder_lock": "^2.0@RC",
         "drupal/layout_builder_operation_link": "^2.2",
         "drupal/layout_builder_restrictions": "^3.0",
         "drupal/layout_builder_shortcuts": "^1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48e90800daac9165891b68743c9c9561",
+    "content-hash": "4055b83cc44a23c30f52f9ffe2bf9b47",
     "packages": [
         {
             "name": "acquia/blt",
@@ -7419,29 +7419,29 @@
         },
         {
             "name": "drupal/layout_builder_lock",
-            "version": "1.2.0",
+            "version": "2.0.0-rc2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/layout_builder_lock.git",
-                "reference": "8.x-1.2"
+                "reference": "2.0.0-rc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/layout_builder_lock-8.x-1.2.zip",
-                "reference": "8.x-1.2",
-                "shasum": "818a70463a349c55db9ca31d6dd9ab926c427d6c"
+                "url": "https://ftp.drupal.org/files/projects/layout_builder_lock-2.0.0-rc2.zip",
+                "reference": "2.0.0-rc2",
+                "shasum": "b839b3f97593759c8f9077cefeb9d84fb9283aaa"
             },
             "require": {
-                "drupal/core": "^9.2 || ^10"
+                "drupal/core": "^9.2 || ^10 || ^11"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.2",
-                    "datestamp": "1666207477",
+                    "version": "2.0.0-rc2",
+                    "datestamp": "1717529277",
                     "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
+                        "status": "not-covered",
+                        "message": "RC releases are not covered by Drupal security advisories."
                     }
                 }
             },
@@ -23889,6 +23889,7 @@
         "drupal/entity_usage": 10,
         "drupal/find_text": 10,
         "drupal/layout_builder_limit": 10,
+        "drupal/layout_builder_lock": 5,
         "drupal/masquerade": 10,
         "drupal/media_entity_file_replace": 10,
         "drupal/menu_link_weight": 10,
@@ -23905,9 +23906,9 @@
         "ext-json": "*",
         "ext-simplexml": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4055b83cc44a23c30f52f9ffe2bf9b47",
+    "content-hash": "79d581ef55a1c7ea938188863f71e081",
     "packages": [
         {
             "name": "acquia/blt",

--- a/docroot/themes/custom/uids_base/scss/admin.scss
+++ b/docroot/themes/custom/uids_base/scss/admin.scss
@@ -4,6 +4,7 @@
 @use 'admin/_off-canvas.scss';
 @use 'admin/_chosen.scss';
 @use 'admin/_lb-direct-add.scss';
+@use 'admin/_lb-lock.scss';
 @use 'admin/_toolbar.scss';
 @use 'admin/_claro.scss';
 @use 'admin/_ui_icons.scss';

--- a/docroot/themes/custom/uids_base/scss/admin/_lb-lock.scss
+++ b/docroot/themes/custom/uids_base/scss/admin/_lb-lock.scss
@@ -1,0 +1,7 @@
+@use '../uids/scss/abstracts/_variables.scss';
+@use '../uids/scss/abstracts/_utilities.scss';
+// lb_lock module overrides.
+
+.layout-builder-block-locked:not(b) {
+  padding: 0;
+}


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev composer install && ddev blt frontend && ddev blt di --site=default && ddev drush @default.local uli /admin/people
```
1. Add a webmaster to masquerade as
2. Add a featured image to `/about`
3. Edit the layout
4. Confirm spacing on the screenshot below is gone from the featured image
5. Confirm that you can't edit the featured image section and that it is locked. 

I tested updating the header section on the page content type and did not see any new config changes. 