### PR TITLE
[Bug] Added fix for card centered icons

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/card.scss
+++ b/docroot/themes/custom/uids_base/scss/components/card.scss
@@ -70,10 +70,16 @@
 
   .fa-field-item {
     margin-left: 0;
-  }
+    }
   .card__meta {
     .fa-field-item {
       margin-left: 0;
+      svg[class*="fa-"],
+      span[class*="fa-"] {
+        position: relative;
+        left: unset;
+        top: unset;
+      }
     }
   }
 }

--- a/docroot/themes/custom/uids_base/scss/components/card.scss
+++ b/docroot/themes/custom/uids_base/scss/components/card.scss
@@ -70,7 +70,7 @@
 
   .fa-field-item {
     margin-left: 0;
-    }
+  }
   .card__meta {
     .fa-field-item {
       margin-left: 0;


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/8916. 

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test
```
ddev blt frontend && ddev blt ds --site=pathology.medicine.uiowa.edu    && ddev drush @medicinepathology.local uli /research/support  
```
1. Adjust featured content card to centered and confirm that meta icons are centered. 
<!-- Include detailed steps for how to test this PR. -->
```
ddev blt frontend && ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli /featured-content-0  
```
1. Confirm icons are centered. Change back to left aligned and confirm they are left-aligned. 

