### PR TITLE
Dependabot updates again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,29 @@
 version: 2
 updates:
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "11:00"
-    timezone: America/Chicago
-  allow:
-  - dependency-type: all
-  ignore:
-  - dependency-name: "drupal/core-*"
-    update-types: [ "version-update:semver-major" ]
-  - dependency-name: drupal/media_entity_twitter
-    versions:
-    - 2.6.0
-  groups:
-    drupal-core:
-      patterns:
-        - "drupal/core-composer-scaffold"
-        - "drupal/core-recommended"
-        - "drupal/core-dev"
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "11:00"
-    timezone: America/Chicago
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "11:00"
+      timezone: America/Chicago
+    allow:
+      # Allow both direct and indirect updates for all packages.
+      - dependency-type: all
+    ignore:
+      - dependency-name: "drupal/core-*"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: drupal/media_entity_twitter
+        versions:
+          - 2.6.0
+    groups:
+      drupal-core:
+        patterns:
+          - "drupal/core-composer-scaffold"
+          - "drupal/core-recommended"
+          - "drupal/core-dev"
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "11:00"
+      timezone: America/Chicago

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     time: "11:00"
     timezone: America/Chicago
   allow:
-    dependency-type: all
+  - dependency-type: all
   ignore:
   - dependency-name: "drupal/core-*"
     update-types: [ "version-update:semver-major" ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       # Allow both direct and indirect updates for all packages.
       - dependency-type: all
     ignore:
+      # We don't want dependabot to handle major version upgrades.
       - dependency-name: "drupal/core-*"
         update-types: [ "version-update:semver-major" ]
       - dependency-name: drupal/media_entity_twitter


### PR DESCRIPTION
Not sure how this didn't get caught when the last PR was getting merged. But noticing this error now:

```
The property '#/updates/0/allow' of type object did not match the following type: array
```

# How to test
Code review + passing tests.