### PR TITLE
Aggregator/RSS Feed Block - Register cache tags for proper invalidation

### DIFF
--- a/docroot/modules/custom/uiowa_aggregator/uiowa_aggregator.module
+++ b/docroot/modules/custom/uiowa_aggregator/uiowa_aggregator.module
@@ -5,6 +5,8 @@
  * Primary module hooks for uiowa_aggregator module.
  */
 
+use Drupal\aggregator\Entity\Feed;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -177,6 +179,28 @@ function uiowa_aggregator_preprocess_block__inline_block__uiowa_aggregator(&$var
 
   foreach ($block->get('field_uiowa_aggregator_feeds')->getIterator() as $list_string_item) {
     $feeds[] = $list_string_item->getString();
+  }
+
+  // Add cache tags for selected feeds.
+  if ($feeds) {
+    $feed_entities = Feed::loadMultiple($feeds);
+    $feed_tags = [];
+
+    foreach ($feed_entities as $feed) {
+      // Attempt to get these from aggregator since all of
+      // this functionality exists.
+      $tags = $feed->getCacheTags();
+      if (empty($tags)) {
+        // But... fallback to a manually constructed tag if not.
+        $tags = ['aggregator_feed:' . $feed->id()];
+      }
+      $feed_tags = Cache::mergeTags($feed_tags, $tags);
+    }
+
+    $variables['#cache']['tags'] = Cache::mergeTags(
+      $variables['#cache']['tags'] ?? [],
+      $feed_tags
+    );
   }
 
   $per_page = (int) $block->get('field_uiowa_aggregator_count')->getString();


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/9139
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

- On `main`
- `ddev blt ds --site=engineering.uiowa.edu`
- As an anonymous user, go to https://engineering.uiowa.ddev.site/about/employment-opportunities (at the time of writing this, there should be five items listed)
- Login and go to https://engineering.uiowa.ddev.site/admin/config/services/aggregator, click the feed operations button and select delete items.
- As an anonymous user, reload https://engineering.uiowa.ddev.site/about/employment-opportunities
- Because cache did not invalidate, it should still show five items.
- Switch your branch to `aggregator_cache_fix`
- `ddev drush @engineering.local cr` and reload the anonymous page. This should remove the five items but also establish the cache tag.
- On https://engineering.uiowa.ddev.site/admin/config/services/aggregator, click the feed operations button and select update items. The same five items should import.
- As an anonymous user, reload https://engineering.uiowa.ddev.site/about/employment-opportunities
- It should go from no items back to five items.
