### PR TITLE
Hotfix - remove reset button from OnIowa upcoming events page

### DIFF
--- a/config/sites/oniowa.uiowa.edu/config_split.patch.views.view.events.yml
+++ b/config/sites/oniowa.uiowa.edu/config_split.patch.views.view.events.yml
@@ -304,6 +304,9 @@ adding:
             multi_type: separator
             separator: ', '
             field_api_classes: false
+        exposed_form:
+          options:
+            reset_button: false
         style:
           type: table
           options:
@@ -421,4 +424,7 @@ removing:
         fields:
           title:
             label: ''
+        exposed_form:
+          options:
+            reset_button: true
         css_class: 'bef-form bef-form--label-hidden '


### PR DESCRIPTION
Closes #9108 

# How to test
```
ddev blt ds --site=oniowa.uiowa.edu && ddev drush @oniowa.local uli
```
- visit https://oniowa.uiowa.ddev.site/events
- use one of the filters
- confirm that there is no Reset button next to the Apply button 