### PR TITLE
Removed Speech and Hearing Center building.

### DIFF
--- a/config/sites/classrooms.uiowa.edu/classrooms_core.building.shc.yml
+++ b/config/sites/classrooms.uiowa.edu/classrooms_core.building.shc.yml
@@ -1,8 +1,0 @@
-uuid: c1497b6a-9fce-4a79-9641-6bfa5ffea44d
-langcode: en
-status: 1
-dependencies: {  }
-id: shc
-label: 'Speech and Hearing Center'
-description: null
-number: '0198'


### PR DESCRIPTION
Resolves #9154 

# How to test
```
ddev blt ds --site classrooms.uiowa.edu
```
- Visit https://classrooms.uiowa.ddev.site/spaces/find-university-classroom and confirm that the Speech and Hearing Center is no longer present in the Buildings filter drop-down select list.
