### PR TITLE
Grad Neuroscience - re-export after recreating all affected filters across view displays

### DIFF
--- a/config/sites/neuroscience.grad.uiowa.edu/views.view.person_custom.yml
+++ b/config/sites/neuroscience.grad.uiowa.edu/views.view.person_custom.yml
@@ -17,6 +17,8 @@ dependencies:
     - field.storage.node.field_pt_student_program_start
     - field.storage.node.pt_student_dissertation_title
     - node.type.person
+    - sitenow_people.person_type.faculty
+    - sitenow_people.person_type.student
     - system.menu.main
     - taxonomy.vocabulary.department
     - taxonomy.vocabulary.research_areas
@@ -489,9 +491,10 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: string
-          operator: '='
-          value: student
+          plugin_id: entity_reference
+          operator: or
+          value:
+            student: student
           group: 1
           exposed: false
           expose:
@@ -521,6 +524,12 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          reduce_duplicates: false
+          sub_handler: 'default:person_type'
+          widget: select
+          sub_handler_settings:
+            target_bundles: null
+            auto_create: false
         field_person_type_status_value:
           id: field_person_type_status_value
           table: node__field_person_type_status
@@ -1246,9 +1255,10 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: string
-          operator: '='
-          value: faculty
+          plugin_id: entity_reference
+          operator: or
+          value:
+            faculty: faculty
           group: 1
           exposed: false
           expose:
@@ -1278,6 +1288,12 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          reduce_duplicates: false
+          sub_handler: 'default:person_type'
+          widget: select
+          sub_handler_settings:
+            target_bundles: null
+            auto_create: false
         field_person_type_status_value:
           id: field_person_type_status_value
           table: node__field_person_type_status
@@ -2125,9 +2141,10 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: string
-          operator: '='
-          value: student
+          plugin_id: entity_reference
+          operator: or
+          value:
+            student: student
           group: 1
           exposed: false
           expose:
@@ -2157,6 +2174,12 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          reduce_duplicates: false
+          sub_handler: 'default:person_type'
+          widget: select
+          sub_handler_settings:
+            target_bundles: null
+            auto_create: false
         field_person_type_status_value:
           id: field_person_type_status_value
           table: node__field_person_type_status
@@ -2827,9 +2850,10 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: string
-          operator: '='
-          value: student
+          plugin_id: entity_reference
+          operator: or
+          value:
+            student: student
           group: 1
           exposed: false
           expose:
@@ -2859,6 +2883,12 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          reduce_duplicates: false
+          sub_handler: 'default:person_type'
+          widget: select
+          sub_handler_settings:
+            target_bundles: null
+            auto_create: false
         field_person_type_status_value:
           id: field_person_type_status_value
           table: node__field_person_type_status


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/8923

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
 ddev blt ds --site=neuroscience.grad.uiowa.edu && ddev drush @gradneuroscience.local uli people/faculty
```

Confirm that Parker Abbott does not show up on the faculty view and that the filters work to reduce the results. See that the view is not showing former faculty either (e.g. https://gradneuroscience.uiowa.ddev.site/people/francois-m-abboud). Compare with the PROD view to confirm all filters are present and labeled correctly: https://neuroscience.grad.uiowa.edu/people/faculty

Go to https://gradneuroscience.uiowa.ddev.site/people/students and see that it is only showing students not marked as former.

Go to https://gradneuroscience.uiowa.ddev.site/people/students/former and see that it only includes former students.
