### PR TITLE
Added font size adjustments for `small` class

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/typography/paragraph.scss
+++ b/docroot/themes/custom/uids_base/scss/components/typography/paragraph.scss
@@ -27,9 +27,8 @@ figure img {
 }
 
 .small {
-  font-size: variables.$sm !important;
-  line-height: variables.$sm-md !important;
-  font-family: Arial, Helvetica, sans-serif;
+  font-size: 1rem !important;
+  line-height: 1.3 !important;
 }
 
 a:not([href]) {

--- a/docroot/themes/custom/uids_base/scss/components/typography/paragraph.scss
+++ b/docroot/themes/custom/uids_base/scss/components/typography/paragraph.scss
@@ -27,8 +27,8 @@ figure img {
 }
 
 .small {
-  font-size: 1rem !important;
-  line-height: 1.3 !important;
+  font-size: 80%!important;
+  line-height: 1.3!important;
 }
 
 a:not([href]) {


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/9085. 

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt frontend && ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli /small-tag-testing
```
1. Confirm second list item has same font size and line-height of first list item. 

```
ddev blt frontend && ddev blt ds --site=brand.uiowa.edu && ddev drush @brand.local uli /node/add/lockup
```
1. Confirm help text on main content area of brand lockup page is a bit larger than the prod help text: https://brand.uiowa.edu/node/add/lockup.