### PR TITLE
[Bug] Fix for accordion summary overflow

### DIFF
--- a/docroot/sites/safety.uiowa.edu/modules/safety_core/src/Form/LogSearchForm.php
+++ b/docroot/sites/safety.uiowa.edu/modules/safety_core/src/Form/LogSearchForm.php
@@ -139,7 +139,6 @@ class LogSearchForm extends FormBase {
     $form['#attributes'] = [
       'class' => [
         'bg--gray',
-        'form',
         'element--padding__all--minimal',
         'block-margin__bottom--extra',
         'form--horizontal',

--- a/docroot/themes/custom/uids_base/templates/content/node.html.twig
+++ b/docroot/themes/custom/uids_base/templates/content/node.html.twig
@@ -75,7 +75,6 @@
   set classes = [
     'node',
     'node--type-' ~ node.bundle|clean_class,
-    'form',
     node.isPromoted() ? 'node--promoted',
     node.isSticky() ? 'node--sticky',
     not node.isPublished() ? 'node--unpublished',


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/8937. 


<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt frontend && ddev blt ds --site=its.uiowa.edu && ddev drush @its.local uli /services/digital-signage/transition-digital-signage-v2#accordion-item-heading-11691
```
1. Confirm accordion summary does not overflow. 
2. Confirm `form` classes are being added through https://github.com/uiowa/uiowa/blob/main/docroot/themes/custom/uids_base/uids_base.theme#L35 and not needed on the `node.html.twig` template. 
3. I've reviewed a decent amount of our custom forms and they are still getting the custom `form` class from our preprocess functions: https://github.com/search?q=repo%3Auiowa%2Fuiowa+submitForm&type=code. 
