### PR TITLE
Commencement events import fix

### DIFF
--- a/docroot/modules/custom/uiowa_core/src/EntityItemProcessorBase.php
+++ b/docroot/modules/custom/uiowa_core/src/EntityItemProcessorBase.php
@@ -56,11 +56,28 @@ abstract class EntityItemProcessorBase {
       }
     }
 
+    // Allow subclasses to modify values before they are set on the entity.
+    static::prepareUpdatedValues($values, $entity, $record);
+
     foreach ($values as $field => $value) {
       $entity->set($field, $value);
     }
 
     return $updated;
+  }
+
+  /**
+   * Prepare updated values before they are set on the entity.
+   *
+   * @param array $values
+   *   The values to be set on the entity, passed by reference.
+   * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+   *   The entity being processed.
+   * @param mixed $record
+   *   The source record being processed.
+   */
+  protected static function prepareUpdatedValues(array &$values, FieldableEntityInterface $entity, $record): void {
+    // By default, do nothing. Subclasses may override.
   }
 
   /**

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventItemProcessor.php
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventItemProcessor.php
@@ -28,11 +28,12 @@ class EventItemProcessor extends EntityItemProcessorBase {
   ];
 
   /**
-   * Process the body field.
+   * {@inheritdoc}
    */
   public static function process($entity, $record): bool {
     $updated = parent::process($entity, $record);
 
+    // Handle the body field.
     if (isset($record->description)) {
       if ($entity->get('body')->value !== $record->description) {
         // Set both value and format for the body field.
@@ -45,6 +46,19 @@ class EventItemProcessor extends EntityItemProcessorBase {
     }
 
     return $updated;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static function prepareUpdatedValues(array &$values, $entity, $record): void {
+    // If the event end time is being updated, ensure the start time is
+    // included in the update values.
+    if (isset($values['field_event_when']['end_value'])
+      && !isset($values['field_event_when']['value'])
+      && property_exists($record, 'start')) {
+      $values['field_event_when']['value'] = $record->start;
+    }
   }
 
 }


### PR DESCRIPTION
Resolves #9186 

**Narrative:** 

The commencement event importer was encountering issues when one part (start or end) of the date/time field changed but the other did not. The import process would correctly identify only the changed part to be updated. However, the date/time field on the Drupal side of things would  interpret such an update as though a null value had been passed in for the part not being updated. This would sometimes result in either the date not being displayed or fatal PHP errors when trying to view the event page.

The challenge in solving this issue is that the event importer class extends a base class that is extended by 3 other classes, so it is important to not introduce regressions in the other importers. To solve the issue with minimal disruption, I introduce a new method on the `EntityItemProcessorBase` class that is called after the updated values are collected but before the values are set on the entity. The method allows for making alterations to the updated values prior to updating the entity. On the base class this method is empty, so it has no effect unless an extending class overrides it. In the `EventItemProcessor` class, I used this method to ensure that both start and end dates are present if either is updated.

# How to test
- Code review. 
- Login to https://events.uiowa.edu/ (you may have to do this multiple times, the auto-logout is really quick on this site).
- **Note:** When logging in from an event page on the Campus Events website, I encountered the experience multiple times where I was redirected to another (random-seeming) event. So be careful that you are on the event you are expecting before making and save edits to an event.
- Visit https://events.uiowa.edu/event/27927/edit and update the event to include an end time.
- **Note:** There seems to be a slight delay after an event record is changed on the Campus Events website before that change is represented in the API. I was able to work around it by waiting a few extra seconds after making an edit there and then running the import command.
```
ddev blt ds --site commencement.uiowa.edu \
&& ddev drush @commencement.local import-events
```
- Observe that there are 1 or more updates in the command output.
- Review https://commencement.uiowa.ddev.site/ceremonies?session=226 to ensure that the event shows date/times that correspond with what was entered.
```
ddev drush @commencement.local import-events
```
- Observe that there are 0 updates.
- Visit https://events.uiowa.edu/event/27927/edit and update the event to change the start time.
```
ddev drush @commencement.local import-events
```
- Check the ceremonies page again and confirm the start time is updated as expected.
- Visit https://events.uiowa.edu/event/27927/edit and set it back to the original time settings (start: 7pm, end: empty).
```
ddev drush @commencement.local import-events
```
- Check the ceremonies page again and confirm that the details are as expected.

## No regressions
```
ddev blt ds --site classrooms.uiowa.edu && \
ddev blt ds --site emergency.uiowa.edu && \
ddev blt ds --site facilities.uiowa.edu && \
ddev drush @classrooms.local classrooms-buildings && \
ddev drush @classrooms.local classrooms-rooms && \
ddev drush @emergency.local rave-alerts && \
ddev drush @facilities.local fm-buildings && \
ddev drush @facilities.local fm-projects
```
- All import commands run without errors.
- No unexpected import changes (e.g. large number of updates)