### PR TITLE
[Signage] Remove preview functionality

### DIFF
--- a/config/features/signage/node.type.sign.yml
+++ b/config/features/signage/node.type.sign.yml
@@ -45,5 +45,5 @@ type: sign
 description: 'A <em>sign</em> is used to display information on signage displays throughout campus.'
 help: null
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: false

--- a/config/features/signage/node.type.slide.yml
+++ b/config/features/signage/node.type.slide.yml
@@ -45,5 +45,5 @@ type: slide
 description: 'A <em>slide</em> is used to create a slide to display on a sign.'
 help: null
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: false


### PR DESCRIPTION
Resolves #9075 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
```
ddev blt ds --site=signage.sites.uiowa.edu && ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sitessignage.local uli && ddev drush @sandbox.local uli
```
Check for clean syncs
Add and edit a sign and a slide, see that you no longer have the "Preview" option available.
This should be the same on both the standalone and feature versions of signage.