### PR TITLE
Update footer policy link to new location

### DIFF
--- a/docroot/themes/custom/uids_base/templates/uids/footer--socket-menu.twig
+++ b/docroot/themes/custom/uids_base/templates/uids/footer--socket-menu.twig
@@ -5,7 +5,7 @@
       <a href="https://uiowa.edu/privacy">Privacy Notice</a>
     </li>
     <li>
-      <a href="https://opsmanual.uiowa.edu/community-policies/nondiscrimination-statement">UI Nondiscrimination Statement</a>
+      <a href="https://policy.uiowa.edu/community-policies/nondiscrimination-statement">UI Nondiscrimination Statement</a>
     </li>
     <li>
       <a href="https://accessibility.uiowa.edu/">Accessibility</a>


### PR DESCRIPTION
UI Nondiscrimination Statement link in the footer goes to https://opsmanual.uiowa.edu/community-policies/nondiscrimination-statement, which redirects to https://policy.uiowa.edu/community-policies/nondiscrimination-statement.

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
Pull and sync a site (or cache clear a site you already have)
Check the UI Nondiscrimination Statement link, and see that it links directly to policy without needing the redirect