### PR TITLE
[Hotfix] Added patch to get fontawesome working again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -277,6 +277,9 @@
             "drupal/field_delimiter": {
                 "Doesn't work in layout builder": "https://www.drupal.org/files/issues/2020-04-08/field_delimiter-3099580-7.patch"
             },
+            "drupal/fontawesome": {
+                "[3380581] Iconpicker does not render classes appropriately": "https://www.drupal.org/files/issues/2025-03-06/iconpicker-does-not-render_3380581_11.patch"
+            },
             "drupal/fragments": {
                 "remove_views_data_type": "https://www.drupal.org/files/issues/2022-08-24/3305851-remove_views_data_type-6.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "05424e3dc765d867df89938782fb2d88",
+    "content-hash": "d6981bf3047f0ce10766bd096d2d2dae",
     "packages": [
         {
             "name": "acquia/blt",


### PR DESCRIPTION
Missed this in https://github.com/uiowa/uiowa/pull/8802 because it is only happening with some icons. 

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev composer install && ddev blt ds --site=uiowa.edu && ddev drush @home.local uli /node/1/layout
```
1. Resave the event blocks on uiowa.edu and confirm that icons are rendering as expected.
