### PR TITLE
updating Partners dropdown to get city.

### DIFF
--- a/config/sites/iisc.uiowa.edu/views.view.iisc_projects.yml
+++ b/config/sites/iisc.uiowa.edu/views.view.iisc_projects.yml
@@ -543,9 +543,9 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          handler: 'default:node'
+          sub_handler: 'default:node'
           widget: select
-          handler_settings:
+          sub_handler_settings:
             target_bundles:
               partner: partner
             sort:


### PR DESCRIPTION
# How to test

```
  ddev blt ds --site=iisc.uiowa.edu  &&  ddev drush @iisc.local uli  projects

 ```    
The partner dropdown only contains Partners and not people, compared to production 
https://iisc.uiowa.edu/projects.


