### PR TITLE
Signage - UX improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,7 @@
         "drupal/entity_reference_revisions": "^1.5",
         "drupal/entity_reference_unpublished": "^2.0",
         "drupal/entity_usage": "^2.0@beta",
+        "drupal/epp": "^1.7",
         "drupal/field_delimiter": "^2.0",
         "drupal/field_group": "^4.0",
         "drupal/file_mdm": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -5410,35 +5410,39 @@
         },
         {
             "name": "drupal/entity_browser",
-            "version": "2.9.0",
+            "version": "2.15.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/entity_browser.git",
-                "reference": "8.x-2.9"
+                "reference": "8.x-2.15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/entity_browser-8.x-2.9.zip",
-                "reference": "8.x-2.9",
-                "shasum": "251afad80cde9fa547501a8d9de5d94b9f5bacff"
+                "url": "https://ftp.drupal.org/files/projects/entity_browser-8.x-2.15.zip",
+                "reference": "8.x-2.15",
+                "shasum": "86265fadf12f8c2eb4bc0dc813589efe8fa180a2"
             },
             "require": {
-                "drupal/core": "^9.2 || ^10"
+                "drupal/core": "^10.2 || ^11"
+            },
+            "conflict": {
+                "drupal/media_entity": "1.*"
             },
             "require-dev": {
-                "drupal/embed": "~1.0",
-                "drupal/entity_embed": "1.x-dev",
-                "drupal/entity_reference_revisions": "1.x-dev",
-                "drupal/entityqueue": "1.x-dev",
-                "drupal/inline_entity_form": "1.x-dev",
-                "drupal/paragraphs": "1.x-dev",
-                "drupal/token": "1.x-dev"
+                "drupal/embed": "^1.0",
+                "drupal/entity_embed": "^1.0",
+                "drupal/entity_reference_revisions": "^1.0",
+                "drupal/entityqueue": "^1.0",
+                "drupal/inline_entity_form": "^1 || ^3",
+                "drupal/paragraphs": "^1.0",
+                "drupal/search_api": "^1.0",
+                "drupal/token": "^1.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.9",
-                    "datestamp": "1674070933",
+                    "version": "8.x-2.15",
+                    "datestamp": "1756969160",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5466,8 +5470,16 @@
                     "role": "contributor"
                 },
                 {
+                    "name": "devin carlson",
+                    "homepage": "https://www.drupal.org/user/290182"
+                },
+                {
                     "name": "Drupal Media Team",
                     "homepage": "https://www.drupal.org/user/3260690"
+                },
+                {
+                    "name": "grevil",
+                    "homepage": "https://www.drupal.org/user/3668491"
                 },
                 {
                     "name": "marcingy",
@@ -5491,7 +5503,7 @@
                 }
             ],
             "description": "Entity browsing and selecting component.",
-            "homepage": "http://drupal.org/project/entity_browser",
+            "homepage": "https://drupal.org/project/entity_browser",
             "support": {
                 "source": "https://git.drupalcode.org/project/entity_browser",
                 "issues": "https://www.drupal.org/project/issues/entity_browser",
@@ -23972,9 +23984,9 @@
         "ext-json": "*",
         "ext-simplexml": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd5ec039f2a018c1490c8da107c66995",
+    "content-hash": "c350ded7e7c580663b9361e424f35c68",
     "packages": [
         {
             "name": "acquia/blt",
@@ -5779,6 +5779,54 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/entity_usage",
                 "issues": "http://drupal.org/project/issues/entity_usage"
+            }
+        },
+        {
+            "name": "drupal/epp",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/epp.git",
+                "reference": "8.x-1.7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/epp-8.x-1.7.zip",
+                "reference": "8.x-1.7",
+                "shasum": "be7272e367995d9bfd8d2b58241ba7f84534f54e"
+            },
+            "require": {
+                "drupal/core": "^8.7.7 || ^9 || ^10 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.7",
+                    "datestamp": "1732276482",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "anruether",
+                    "homepage": "https://www.drupal.org/user/894458"
+                },
+                {
+                    "name": "geek-merlin",
+                    "homepage": "https://www.drupal.org/user/229048"
+                }
+            ],
+            "description": "Prepopulate entity values via tokens. Install the Token module for more tokens and Token browser access.",
+            "homepage": "https://www.drupal.org/project/epp",
+            "support": {
+                "source": "https://git.drupalcode.org/project/epp"
             }
         },
         {

--- a/config/default/config_split.config_split.signage.yml
+++ b/config/default/config_split.config_split.signage.yml
@@ -26,6 +26,7 @@ complete_list:
   - core.entity_view_display.paragraph.slide_image.default
   - core.entity_view_mode.media.vertical_9_16
   - core.entity_view_mode.media.widescreen_crop_no_focal_point
+  - entity_browser.browser.signage_slide_browser
   - field.storage.paragraph.field_headline
   - image.style.vertical_9_16_1458_x_2592
   - image.style.widescreen_16_9_2592_x_1458
@@ -43,6 +44,7 @@ complete_list:
   - system.action.user_add_role_action.sign_manager
   - system.action.user_remove_role_action.sign_manager
   - user.role.sign_manager
+  - views.view.signage_slide_content
   - 'field.storage.node.field_sign_*'
   - 'field.storage.node.field_slide_*'
   - 'field.storage.paragraph.field_slide_*'

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -40,6 +40,7 @@ module:
   entity_reference_revisions: 0
   entity_reference_unpublished: 0
   entity_usage: 0
+  epp: 0
   field: 0
   field_delimiter: 0
   field_group: 0

--- a/config/features/signage/core.entity_form_display.node.sign.default.yml
+++ b/config/features/signage/core.entity_form_display.node.sign.default.yml
@@ -55,7 +55,7 @@ content:
       removed_reference: keep
     third_party_settings:
       entity_browser_entity_form:
-        entity_browser_id: _none
+        entity_browser_id: signage_slide_browser
   moderation_state:
     type: moderation_state_default
     weight: 11

--- a/config/features/signage/entity_browser.browser.signage_slide_browser.yml
+++ b/config/features/signage/entity_browser.browser.signage_slide_browser.yml
@@ -1,0 +1,31 @@
+uuid: a2c47b7a-8ca5-40af-8a4e-eb4109df90ad
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.signage_slide_content
+  module:
+    - views
+name: signage_slide_browser
+label: 'Slide Browser'
+display: modal
+display_configuration:
+  width: ''
+  height: ''
+  link_text: 'Select slides'
+  auto_open: true
+selection_display: no_display
+selection_display_configuration: {  }
+widget_selector: single
+widget_selector_configuration: {  }
+widgets:
+  5b8f18af-610a-4ff0-a554-e45bfb1a5422:
+    id: view
+    uuid: 5b8f18af-610a-4ff0-a554-e45bfb1a5422
+    label: Slides
+    weight: 1
+    settings:
+      submit_text: 'Add slides'
+      auto_select: false
+      view: signage_slide_content
+      view_display: entity_browser_featured

--- a/config/features/signage/views.view.signage_slide_content.yml
+++ b/config/features/signage/views.view.signage_slide_content.yml
@@ -5,12 +5,10 @@ dependencies:
   config:
     - field.storage.node.field_slide_description
     - node.type.slide
-    - taxonomy.vocabulary.tags
   module:
     - entity_browser
     - node
     - smart_trim
-    - taxonomy
     - user
 id: signage_slide_content
 label: Slides
@@ -485,106 +483,6 @@ display:
               webmaster: '0'
               administrator: '0'
             reduce: true
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-        field_tags_target_id:
-          id: field_tags_target_id
-          table: node__field_tags
-          field: field_tags_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: taxonomy_index_tid
-          operator: or
-          value: null
-          group: 1
-          exposed: true
-          expose:
-            operator_id: field_tags_target_id_op
-            label: Tags
-            description: ''
-            use_operator: false
-            operator: field_tags_target_id_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: field_tags_target_id
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              viewer: '0'
-              editor: '0'
-              publisher: '0'
-              webmaster: '0'
-              administrator: '0'
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          vid: tags
-          type: cshs
-          hierarchy: false
-          limit: true
-          error_message: true
-          force_deepest: false
-          parent: 0
-          level_labels: ''
-        sticky:
-          id: sticky
-          table: node_field_data
-          field: sticky
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: sticky
-          plugin_id: boolean
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: Sticky
-            description: ''
-            use_operator: false
-            operator: sticky_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: sticky
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              viewer: '0'
-              editor: '0'
-              publisher: '0'
-              webmaster: '0'
-              administrator: '0'
           is_grouped: false
           group_info:
             label: ''

--- a/config/features/signage/views.view.signage_slide_content.yml
+++ b/config/features/signage/views.view.signage_slide_content.yml
@@ -4,11 +4,15 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_slide_description
+    - field.storage.node.field_slide_duration
     - node.type.slide
+    - taxonomy.vocabulary.tags
   module:
     - entity_browser
     - node
+    - options
     - smart_trim
+    - taxonomy
     - user
 id: signage_slide_content
 label: Slides
@@ -131,6 +135,68 @@ display:
           type: string
           settings:
             link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_slide_duration:
+          id: field_slide_duration
+          table: node__field_slide_duration
+          field: field_slide_duration
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Duration
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -495,6 +561,106 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_tags_target_id:
+          id: field_tags_target_id
+          table: node__field_tags
+          field: field_tags_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: null
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_tags_target_id_op
+            label: Tags
+            description: ''
+            use_operator: false
+            operator: field_tags_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_tags_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              viewer: '0'
+              editor: '0'
+              publisher: '0'
+              webmaster: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: tags
+          type: cshs
+          hierarchy: false
+          limit: true
+          error_message: true
+          force_deepest: false
+          parent: 0
+          level_labels: ''
+        sticky:
+          id: sticky
+          table: node_field_data
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: sticky
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Sticky
+            description: ''
+            use_operator: false
+            operator: sticky_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: sticky
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              viewer: '0'
+              editor: '0'
+              publisher: '0'
+              webmaster: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -592,18 +758,7 @@ display:
           replica: false
           query_tags: {  }
       relationships: {  }
-      header:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text_custom
-          empty: true
-          content: 'Only published content is available for selection.'
-          tokenize: false
+      header: {  }
       footer: {  }
       display_extenders: {  }
     cache_metadata:
@@ -617,6 +772,7 @@ display:
         - user.permissions
       tags:
         - 'config:field.storage.node.field_slide_description'
+        - 'config:field.storage.node.field_slide_duration'
   entity_browser_featured:
     id: entity_browser_featured
     display_title: 'Entity browser'
@@ -636,3 +792,4 @@ display:
         - user.permissions
       tags:
         - 'config:field.storage.node.field_slide_description'
+        - 'config:field.storage.node.field_slide_duration'

--- a/config/features/signage/views.view.signage_slide_content.yml
+++ b/config/features/signage/views.view.signage_slide_content.yml
@@ -1,0 +1,740 @@
+uuid: c9fc2a9b-bb03-4222-83cc-ba8ab23e37b6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_slide_description
+    - node.type.slide
+    - taxonomy.vocabulary.tags
+  module:
+    - entity_browser
+    - node
+    - smart_trim
+    - taxonomy
+    - user
+id: signage_slide_content
+label: Slides
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Master
+    display_plugin: default
+    position: 0
+    display_options:
+      fields:
+        entity_browser_select:
+          id: entity_browser_select
+          table: node
+          field: entity_browser_select
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_browser_select
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          use_field_cardinality: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_slide_description:
+          id: field_slide_description
+          table: node__field_slide_description
+          field: field_slide_description
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Description
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: smart_trim
+          settings:
+            trim_length: 40
+            trim_type: words
+            trim_suffix: ''
+            wrap_output: false
+            wrap_class: trimmed
+            more:
+              display_link: false
+              target_blank: false
+              link_trim_only: false
+              class: more-link
+              text: More
+              aria_label: 'Read more about [node:title]'
+              token_browser: ''
+            trim_options:
+              text: true
+              trim_zero: false
+              replace_tokens: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        uid:
+          id: uid
+          table: node_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: uid
+          plugin_id: field
+          label: Author
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: short
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: ''
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: mini
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 25
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
+      filters:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Title
+            description: ''
+            use_operator: false
+            operator: title_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              editor: '0'
+              publisher: '0'
+              webmaster: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            slide: slide
+          group: 1
+          exposed: false
+          expose:
+            operator_id: type_op
+            label: Type
+            description: ''
+            use_operator: false
+            operator: type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              viewer: '0'
+              editor: '0'
+              publisher: '0'
+              webmaster: '0'
+              administrator: '0'
+            reduce: true
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_tags_target_id:
+          id: field_tags_target_id
+          table: node__field_tags
+          field: field_tags_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: null
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_tags_target_id_op
+            label: Tags
+            description: ''
+            use_operator: false
+            operator: field_tags_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_tags_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              viewer: '0'
+              editor: '0'
+              publisher: '0'
+              webmaster: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: tags
+          type: cshs
+          hierarchy: false
+          limit: true
+          error_message: true
+          force_deepest: false
+          parent: 0
+          level_labels: ''
+        sticky:
+          id: sticky
+          table: node_field_data
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: sticky
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Sticky
+            description: ''
+            use_operator: false
+            operator: sticky_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: sticky
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              viewer: '0'
+              editor: '0'
+              publisher: '0'
+              webmaster: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            entity_browser_select: entity_browser_select
+            field_image: field_image
+            title: title
+            body: body
+            uid: uid
+            type: type
+            moderation_state: moderation_state
+            changed: changed
+          default: changed
+          info:
+            entity_browser_select:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_image:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            body:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            moderation_state:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'Only published content is available for selection.'
+          tokenize: false
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_slide_description'
+  entity_browser_featured:
+    id: entity_browser_featured
+    display_title: 'Entity browser'
+    display_plugin: entity_browser
+    position: 1
+    display_options:
+      display_extenders:
+        metatag_display_extender: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_slide_description'

--- a/config/features/signage/views.view.signage_slide_content.yml
+++ b/config/features/signage/views.view.signage_slide_content.yml
@@ -6,13 +6,11 @@ dependencies:
     - field.storage.node.field_slide_description
     - field.storage.node.field_slide_duration
     - node.type.slide
-    - taxonomy.vocabulary.tags
   module:
     - entity_browser
     - node
     - options
     - smart_trim
-    - taxonomy
     - user
 id: signage_slide_content
 label: Slides
@@ -467,52 +465,6 @@ display:
       sorts: {  }
       arguments: {  }
       filters:
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: title
-          plugin_id: string
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: title_op
-            label: Title
-            description: ''
-            use_operator: false
-            operator: title_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: title
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              editor: '0'
-              publisher: '0'
-              webmaster: '0'
-              administrator: '0'
-            placeholder: ''
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
         type:
           id: type
           table: node_field_data
@@ -561,27 +513,27 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        field_tags_target_id:
-          id: field_tags_target_id
-          table: node__field_tags
-          field: field_tags_target_id
+        combine:
+          id: combine
+          table: views
+          field: combine
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: taxonomy_index_tid
-          operator: or
-          value: null
+          plugin_id: combine
+          operator: contains
+          value: ''
           group: 1
           exposed: true
           expose:
-            operator_id: field_tags_target_id_op
-            label: Tags
+            operator_id: combine_op
+            label: Search
             description: ''
             use_operator: false
-            operator: field_tags_target_id_op
+            operator: combine_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: field_tags_target_id
+            identifier: search
             required: false
             remember: false
             multiple: false
@@ -593,7 +545,8 @@ display:
               publisher: '0'
               webmaster: '0'
               administrator: '0'
-            reduce: false
+              sign_manager: '0'
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -606,61 +559,9 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          reduce_duplicates: false
-          vid: tags
-          type: cshs
-          hierarchy: false
-          limit: true
-          error_message: true
-          force_deepest: false
-          parent: 0
-          level_labels: ''
-        sticky:
-          id: sticky
-          table: node_field_data
-          field: sticky
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: sticky
-          plugin_id: boolean
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: Sticky
-            description: ''
-            use_operator: false
-            operator: sticky_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: sticky
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              viewer: '0'
-              editor: '0'
-              publisher: '0'
-              webmaster: '0'
-              administrator: '0'
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
+          fields:
+            title: title
+            field_slide_description: field_slide_description
       filter_groups:
         operator: AND
         groups:
@@ -780,7 +681,9 @@ display:
     position: 1
     display_options:
       display_extenders:
-        metatag_display_extender: {  }
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/sites/signage.sites.uiowa.edu/field.field.node.sign.og_audience.yml
+++ b/config/sites/signage.sites.uiowa.edu/field.field.node.sign.og_audience.yml
@@ -7,7 +7,12 @@ dependencies:
     - node.type.sign
     - node.type.signage_group
   module:
+    - epp
     - og
+third_party_settings:
+  epp:
+    value: '[current-page:query:group]'
+    on_update: 0
 id: node.sign.og_audience
 field_name: og_audience
 entity_type: node

--- a/config/sites/signage.sites.uiowa.edu/field.field.node.slide.og_audience.yml
+++ b/config/sites/signage.sites.uiowa.edu/field.field.node.slide.og_audience.yml
@@ -7,7 +7,12 @@ dependencies:
     - node.type.signage_group
     - node.type.slide
   module:
+    - epp
     - og
+third_party_settings:
+  epp:
+    value: '[current-page:query:group]'
+    on_update: 0
 id: node.slide.og_audience
 field_name: og_audience
 entity_type: node

--- a/docroot/sites/signage.sites.uiowa.edu/modules/sitessignage_core/sitessignage_core.links.action.yml
+++ b/docroot/sites/signage.sites.uiowa.edu/modules/sitessignage_core/sitessignage_core.links.action.yml
@@ -1,0 +1,14 @@
+sitessignage_core.group_add_sign:
+  route_name: node.add
+  route_parameters:
+    node_type: sign
+  title: 'Add sign'
+  appears_on:
+    - entity.node.canonical
+sitessignage_core.group_add_slide:
+  route_name: node.add
+  route_parameters:
+    node_type: slide
+  title: 'Add slide'
+  appears_on:
+    - entity.node.canonical

--- a/docroot/sites/signage.sites.uiowa.edu/modules/sitessignage_core/sitessignage_core.links.action.yml
+++ b/docroot/sites/signage.sites.uiowa.edu/modules/sitessignage_core/sitessignage_core.links.action.yml
@@ -5,6 +5,7 @@ sitessignage_core.group_add_sign:
   title: 'Add sign'
   appears_on:
     - entity.node.canonical
+
 sitessignage_core.group_add_slide:
   route_name: node.add
   route_parameters:

--- a/docroot/sites/signage.sites.uiowa.edu/modules/sitessignage_core/sitessignage_core.module
+++ b/docroot/sites/signage.sites.uiowa.edu/modules/sitessignage_core/sitessignage_core.module
@@ -121,8 +121,20 @@ function sitessignage_core_preprocess_block__local_actions_block(&$variables) {
   if ($route_match->getRouteName() == 'entity.node.canonical') {
     $node = $route_match->getParameter('node');
     if ($node->bundle() !== 'signage_group') {
-      unset($variables['content']['signage_sitenow.group_add_sign']);
-      unset($variables['content']['signage_sitenow.group_add_slide']);
+      unset($variables['content']['sitessignage_core.group_add_sign']);
+      unset($variables['content']['sitessignage_core.group_add_slide']);
+    }
+    else {
+      foreach (['sign', 'slide'] as $type) {
+        if (isset($variables['content']["sitessignage_core.group_add_{$type}"]['#link']['url'])) {
+          /** @var \Drupal\Core\Url $url */
+          $url = $variables['content']["sitessignage_core.group_add_{$type}"]['#link']['url'];
+          $options = $url->getOptions();
+          $options['query']['group'] = $node->id();
+          $url->setOptions($options);
+          $variables['content']["sitessignage_core.group_add_{$type}"]['#link']['url'] = $url;
+        }
+      }
     }
   }
 }

--- a/docroot/sites/signage.sites.uiowa.edu/modules/sitessignage_core/sitessignage_core.module
+++ b/docroot/sites/signage.sites.uiowa.edu/modules/sitessignage_core/sitessignage_core.module
@@ -110,3 +110,19 @@ function sitessignage_core_entity_view_alter(array &$build, $entity, $display) {
     }
   }
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function sitessignage_core_preprocess_block__local_actions_block(&$variables) {
+  // Get the current route node and check its bundle type.
+  /** @var \Drupal\Core\Routing\RouteMatch $route_match */
+  $route_match = \Drupal::service('current_route_match');
+  if ($route_match->getRouteName() == 'entity.node.canonical') {
+    $node = $route_match->getParameter('node');
+    if ($node->bundle() !== 'signage_group') {
+      unset($variables['content']['signage_sitenow.group_add_sign']);
+      unset($variables['content']['signage_sitenow.group_add_slide']);
+    }
+  }
+}


### PR DESCRIPTION
This PR improves the UI/UX for selecting existing slides in the context of building a sign. It also introduces "Add sign" and "Add slide" buttons to group pages, which pre-populated the group on the add node form.

Resolves #9128 
Resolves #9135 

# How to test
- First time:
```
ddev composer install
```
- Setup:
```
ddev blt ds --site signage.sites.uiowa.edu && ddev drush @sitessignage.local uli
```
- Test adding new and existing slides and saving signs to ensure everything still works there. Test with existing signs and new signs. No need to worry about specifically testing the slide creation workflow outside of the sign context because these changes don't affect that.
- Confirm the correct slides are added.
- Visit a group page and confirm that links are available for adding a sign and a slide.
- Confirm that other content types do not show the links for adding signs and slides.
- Test group page links for adding signs and slides to see that the group is pre-populated into each one.

## v2
```
ddev blt ds --site hawkeyemarchingband.uiowa.edu && ddev drush @hawkeyemarchingband.local uli
```
- Confirm that adding content to feature content paragraph still works as expected.