### PR TITLE
removing international option for scholarship

### DIFF
--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/src/Form/ScholarshipsJumpMenu.php
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/src/Form/ScholarshipsJumpMenu.php
@@ -31,7 +31,6 @@ class ScholarshipsJumpMenu extends FormBase {
       '#options' => [
         'first-year' => $this->t('First Year'),
         'transfer' => $this->t('Transfer'),
-        'international' => $this->t('International'),
       ],
       "#empty_option" => $this->t('- Select -'),
       '#ajax' => [
@@ -69,12 +68,6 @@ class ScholarshipsJumpMenu extends FormBase {
     $build_info = $form_state->getBuildInfo();
 
     if ($selectedValue = $form_state->getValue('scholarship_type')) {
-      if ($selectedValue === 'international') {
-        $url = Url::fromRoute('entity.node.canonical', ['node' => $build_info["scholarship_paths"]["international"]]);
-        $response->addCommand(new InvokeCommand('#edit-scholarship-type', 'val', ['']));
-        $response->addCommand(new RedirectCommand($url->toString()));
-        return $response;
-      }
       if ($selectedValue === 'transfer') {
         $url = Url::fromRoute('entity.node.canonical', ['node' => $build_info["scholarship_paths"]["transfer"]]);
         $response->addCommand(new InvokeCommand('#edit-scholarship-type', 'val', ['']));

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/src/Plugin/Block/ScholarshipsBlock.php
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/src/Plugin/Block/ScholarshipsBlock.php
@@ -73,7 +73,6 @@ class ScholarshipsBlock extends BlockBase {
       '#options' => [
         'first-year' => $this->t('First Year'),
         'transfer' => $this->t('Transfer'),
-        'international' => $this->t('International'),
       ],
       '#default_value' => $config['scholarship_type'] ?? '',
     ];

--- a/docroot/sites/admissions.uiowa.edu/modules/admissions_core/src/Plugin/Block/ScholarshipsJumpMenuBlock.php
+++ b/docroot/sites/admissions.uiowa.edu/modules/admissions_core/src/Plugin/Block/ScholarshipsJumpMenuBlock.php
@@ -64,7 +64,6 @@ class ScholarshipsJumpMenuBlock extends BlockBase implements ContainerFactoryPlu
     $config = $this->getConfiguration();
     $paths = [
       'transfer' => $config['transfer_path'],
-      'international' => $config['international_path'],
       'resident' => $config['resident_path'],
       'nonresident' => $config['nonresident_path'],
     ];
@@ -95,21 +94,7 @@ class ScholarshipsJumpMenuBlock extends BlockBase implements ContainerFactoryPlu
       '#default_value' => $transfer_entity ?? NULL,
       '#required' => TRUE,
     ];
-    if (isset($config['international_path'])) {
-      $international_entity = $this->entityTypeManager->getStorage('node')->load($config['international_path']);
-    }
-    $form['international_path'] = [
-      '#type' => 'entity_autocomplete',
-      '#title' => $this->t('International Path'),
-      '#description' => $this->t('Url for the international option'),
-      '#target_type' => 'node',
-      '#selection_handler' => 'default',
-      '#selection_settings' => [
-        'target_bundles' => ['page'],
-      ],
-      '#default_value' => $international_entity ?? NULL,
-      '#required' => TRUE,
-    ];
+
     if (isset($config['resident_path'])) {
       $resident_entity = $this->entityTypeManager->getStorage('node')->load($config['resident_path']);
     }
@@ -152,7 +137,6 @@ class ScholarshipsJumpMenuBlock extends BlockBase implements ContainerFactoryPlu
     parent::blockSubmit($form, $form_state);
     $values = $form_state->getValues();
     $this->configuration['transfer_path'] = $values['transfer_path'];
-    $this->configuration['international_path'] = $values['international_path'];
     $this->configuration['nonresident_path'] = $values['nonresident_path'];
     $this->configuration['resident_path'] = $values['resident_path'];
   }


### PR DESCRIPTION
# How to test
First run 
`ddev blt ds --site=admissions.uiowa.edu`

Then go to 
`ddev @admissions.local uli  /finances/scholarships`

Check if international option has been removed successfully 

<img width="1506" height="364" alt="Screenshot 2025-08-22 at 4 33 13 PM" src="https://github.com/user-attachments/assets/5eee77c5-bf92-470e-a8ea-9bc8529d9390" />
<img width="1877" height="845" alt="Screenshot 2025-08-22 at 4 33 46 PM" src="https://github.com/user-attachments/assets/10352e0f-3c98-4776-af52-b255855d637d" />


