### PR TITLE
Facilities - fix view config and sort artists by label

### DIFF
--- a/config/sites/facilities.uiowa.edu/views.view.artwork.yml
+++ b/config/sites/facilities.uiowa.edu/views.view.artwork.yml
@@ -1042,9 +1042,9 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          handler: 'default:node'
+          sub_handler: 'default:node'
           widget: select
-          handler_settings:
+          sub_handler_settings:
             target_bundles:
               building: building
             sort:
@@ -1099,8 +1099,16 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          handler: 'default:node'
+          sub_handler: 'default:node'
           widget: select
+          sub_handler_settings:
+            target_bundles: null
+            sort:
+              field: _none
+              direction: ASC
+            auto_create: false
+            auto_create_bundle: ''
+          handler: 'default:node'
           handler_settings:
             target_bundles:
               person: person

--- a/docroot/modules/custom/uiowa_core/src/Plugin/views/filter/EntityReferenceOverride.php
+++ b/docroot/modules/custom/uiowa_core/src/Plugin/views/filter/EntityReferenceOverride.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\uiowa_core\Plugin\views\filter;
+
+use Drupal\views\Plugin\views\filter\EntityReference;
+
+/**
+ * Custom override of EntityReference filter to increase the select limit.
+ */
+class EntityReferenceOverride extends EntityReference {
+  public const WIDGET_SELECT_LIMIT = 500;
+
+}

--- a/docroot/sites/facilities.uiowa.edu/modules/facilities_core/facilities_core.module
+++ b/docroot/sites/facilities.uiowa.edu/modules/facilities_core/facilities_core.module
@@ -15,6 +15,7 @@ use Drupal\Core\Url;
 use Drupal\facilities_core\Entity\Artwork;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
+use Drupal\uiowa_core\Plugin\views\filter\EntityReferenceOverride;
 
 /**
  * Set dynamic allowed values bus routes status.
@@ -197,6 +198,16 @@ function facilities_core_form_views_exposed_form_alter(&$form, FormStateInterfac
         $form['field_artwork_artist_target_id']['#options'] = $options;
       }
     }
+  }
+}
+
+/**
+ * Implements hook_views_plugins_filter_alter().
+ */
+function facilities_core_views_plugins_filter_alter(array &$plugins): void {
+  // Override all entity reference filter plugins for this site. :grimacing:.
+  if (isset($plugins['entity_reference'])) {
+    $plugins['entity_reference']['class'] = EntityReferenceOverride::class;
   }
 }
 

--- a/docroot/sites/facilities.uiowa.edu/modules/facilities_core/facilities_core.module
+++ b/docroot/sites/facilities.uiowa.edu/modules/facilities_core/facilities_core.module
@@ -191,6 +191,9 @@ function facilities_core_form_views_exposed_form_alter(&$form, FormStateInterfac
           }
         }
 
+        // Sort the options alphabetically by value.
+        asort($options);
+
         $form['field_artwork_artist_target_id']['#options'] = $options;
       }
     }


### PR DESCRIPTION
Reported by Facilities in its-web
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt ds --site=facilities.uiowa.edu && ddev drush @facilities.local uli art-campus/art-campus-gallery
```

- See that the buildings filter does not contain non-building content
- See that the artists filter is sorted alphabetically by option value
- You see a seemingly complete list of buildings (goes beyond C down through the rest of the alphabet).
- You don't notice any performance issues with loading the view compared to PROD.