### PR TITLE
Hotfix - add schema alter info for custom fields on basic site settings form

### DIFF
--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -1847,3 +1847,28 @@ function uiowa_core_clean_address_fields(array &$form, FormStateInterface $form_
     }
   }
 }
+
+/**
+ * Implements hook_config_schema_info_alter().
+ */
+function uiowa_core_config_schema_info_alter(&$schemas) {
+  // Extend the schema for 'system.site'.
+  $schemas['system.site']['mapping']['has_parent'] = [
+    'type' => 'boolean',
+    'label' => t('Has parent organization'),
+  ];
+  $schemas['system.site']['mapping']['parent'] = [
+    'type' => 'mapping',
+    'label' => t('Parent organization'),
+    'mapping' => [
+      'name' => [
+        'type' => 'text',
+        'label' => t('Parent organization name'),
+      ],
+      'url' => [
+        'type' => 'uri',
+        'label' => t('Parent organization URL'),
+      ],
+    ],
+  ];
+}


### PR DESCRIPTION
This is preventing the save of the basic site settings form even if they are not trying to set or modify a parent organization.

Reported by more than one user in its-web

Referenced https://www.jaypan.com/tutorial/drupal-extending-core-configuration-extending-core-forms-and-overriding-core-routes as it appears our docroot/modules/custom/uiowa_core/config/schema/uiowa_core.schema.yml file is not correct or not being picked up.

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

On `main`:

```
ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli admin/config/system/site-information
```

Try to save the form. There is an error about an invalid parent key.

Checkout this branch `extend_system_site_schema`.

```
ddev drush @sandbox.local cr
```

Try to save the form. Success! Try entering parent org info. Save. Success!
