### PR TITLE
Neuroscience Grad - remove views configured menu links

### DIFF
--- a/config/sites/neuroscience.grad.uiowa.edu/views.view.person_custom.yml
+++ b/config/sites/neuroscience.grad.uiowa.edu/views.view.person_custom.yml
@@ -19,7 +19,6 @@ dependencies:
     - node.type.person
     - sitenow_people.person_type.faculty
     - sitenow_people.person_type.student
-    - system.menu.main
     - taxonomy.vocabulary.department
     - taxonomy.vocabulary.research_areas
   module:
@@ -1462,10 +1461,12 @@ display:
         filter_groups: false
       display_description: ''
       display_extenders:
-        metatag_display_extender: {  }
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
       path: people/faculty
       menu:
-        type: normal
+        type: none
         title: Faculty
         description: ''
         weight: -50
@@ -2234,10 +2235,12 @@ display:
       relationships: {  }
       display_description: ''
       display_extenders:
-        metatag_display_extender: {  }
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
       path: people/students/former
       menu:
-        type: normal
+        type: none
         title: 'Past students'
         description: ''
         weight: -30
@@ -2952,10 +2955,12 @@ display:
           required: false
       display_description: ''
       display_extenders:
-        metatag_display_extender: {  }
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
       path: people/students
       menu:
-        type: normal
+        type: none
         title: Students
         description: ''
         weight: -40


### PR DESCRIPTION
As part of support, Makur requested these configuration based menu links be removed so that they can control links to these pages using regular menu links.

# How to test

```
ddev blt ds --site=neuroscience.grad.uiowa.edu
```

See that the Faculty link is gone from the People dropdown and the students and former students links are regular menu links that can be enabled/disable and which persist between syncs.

# Follow-up

- Contact Makur that this has been deployed.
- Ask if the link to Faculty should be re-created as a regular menu link
