### PR TITLE
Patch RH .install file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -307,6 +307,9 @@
                 "Better error messages for missing referenced entities": "https://www.drupal.org/files/issues/2022-02-10/3095945-paragraphs-error-message-20.patch",
                 "find the correct revision ID of the parent": "https://www.drupal.org/files/issues/2020-07-08/access-controll-issue-3090200-22.patch"
             },
+            "drupal/rabbit_hole": {
+                "Issue with .install file.": "patches/rabbit_hole_install_fix.patch"
+            },
             "drupal/redirect": {
                 "Match redirect": "https://www.drupal.org/files/issues/2020-04-13/redirect-n2831605-31.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7db65e0f04bb6ff168834aadfe325dea",
+    "content-hash": "ab4a17ed5c490e6f3f6c4d892159f3b2",
     "packages": [
         {
             "name": "acquia/blt",
@@ -9045,6 +9045,10 @@
                     "name": "Pravin Gaikwad (Rajeshreeputra)",
                     "homepage": "https://www.drupal.org/u/rajeshreeputra",
                     "role": "Maintainer"
+                },
+                {
+                    "name": "seanb",
+                    "homepage": "https://www.drupal.org/user/545912"
                 }
             ],
             "description": "Track and prune node revisions.",
@@ -23615,9 +23619,9 @@
         "ext-json": "*",
         "ext-simplexml": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -4127,3 +4127,31 @@ function sitenow_update_10022() {
 
   });
 }
+
+/**
+ * Resolving what rabbit_hole failed to do properly.
+ */
+function sitenow_update_10023() {
+  $module_name = 'rabbit_hole';
+  $entity_type = 'node';
+  $fields = [
+    'rh_action',
+    'rh_redirect',
+    'rh_redirect_response',
+    'rh_redirect_fallback_action',
+  ];
+
+  $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+  $field_definitions = \Drupal::service('entity_field.manager')
+    ->getFieldDefinitions($entity_type, $entity_type);
+  foreach ($fields as $field_name) {
+    if (!empty($field_definitions[$field_name])) {
+      $entity_definition_update_manager
+        ->installFieldStorageDefinition(
+          $field_name,
+          $entity_type,
+          $module_name,
+          $field_definitions[$field_name]);
+    }
+  }
+}

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -4142,17 +4142,21 @@ function sitenow_update_10023() {
   ];
 
   $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+  $changes = $entity_definition_update_manager->getChangeList();
   $field_definitions = \Drupal::service('entity_field.manager')
     ->getFieldDefinitions($entity_type, $entity_type);
   foreach ($fields as $field_name) {
-    if (!empty($field_definitions[$field_name])) {
-      \Drupal::messenger()->addMessage(t('Installing config definition for @field.', ['@field' => $field_name]));
-      $entity_definition_update_manager
-        ->installFieldStorageDefinition(
-          $field_name,
-          $entity_type,
-          $module_name,
-          $field_definitions[$field_name]);
+    // Make sure the field exists in the change list.
+    if (isset($changes[$entity_type]['field_storage_definitions'][$field_name])) {
+      if (!empty($field_definitions[$field_name])) {
+        \Drupal::messenger()->addMessage(t('Installing config definition for @field.', ['@field' => $field_name]));
+        $entity_definition_update_manager
+          ->installFieldStorageDefinition(
+            $field_name,
+            $entity_type,
+            $module_name,
+            $field_definitions[$field_name]);
+      }
     }
   }
 }

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -4146,6 +4146,7 @@ function sitenow_update_10023() {
     ->getFieldDefinitions($entity_type, $entity_type);
   foreach ($fields as $field_name) {
     if (!empty($field_definitions[$field_name])) {
+      \Drupal::messenger()->addMessage(t('Installing config definition for @field.', ['@field' => $field_name]));
       $entity_definition_update_manager
         ->installFieldStorageDefinition(
           $field_name,

--- a/patches/rabbit_hole_install_fix.patch
+++ b/patches/rabbit_hole_install_fix.patch
@@ -1,0 +1,19 @@
+diff --git a/rabbit_hole.install b/rabbit_hole.install
+index a835ddb..d990336 100644
+--- a/rabbit_hole.install
++++ b/rabbit_hole.install
+@@ -205,7 +205,13 @@ function rabbit_hole_update_8106(&$sandbox) {
+       $sandbox['entity_types'][$entity_type_id]['progress'] = 0;
+       $sandbox['entity_types'][$entity_type_id]['current'] = 0;
+       $sandbox['entity_types'][$entity_type_id]['finished'] = FALSE;
+-      $sandbox['max'] += $sandbox['entity_types'][$entity_type_id]['max'] = $max_query->execute();
++      try {
++        $max = $max_query->execute();
++      }
++      catch (\Exception $e) {
++        $max = 0;
++      }
++      $sandbox['max'] += $sandbox['entity_types'][$entity_type_id]['max'] = $max;
+     }
+   }
+ 


### PR DESCRIPTION
Resolves #8897 

# How to test

```
ddev composer install && 
ddev blt ds --site dsri.uiowa.edu && 
ddev blt ds --site hr.uiowa.edu && 
ddev blt ds --site riskmanagement.fo.uiowa.edu && 
ddev blt ds --site physics.uiowa.edu && ddev blt ds --site admissions.uiowa.edu
```
- Confirm all sites sync (and therefore updates were successful)
- The sitenow update hook should run on admissions, but it shouldn't try to re-install the fields.