### PR TITLE
[Bug] Menu fix for unpublished pages in dropdown

### DIFF
--- a/docroot/themes/custom/uids_base/assets/js/accessible-menu.init.js
+++ b/docroot/themes/custom/uids_base/assets/js/accessible-menu.init.js
@@ -43,8 +43,8 @@
           menuWrapper.insertAdjacentElement('afterbegin', toggleBtn);
         }
 
-        // Find all menu items that can be displayed.
-        const expandableMenuItems = menuElement.querySelectorAll('li.menu-item--expanded > a, li.menu-item--expanded > span');
+        // Find all menu items that can be displayed, excluding those with unpublished children.
+        const expandableMenuItems = menuElement.querySelectorAll('li.menu-item--expanded:not(.menu-child--unpublished) > a, li.menu-item--expanded:not(.menu-child--unpublished) > span');
 
         // Add buttons to toggle menus. Buttons are generated here to support
         // no JS and sub-menus displayed by default.
@@ -69,7 +69,7 @@
           menuElement,
           // We have to add 'span' to handle <nolink>.
           menuLinkSelector: 'a, span',
-          submenuItemSelector: 'li.menu-item--expanded',
+          submenuItemSelector: 'li.menu-item--expanded:not(.menu-child--unpublished)',
           controllerElement: menuWrapper.querySelector(`#${toggleBtnId}`),
           submenuToggleSelector: 'button',
           containerElement: menuWrapper,

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -1126,7 +1126,7 @@ function uids_base_preprocess_menu(&$variables) {
       break;
 
     case 'main':
-      // Add class to all menu items
+      // Add class to all menu items.
       foreach ($variables['items'] as &$item) {
         if (!isset($item['attributes']['class'])) {
           $item['attributes']['class'] = [];

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -1125,6 +1125,20 @@ function uids_base_preprocess_menu(&$variables) {
       $variables['limit'] = theme_get_setting('header.top_links_limit');
       break;
 
+    case 'main':
+      // Add class to all menu items
+      foreach ($variables['items'] as &$item) {
+        if (!isset($item['attributes']['class'])) {
+          $item['attributes']['class'] = [];
+        }
+        // Check if item is expanded but has no published children.
+        if (isset($item['is_expanded']) && $item['is_expanded'] &&
+          (empty($item['below']) || count($item['below']) === 0)) {
+          $item['attributes']['class'][] = 'menu-child--unpublished';
+        }
+      }
+      break;
+
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/7970. 

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt ds --site=tippie.uiowa.edu && ddev drush @tippie.local uli /about/alumni
```

1. Set all child pages under "Alumni updates" to unpublished: https://tippie.uiowa.ddev.site/node/2341/edit and https://tippie.uiowa.ddev.site/node/4401/edit
2. Test in private browser window and confirm that other menus work and there is not arrow next to "Alumni updates"
3. Test as authenticated and confirm that you can still see the pages in the menu
