### PR TITLE
Classrooms building filter fixes

### DIFF
--- a/config/sites/classrooms.uiowa.edu/views.view.room_list.yml
+++ b/config/sites/classrooms.uiowa.edu/views.view.room_list.yml
@@ -403,6 +403,16 @@ display:
               secondary_label: Filters
               secondary_open: true
               reset_button_always_show: false
+            sort:
+              plugin_id: default
+              advanced:
+                combine: true
+                combine_rewrite: "Combined ID Ascending|Sort by: A - Z\r\nCombined ID Descending|Sort by: Z - A\r\nMax Occupancy Ascending|Sort by: Occupancy (Low to High)\r\nMax Occupancy Descending|Sort by: Occupancy (High to Low)\r\n"
+                reset: false
+                reset_label: ''
+                collapsible: false
+                collapsible_label: 'Sort options'
+                is_secondary: false
             filter:
               combine:
                 plugin_id: default
@@ -415,7 +425,7 @@ display:
               field_room_building_id_target_id:
                 plugin_id: default
                 advanced:
-                  sort_options: false
+                  sort_options: true
                   rewrite:
                     filter_rewrite_values: '- Any -|Building'
                     filter_rewrite_values_key: false
@@ -423,6 +433,84 @@ display:
                   collapsible_disable_automatic_open: false
                   is_secondary: true
                   hide_label: false
+              field_room_max_occupancy_value:
+                plugin_id: default
+                advanced:
+                  placeholder_text: ''
+                  rewrite:
+                    filter_rewrite_values: '- Any -|Occupancy'
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: true
+                  hide_label: false
+              field_room_scheduling_regions_target_id:
+                plugin_id: default
+                advanced:
+                  sort_options: false
+                  rewrite:
+                    filter_rewrite_values: '- Any -|Region'
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: true
+                  hide_label: false
+              field_room_type_target_id:
+                plugin_id: bef
+                advanced:
+                  sort_options: true
+                  rewrite:
+                    filter_rewrite_values: '- Any -|Type'
+                    filter_rewrite_values_key: false
+                  collapsible: true
+                  collapsible_disable_automatic_open: false
+                  is_secondary: true
+                  hide_label: false
+                select_all_none: false
+                select_all_none_nested: false
+                display_inline: false
+              field_room_technology_features_target_id:
+                plugin_id: bef
+                advanced:
+                  sort_options: true
+                  rewrite:
+                    filter_rewrite_values: '- Any -|Technology'
+                    filter_rewrite_values_key: false
+                  collapsible: true
+                  collapsible_disable_automatic_open: false
+                  is_secondary: true
+                  hide_label: false
+                select_all_none: false
+                select_all_none_nested: false
+                display_inline: false
+              field_room_features_target_id:
+                plugin_id: bef
+                advanced:
+                  sort_options: true
+                  rewrite:
+                    filter_rewrite_values: '- Any -|Room features'
+                    filter_rewrite_values_key: false
+                  collapsible: true
+                  collapsible_disable_automatic_open: false
+                  is_secondary: true
+                  hide_label: false
+                select_all_none: false
+                select_all_none_nested: false
+                display_inline: false
+              field_room_accessibility_feature_target_id:
+                plugin_id: bef
+                advanced:
+                  sort_options: true
+                  rewrite:
+                    filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
+                  collapsible: true
+                  collapsible_disable_automatic_open: false
+                  is_secondary: true
+                  hide_label: false
+                select_all_none: false
+                select_all_none_nested: false
+                display_inline: false
       access:
         type: perm
         options:

--- a/config/sites/classrooms.uiowa.edu/views.view.room_list.yml
+++ b/config/sites/classrooms.uiowa.edu/views.view.room_list.yml
@@ -403,16 +403,6 @@ display:
               secondary_label: Filters
               secondary_open: true
               reset_button_always_show: false
-            sort:
-              plugin_id: default
-              advanced:
-                combine: true
-                combine_rewrite: "Combined ID Ascending|Sort by: A - Z\r\nCombined ID Descending|Sort by: Z - A\r\nMax Occupancy Ascending|Sort by: Occupancy (Low to High)\r\nMax Occupancy Descending|Sort by: Occupancy (High to Low)\r\n"
-                reset: false
-                reset_label: ''
-                collapsible: false
-                collapsible_label: 'Sort options'
-                is_secondary: false
             filter:
               combine:
                 plugin_id: default
@@ -425,89 +415,14 @@ display:
               field_room_building_id_target_id:
                 plugin_id: default
                 advanced:
-                  placeholder_text: ''
-                  collapsible: false
-                  collapsible_disable_automatic_open: false
-                  is_secondary: true
-                  hide_label: false
-              field_room_max_occupancy_value:
-                plugin_id: default
-                advanced:
-                  placeholder_text: ''
-                  rewrite:
-                    filter_rewrite_values: '- Any -|Occupancy'
-                    filter_rewrite_values_key: false
-                  collapsible: false
-                  collapsible_disable_automatic_open: false
-                  is_secondary: true
-                  hide_label: false
-              field_room_scheduling_regions_target_id:
-                plugin_id: default
-                advanced:
                   sort_options: false
                   rewrite:
-                    filter_rewrite_values: '- Any -|Region'
+                    filter_rewrite_values: '- Any -|Building'
                     filter_rewrite_values_key: false
                   collapsible: false
                   collapsible_disable_automatic_open: false
                   is_secondary: true
                   hide_label: false
-              field_room_type_target_id:
-                plugin_id: bef
-                advanced:
-                  sort_options: true
-                  rewrite:
-                    filter_rewrite_values: '- Any -|Type'
-                    filter_rewrite_values_key: false
-                  collapsible: true
-                  collapsible_disable_automatic_open: false
-                  is_secondary: true
-                  hide_label: false
-                select_all_none: false
-                select_all_none_nested: false
-                display_inline: false
-              field_room_technology_features_target_id:
-                plugin_id: bef
-                advanced:
-                  sort_options: true
-                  rewrite:
-                    filter_rewrite_values: '- Any -|Technology'
-                    filter_rewrite_values_key: false
-                  collapsible: true
-                  collapsible_disable_automatic_open: false
-                  is_secondary: true
-                  hide_label: false
-                select_all_none: false
-                select_all_none_nested: false
-                display_inline: false
-              field_room_features_target_id:
-                plugin_id: bef
-                advanced:
-                  sort_options: true
-                  rewrite:
-                    filter_rewrite_values: '- Any -|Room features'
-                    filter_rewrite_values_key: false
-                  collapsible: true
-                  collapsible_disable_automatic_open: false
-                  is_secondary: true
-                  hide_label: false
-                select_all_none: false
-                select_all_none_nested: false
-                display_inline: false
-              field_room_accessibility_feature_target_id:
-                plugin_id: bef
-                advanced:
-                  sort_options: true
-                  rewrite:
-                    filter_rewrite_values: ''
-                    filter_rewrite_values_key: false
-                  collapsible: true
-                  collapsible_disable_automatic_open: false
-                  is_secondary: true
-                  hide_label: false
-                select_all_none: false
-                select_all_none_nested: false
-                display_inline: false
       access:
         type: perm
         options:
@@ -1694,9 +1609,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: string
-          operator: '='
-          value: ''
+          plugin_id: entity_reference
+          operator: or
+          value: {  }
           group: 1
           exposed: true
           expose:
@@ -1719,7 +1634,7 @@ display:
               publisher: '0'
               webmaster: '0'
               administrator: '0'
-            placeholder: ''
+            reduce: false
           is_grouped: false
           group_info:
             label: ''
@@ -1732,6 +1647,12 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          reduce_duplicates: false
+          sub_handler: 'default:building'
+          widget: select
+          sub_handler_settings:
+            target_bundles: null
+            auto_create: false
         field_room_instruction_category_value:
           id: field_room_instruction_category_value
           table: node__field_room_instruction_category
@@ -2391,9 +2312,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: string
-          operator: '='
-          value: ''
+          plugin_id: entity_reference
+          operator: or
+          value: {  }
           group: 1
           exposed: true
           expose:
@@ -2416,7 +2337,7 @@ display:
               publisher: '0'
               webmaster: '0'
               administrator: '0'
-            placeholder: ''
+            reduce: false
           is_grouped: false
           group_info:
             label: ''
@@ -2429,6 +2350,12 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          reduce_duplicates: false
+          sub_handler: 'default:building'
+          widget: select
+          sub_handler_settings:
+            target_bundles: null
+            auto_create: false
         field_room_max_occupancy_value:
           id: field_room_max_occupancy_value
           table: node__field_room_max_occupancy

--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -1633,34 +1633,6 @@ function uiowa_core_state_options(FieldStorageConfig $definition, ?ContentEntity
 }
 
 /**
- * Helper function convert exposed filter to select dropdown.
- */
-function uiowa_core_config_entity_filter_select(array &$form, $entity_id) {
-  // Get available configuration entities.
-  $storage = Drupal::getContainer()->get('entity_type.manager')->getStorage($entity_id);
-  $entities = $storage->getQuery()
-    ->accessCheck()
-    ->condition('status', 1)
-    ->sort('title')
-    ->execute();
-
-  // Build a list of options.
-  $options = [];
-  $config_entities = $storage->loadMultiple($entities);
-  foreach ($config_entities as $item) {
-    $options[$item->id()] = $item->label();
-  }
-  asort($options);
-
-  // Rebuild the text filter as select list dropdown.
-  $form['#type'] = 'select';
-  $form['#multiple'] = FALSE;
-  $form['#empty_option'] = t('- Any -');
-  $form['#options'] = $options;
-  unset($form['#size']);
-}
-
-/**
  * Helper function to set the field label icon.
  *
  * @param array $variables

--- a/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/classrooms_core.module
+++ b/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/classrooms_core.module
@@ -534,56 +534,6 @@ function classrooms_core_theme($existing, $type, $theme, $path) {
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
- */
-function classrooms_core_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $view = $form_state->get('view');
-  $view_display = $view->getDisplay();
-  $block_id = $view_display->display['id'];
-
-  if (in_array($block_id, ['block_rooms', 'block_programmed_rooms_list'])) {
-    $building_filter = 'field_room_building_id_target_id';
-    if (isset($form[$building_filter])) {
-      uiowa_core_config_entity_filter_select($form[$building_filter], 'building');
-
-      // Change the label from default `- Any -`.
-      $form[$building_filter]['#empty_option'] = t('Building');
-
-      // Hack to further treat this field as a select as it relates to BEF.
-      // This is dependent on BEF select fields not changing in structure.
-      $form[$building_filter]['#process'] = [
-        [
-          'Drupal\Core\Render\Element\Select',
-          'processSelect',
-        ],
-        [
-          'Drupal\Core\Render\Element\Select',
-          'processAjaxForm',
-        ],
-        [
-          'Drupal\inline_form_errors\RenderElementHelper',
-          'processElement',
-        ],
-        [
-          '\Drupal\Core\Render\Element\RenderElement',
-          'processGroup',
-        ],
-      ];
-      $form[$building_filter]['#pre_render'] = [
-        [
-          'Drupal\Core\Render\Element\Select',
-          'preRenderSelect',
-        ],
-        [
-          '\Drupal\Core\Render\Element\RenderElement',
-          'preRenderGroup',
-        ],
-      ];
-    }
-  }
-}
-
-/**
  * Implements hook_views_pre_view().
  */
 function classrooms_core_views_pre_view(ViewExecutable $view, $display_id, array &$args) {


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/8895
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt ds --site=classrooms.uiowa.edu && ddev drush @classrooms.local uli spaces/find-university-classroom
```

Compare placement, look, functionality with [PROD](https://classrooms.uiowa.edu/spaces/find-university-classroom) but note that the building filter now filters the results properly.

Go to https://classrooms.uiowa.ddev.site/spaces/programmed-classrooms and compare placement, look, functionality with [PROD](https://classrooms.uiowa.edu/spaces/programmed-classrooms) but note that the building filter now filters the results properly.

Perform a docroot string search on `uiowa_core_config_entity_filter_select` and note that it is no longer being called by anything in the codebase.

