### PR TITLE
Signage - add entity browser permission

### DIFF
--- a/config/features/signage/user.role.sign_manager.yml
+++ b/config/features/signage/user.role.sign_manager.yml
@@ -3,6 +3,9 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.featured_content_browser
+    - entity_browser.browser.media_wysiwyg_browser
+    - entity_browser.browser.signage_slide_browser
     - filter.format.basic
     - filter.format.filtered_html
     - filter.format.minimal
@@ -40,6 +43,7 @@ permissions:
   - 'access files overview'
   - 'access media overview'
   - 'access media_wysiwyg_browser entity browser pages'
+  - 'access signage_slide_browser entity browser pages'
   - 'access toolbar'
   - 'access users overview'
   - 'create and edit custom blocks'


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->
https://iowaweb.slack.com/archives/C0164FNN1PV/p1757354300638369

<img width="709" height="226" alt="Screenshot 2025-09-08 at 12 57 40 PM" src="https://github.com/user-attachments/assets/562c1f8e-f8f2-4a71-b2ac-282f0b5644fc" />


# How to test

As a sign manager user, you can add/edit a sign and select the existing slide button that shows the entity browser and not an access denied message.