### PR TITLE
Signage - Robots

### DIFF
--- a/config/default/config_split.config_split.signage.yml
+++ b/config/default/config_split.config_split.signage.yml
@@ -20,6 +20,8 @@ complete_list:
   - field.field.node.slide.field_image
   - field.storage.node.field_sign_display_title
   - field.storage.node.field_sign_hide_header
+  - metatag.metatag_defaults.node__sign
+  - metatag.metatag_defaults.node__slide
   - node.type.sign
   - node.type.slide
   - pathauto.pattern.sign

--- a/config/features/signage/metatag.metatag_defaults.node__sign.yml
+++ b/config/features/signage/metatag.metatag_defaults.node__sign.yml
@@ -1,0 +1,8 @@
+uuid: e11b8a18-9d30-4bf3-a932-1d4a833f7613
+langcode: en
+status: true
+dependencies: {  }
+id: node__sign
+label: 'Content: Sign'
+tags:
+  robots: 'noindex, nofollow'

--- a/config/features/signage/metatag.metatag_defaults.node__slide.yml
+++ b/config/features/signage/metatag.metatag_defaults.node__slide.yml
@@ -1,0 +1,8 @@
+uuid: 7cd74445-4448-476d-933d-925a3d13dcf0
+langcode: en
+status: true
+dependencies: {  }
+id: node__slide
+label: 'Content: Slide'
+tags:
+  robots: 'noindex, nofollow'

--- a/config/sites/signage.sites.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/signage.sites.uiowa.edu/config_split.config_split.site.yml
@@ -20,6 +20,7 @@ complete_list:
   - field.field.node.sign.og_audience
   - field.field.node.slide.og_audience
   - node.type.signage_group
+  - robotstxt.settings
 partial_list:
   - administerusersbyrole.settings
   - views.view.og_members_overview

--- a/config/sites/signage.sites.uiowa.edu/config_split.patch.core.entity_view_display.node.sign.default.yml
+++ b/config/sites/signage.sites.uiowa.edu/config_split.patch.core.entity_view_display.node.sign.default.yml
@@ -2,6 +2,9 @@ adding:
   dependencies:
     config:
       - field.field.node.sign.og_audience
+    module:
+      - field_delimiter
+      - options
   hidden:
     og_audience: true
 removing: {  }

--- a/config/sites/signage.sites.uiowa.edu/robotstxt.settings.yml
+++ b/config/sites/signage.sites.uiowa.edu/robotstxt.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: ceCx5XZ_ay1Mxcv-sB95U_fBKoVkpvo8RaQiwutSZLI
+content: "User-agent: *\r\nDisallow: /"


### PR DESCRIPTION
Resolves #8940 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
```
ddev blt ds --site=signage.sites.uiowa.edu && 
ddev blt ds --site=default && 
ddev drush @default.local config-split:activate signage -y && 
ddev drush @default.local cim -y && 
ddev drush @sitessignage.local uli /admin/config/search/robotstxt && 
ddev drush @default.local uli /node/add
```

Check that the signage.sites.uiowa.edu robots configuration should disallow all agents. (Note: You can't go directly to `/robots.txt`, because locally that'll have environment-specific settings anyway).

For signage-enabled default, add a sign and a slide. 
For each, View Page Source and see that robots `nofollow` and `noindex` metatags are set.
While editing, see that you don't have a `metatags` field to edit away from these defaults. Also verify that the Sitemap option is uneditable, and defaulted to not include in the sitemap.