### PR TITLE
Updated siteimprove to 3.0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -188,7 +188,7 @@
         "drupal/search_api_autocomplete": "^1.5",
         "drupal/simple_sitemap": "^4.2",
         "drupal/simplei": "^2.1",
-        "drupal/siteimprove": "^2.0",
+        "drupal/siteimprove": "^3.0",
         "drupal/smart_date": "^4.0.3",
         "drupal/smart_trim": "^2.0",
         "drupal/stage_file_proxy": "^3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "825eb5c38e53f01b9528c0217c843650",
+    "content-hash": "875de019aae7f72e190611e5a3c09a58",
     "packages": [
         {
             "name": "acquia/blt",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f67bb0f883c34a0f8a9d625e74131f2",
+    "content-hash": "d761fa05691f046ca48698b450510338",
     "packages": [
         {
             "name": "acquia/blt",
@@ -7254,6 +7254,50 @@
             }
         },
         {
+            "name": "drupal/js_cookie",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/js_cookie.git",
+                "reference": "1.0.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/js_cookie-1.0.1.zip",
+                "reference": "1.0.1",
+                "shasum": "e010b3de64a0d57eef9c1773c4dd7e3d9bd9118c"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.1",
+                    "datestamp": "1693951097",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                }
+            ],
+            "description": "Provides the js-cookie library as a dependency.",
+            "homepage": "https://www.drupal.org/project/js_cookie",
+            "support": {
+                "source": "https://git.drupalcode.org/project/js_cookie"
+            }
+        },
+        {
             "name": "drupal/jsonapi_extras",
             "version": "3.24.0",
             "source": {
@@ -10824,20 +10868,21 @@
         },
         {
             "name": "drupal/siteimprove",
-            "version": "2.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/siteimprove.git",
-                "reference": "2.0.2"
+                "reference": "3.0.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/siteimprove-2.0.2.zip",
-                "reference": "2.0.2",
-                "shasum": "9e716fcd5ae3e7b23a1c8a9bdc6a0980085c2642"
+                "url": "https://ftp.drupal.org/files/projects/siteimprove-3.0.3.zip",
+                "reference": "3.0.3",
+                "shasum": "31e76df1be474ce5a3b78f8be7e1afa143888c87"
             },
             "require": {
-                "drupal/core": "^9.2 || ^10"
+                "drupal/core": "^10.2 || ^11",
+                "drupal/js_cookie": "^1.0"
             },
             "require-dev": {
                 "drupal/domain_access": "*"
@@ -10845,8 +10890,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.2",
-                    "datestamp": "1704376526",
+                    "version": "3.0.3",
+                    "datestamp": "1742904256",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -66,6 +66,7 @@ module:
   jquery_ui_datepicker: 0
   jquery_ui_slider: 0
   jquery_ui_touch_punch: 0
+  js_cookie: 0
   layout_builder: 0
   layout_builder_expose_all_field_blocks: 0
   layout_builder_limit: 0

--- a/config/envs/dev/siteimprove.settings.yml
+++ b/config/envs/dev/siteimprove.settings.yml
@@ -5,4 +5,5 @@ domain_plugin_id: siteimprovedomain_simple
 prepublish_enabled: false
 enabled_group_types: null
 overlay_default_collapse: false
+overlay_cookie_secure: false
 use_latest_experience: false

--- a/config/envs/prod/config_split.patch.user.role.webmaster.yml
+++ b/config/envs/prod/config_split.patch.user.role.webmaster.yml
@@ -2,7 +2,6 @@ adding:
   dependencies:
     module:
       - siteimprove
-      - js_cookie
   permissions:
     - 'use siteimprove'
 removing: {  }

--- a/config/envs/prod/config_split.patch.user.role.webmaster.yml
+++ b/config/envs/prod/config_split.patch.user.role.webmaster.yml
@@ -2,6 +2,7 @@ adding:
   dependencies:
     module:
       - siteimprove
+      - js_cookie
   permissions:
     - 'use siteimprove'
 removing: {  }

--- a/config/envs/prod/siteimprove.settings.yml
+++ b/config/envs/prod/siteimprove.settings.yml
@@ -4,16 +4,6 @@ langcode: en
 token: b8ca141174884c64bb80df204f92d070
 domain_plugin_id: siteimprovedomain_simple
 prepublish_enabled: false
-api_username: ''
-api_key: ''
-enabled_content_types:
-  article: '0'
-  contact: '0'
-  page: '0'
-  person: '0'
-enabled_taxonomies:
-  research_areas: '0'
-  tags: '0'
 enabled_group_types: null
 overlay_default_collapse: false
 overlay_cookie_secure: false

--- a/config/envs/prod/siteimprove.settings.yml
+++ b/config/envs/prod/siteimprove.settings.yml
@@ -4,6 +4,17 @@ langcode: en
 token: b8ca141174884c64bb80df204f92d070
 domain_plugin_id: siteimprovedomain_simple
 prepublish_enabled: false
+api_username: ''
+api_key: ''
+enabled_content_types:
+  article: '0'
+  contact: '0'
+  page: '0'
+  person: '0'
+enabled_taxonomies:
+  research_areas: '0'
+  tags: '0'
 enabled_group_types: null
 overlay_default_collapse: false
+overlay_cookie_secure: false
 use_latest_experience: false

--- a/config/envs/stage/siteimprove.settings.yml
+++ b/config/envs/stage/siteimprove.settings.yml
@@ -5,4 +5,5 @@ domain_plugin_id: siteimprovedomain_simple
 prepublish_enabled: false
 enabled_group_types: null
 overlay_default_collapse: false
+overlay_cookie_secure: false
 use_latest_experience: false


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev composer install && ddev  blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli /admin/config/system/siteimprove
```

Review changelog https://git.drupalcode.org/project/siteimprove/-/compare/2.0.2...3.0.3?from_project_id=48082&straight=false

- Because this is environment based, actual testing of the functionality needs to happen in PROD where these domains are hooked up with the SiteImprove service.
- To test config import, etc., pick a site and change which environment split is imported on sync by adjusting the site's local.settings.php file:

```
$config['config_split.config_split.local']['status'] = FALSE;
$config['config_split.config_split.prod']['status'] = TRUE;
```

