### PR TITLE
config fix for signage feature

### DIFF
--- a/config/features/signage/core.entity_form_display.node.sign.default.yml
+++ b/config/features/signage/core.entity_form_display.node.sign.default.yml
@@ -62,9 +62,6 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  og_audience:
-    settings: {  }
-    third_party_settings: {  }
   path:
     type: path
     weight: 9

--- a/config/features/signage/core.entity_form_display.node.slide.default.yml
+++ b/config/features/signage/core.entity_form_display.node.slide.default.yml
@@ -63,9 +63,6 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  og_audience:
-    settings: {  }
-    third_party_settings: {  }
   path:
     type: path
     weight: 8

--- a/config/features/signage/core.entity_form_display.node.slide.minimal.yml
+++ b/config/features/signage/core.entity_form_display.node.slide.minimal.yml
@@ -76,9 +76,6 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  og_audience:
-    settings: {  }
-    third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
     weight: 5


### PR DESCRIPTION
og_audience remnant is still contained in the feature when the og module is not even turned on for the feature.

# How to test

## Reproduce

On `main`
```
ddev drush @sandbox.local sql-drop -y && ddev drush @sandbox.local cr && ddev blt ds --site=sandbox.uiowa.edu
```
You should see config diff issues.

`ddev drush @sandbox.local cim --diff` should reveal the conflicts.

## Fix

On this branch `config_fix_og_audience_signage_feature`

```
ddev drush @sandbox.local sql-drop -y && ddev drush @sandbox.local cr && ddev blt ds --site=sandbox.uiowa.edu
```

Success!
