### PR TITLE
[Signage] Signage groups list block

### DIFF
--- a/config/sites/signage.sites.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/signage.sites.uiowa.edu/config_split.config_split.site.yml
@@ -23,6 +23,7 @@ complete_list:
   - field.field.node.slide.og_audience
   - node.type.signage_group
   - robotstxt.settings
+  - views.view.signage_groups
   - views.view.signage_group_content
   - views.view.user_signage_groups
 partial_list:

--- a/config/sites/signage.sites.uiowa.edu/views.view.signage_groups.yml
+++ b/config/sites/signage.sites.uiowa.edu/views.view.signage_groups.yml
@@ -1,18 +1,19 @@
-uuid: 6b278ae7-bb31-4a26-8d3a-513b4b2353a2
+uuid: eb824cce-ba1c-4137-b360-c625848d844b
 langcode: en
 status: true
 dependencies:
+  config:
+    - node.type.signage_group
   module:
     - node
-    - og
     - user
-id: user_signage_groups
-label: 'User signage groups'
+id: signage_groups
+label: 'Signage groups'
 module: views
-description: ''
+description: 'The full list of signage groups'
 tag: ''
-base_table: og_membership
-base_field: id
+base_table: node_field_data
+base_field: nid
 display:
   default:
     id: default
@@ -20,17 +21,15 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: ''
+      title: 'Signage groups'
       fields:
         title:
           id: title
           table: node_field_data
           field: title
-          relationship: group_entity_node
+          relationship: none
           group_type: group
           admin_label: ''
-          entity_type: node
-          entity_field: title
           plugin_id: field
           label: ''
           exclude: false
@@ -65,7 +64,7 @@ display:
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: false
+          element_label_colon: true
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -76,7 +75,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: true
+            link_to_entity: false
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -92,7 +91,7 @@ display:
         options:
           offset: 0
           pagination_heading_level: h4
-          items_per_page: 10
+          items_per_page: 50
           total_pages: null
           id: 0
           tags:
@@ -132,7 +131,7 @@ display:
           id: title
           table: node_field_data
           field: title
-          relationship: group_entity_node
+          relationship: none
           group_type: group
           admin_label: ''
           entity_type: node
@@ -143,44 +142,28 @@ display:
             label: ''
             field_identifier: ''
           exposed: false
-      arguments:
-        uid:
-          id: uid
-          table: users_field_data
-          field: uid
-          relationship: uid
-          group_type: group
-          admin_label: ''
-          entity_type: user
-          entity_field: uid
-          plugin_id: user_uid
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: user
-          default_argument_options:
-            user: false
-          summary_options:
-            base_path: ''
-            count: true
-            override: false
-            items_per_page: 25
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: false
-          not: false
-      filters: {  }
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            signage_group: signage_group
       style:
         type: html_list
         options:
@@ -192,11 +175,6 @@ display:
           class: ''
       row:
         type: fields
-        options:
-          default_field_elements: true
-          inline: {  }
-          separator: ''
-          hide_empty: false
       query:
         type: views_query
         options:
@@ -205,43 +183,8 @@ display:
           distinct: false
           replica: false
           query_tags: {  }
-      relationships:
-        group_entity_node:
-          id: group_entity_node
-          table: og_membership
-          field: group_entity_node
-          relationship: none
-          group_type: group
-          admin_label: 'OG Group: Content'
-          entity_type: og_membership
-          plugin_id: standard
-          required: true
-        uid:
-          id: uid
-          table: og_membership
-          field: uid
-          relationship: none
-          group_type: group
-          admin_label: User
-          entity_type: og_membership
-          entity_field: uid
-          plugin_id: standard
-          required: true
-      css_class: ''
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text
-          empty: false
-          content:
-            value: "<br>\r\n<h4>Signage group membership</h4>"
-            format: filtered_html
-          tokenize: false
+      relationships: {  }
+      header: {  }
       footer: {  }
       display_extenders: {  }
     cache_metadata:
@@ -249,12 +192,12 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url
         - url.query_args
+        - 'user.node_grants:view'
         - user.permissions
       tags: {  }
-  user_signage_groups_block:
-    id: user_signage_groups_block
+  block_1:
+    id: block_1
     display_title: Block
     display_plugin: block
     position: 1
@@ -263,7 +206,8 @@ display:
         metatag_display_extender:
           metatags: {  }
           tokenize: false
-      block_description: 'Signage group membership'
+      block_description: 'Signage Groups'
+      block_category: Lists
       allow:
         items_per_page: false
         offset: '0'
@@ -284,7 +228,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url
         - url.query_args
+        - 'user.node_grants:view'
         - user.permissions
       tags: {  }


### PR DESCRIPTION
Resolves #9027 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
```
ddev blt ds --site=signage.sites.uiowa.edu && ddev drush @sitessignage.local uli /user/71
```
See that the list of user groups to which the user is assigned is sorted alphabetically, as compared to https://signage.sites.uiowa.edu/user/71

Edit or add a new page, and add the Signage Groups list block, and see that it functions as described in #9027 