### PR TITLE
[Policy] Show breadcrumbs for print

### DIFF
--- a/docroot/sites/policy.uiowa.edu/modules/policy_core/css/print.css
+++ b/docroot/sites/policy.uiowa.edu/modules/policy_core/css/print.css
@@ -1,0 +1,9 @@
+/* ShowPage elements
+----------------------------------------- */
+nav.breadcrumb {
+  display:block !important
+}
+
+.content__container nav.breadcrumb  a:not(.bttn):not(.photoswipe)[href]:after {
+  content: "";
+}

--- a/docroot/sites/policy.uiowa.edu/modules/policy_core/css/print.css
+++ b/docroot/sites/policy.uiowa.edu/modules/policy_core/css/print.css
@@ -4,6 +4,6 @@ nav.breadcrumb {
   display:block !important
 }
 
-.content__container nav.breadcrumb  a:not(.bttn):not(.photoswipe)[href]:after {
+nav.breadcrumb  a:not(.bttn):not(.photoswipe)[href]:after {
   content: "";
 }

--- a/docroot/sites/policy.uiowa.edu/modules/policy_core/css/print.css
+++ b/docroot/sites/policy.uiowa.edu/modules/policy_core/css/print.css
@@ -1,7 +1,8 @@
 /* ShowPage elements
 ----------------------------------------- */
 nav.breadcrumb {
-  display:block !important
+  display:block !important;
+  margin-top: 0;
 }
 
 nav.breadcrumb  a:not(.bttn):not(.photoswipe)[href]:after {

--- a/docroot/sites/policy.uiowa.edu/modules/policy_core/css/print.css
+++ b/docroot/sites/policy.uiowa.edu/modules/policy_core/css/print.css
@@ -4,7 +4,15 @@ nav.breadcrumb {
   display:block !important;
   margin-top: 0;
 }
-
-nav.breadcrumb  a:not(.bttn):not(.photoswipe)[href]:after {
+/* Remove url from displaying for breadcrumb links */
+nav.breadcrumb a:not(.bttn):not(.photoswipe)[href]:after {
+  content: "";
+}
+/* Hide current page in breadcrumbs */
+nav.breadcrumb li:not(:has(a)) {
+  display: none;
+}
+/* Hide dividing line for second to last child */
+nav.breadcrumb li:nth-last-child(2):after {
   content: "";
 }

--- a/docroot/sites/policy.uiowa.edu/modules/policy_core/policy_core.libraries.yml
+++ b/docroot/sites/policy.uiowa.edu/modules/policy_core/policy_core.libraries.yml
@@ -2,3 +2,4 @@ policy:
   css:
     theme:
       css/policy.css: {}
+      css/print.css: { media: print }

--- a/docroot/themes/custom/uids_base/scss/theme/print.scss
+++ b/docroot/themes/custom/uids_base/scss/theme/print.scss
@@ -135,13 +135,15 @@ abbr[title]::after {
 .iowa-bar__container {
   margin: initial;
   padding: 0 !important;
+  display: flex!important;
 }
 
 .iowa-bar__below {
   border-block-end: none;
 }
 
-.iowa-bar__below .site-name {
+.iowa-bar__below .site-name,
+.iowa-bar--full .site-name {
   padding-block: 0;
   padding-inline-start: 1.25rem !important;
   font-size: 18pt !important;
@@ -154,8 +156,9 @@ abbr[title]::after {
   }
 }
 
+.iowa-bar__below .iowa-bar__container,
 .iowa-bar__below .iowa-bar__container {
-  min-height: auto;
+  height: auto;
 }
 
 .logo--tab {

--- a/docroot/themes/custom/uids_base/scss/theme/print.scss
+++ b/docroot/themes/custom/uids_base/scss/theme/print.scss
@@ -138,6 +138,11 @@ abbr[title]::after {
   display: flex!important;
 }
 
+.iowa-bar--full .iowa-bar__container {
+  align-items: inherit;
+  flex-wrap: nowrap;
+}
+
 .iowa-bar__below {
   border-block-end: none;
 }
@@ -162,10 +167,14 @@ abbr[title]::after {
 }
 
 .logo--tab {
-  height: 70px !important;
+  height: 72px !important;
   padding-block: 25px !important;
   padding-inline: 1.25rem !important;
-  width: 109px !important;
+  width: 104px !important;
+}
+
+.iowa-bar--full .logo--tab {
+  width: 91px !important;
 }
 
 .logo-icon {

--- a/docroot/themes/custom/uids_base/scss/theme/print.scss
+++ b/docroot/themes/custom/uids_base/scss/theme/print.scss
@@ -161,20 +161,25 @@ abbr[title]::after {
   }
 }
 
-.iowa-bar__below .iowa-bar__container,
 .iowa-bar__below .iowa-bar__container {
-  height: auto;
+  min-height: auto;
+}
+
+.iowa-bar--full .site-name {
+  margin: 0!important;
 }
 
 .logo--tab {
-  height: 72px !important;
-  padding-block: 25px !important;
+  height: 38px !important;
+  padding-block: 8px !important;
   padding-inline: 1.25rem !important;
+  margin-block-end: 0 !important;
   width: 104px !important;
 }
 
 .iowa-bar--full .logo--tab {
   width: 91px !important;
+  padding-block: 8px !important;
 }
 
 .logo-icon {


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/9174. 

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test
```
ddev blt frontend && ddev blt ds --site=policy.uiowa.edu   && ddev drush @policy.local uli /governance/board-regents#Membership
```
1. Try to print the page and confirm the breadcrumbs appear without href information and the current page title listed in the breadcrumb.  
2. Test in Chrome, Safari, and Firefox. 
3. Compare against prod and confirm that the header site name appears styled in local version. 
4. Switch to "Below" header option at https://policy.uiowa.ddev.site/admin/appearance/settings/uids_base and confirm the header renders similar. 
