### PR TITLE
Add conditional on page_bottom wrapper in html template

### DIFF
--- a/docroot/themes/custom/uids_base/templates/layout/html.html.twig
+++ b/docroot/themes/custom/uids_base/templates/layout/html.html.twig
@@ -57,9 +57,7 @@
 
 {{ page_top }}
 {{ page }}
-{% if page_bottom %}
-  <div {{ uiowa_attribute.addClass(header_classes) }}>{{ page_bottom }}</div>
-{% endif %}
+{% if page_bottom %}<div {{ uiowa_attribute.addClass(header_classes) }}>{{ page_bottom }}</div>{% endif %}
 <js-bottom-placeholder token="{{ placeholder_token }}">
   </body>
 </html>

--- a/docroot/themes/custom/uids_base/templates/layout/html.html.twig
+++ b/docroot/themes/custom/uids_base/templates/layout/html.html.twig
@@ -57,7 +57,9 @@
 
 {{ page_top }}
 {{ page }}
-{% if page_bottom %}<div {{ uiowa_attribute.addClass(header_classes) }}>{{ page_bottom }}</div>{% endif %}
+{% if page_bottom %}
+  <div {{ uiowa_attribute.addClass(header_classes) }}>{{ page_bottom }}</div>
+{% endif %}
 <js-bottom-placeholder token="{{ placeholder_token }}">
   </body>
 </html>

--- a/docroot/themes/custom/uids_base/templates/layout/html.html.twig
+++ b/docroot/themes/custom/uids_base/templates/layout/html.html.twig
@@ -57,7 +57,9 @@
 
 {{ page_top }}
 {{ page }}
-<div {{ uiowa_attribute.addClass(header_classes) }}>{{ page_bottom }}</div>
+{% if page_bottom %}
+  <div {{ uiowa_attribute.addClass(header_classes) }}>{{ page_bottom }}</div>
+{% endif %}
 <js-bottom-placeholder token="{{ placeholder_token }}">
   </body>
 </html>


### PR DESCRIPTION
Fixes https://github.com/uiowa/uiowa/issues/9123
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

- We don't use `page_bottom` for much but to test this, you can switch between an anonymous sign display and an authenticated backend path. For the anonymous sign display, you no longer see the empty div `<div class="uiowa__container"></div>` and in the backend you do. The tour module loads in page_bottom so that is why this template properly renders the page_bottom div when authenticated.
- Uses the same pattern as https://github.com/uiowa/uiowa/blob/main/docroot/themes/custom/uids_base/templates/block/block--inline-block--uiowa-page-title-hero.html.twig#L38
- This does cause a change to the Percy baseline will need approval to merge.
