### PR TITLE
Commencement event import fix pt. 2

### DIFF
--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventItemProcessor.php
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventItemProcessor.php
@@ -52,12 +52,23 @@ class EventItemProcessor extends EntityItemProcessorBase {
    * {@inheritdoc}
    */
   protected static function prepareUpdatedValues(array &$values, $entity, $record): void {
-    // If the event end time is being updated, ensure the start time is
-    // included in the update values.
-    if (isset($values['field_event_when']['end_value'])
-      && !isset($values['field_event_when']['value'])
-      && property_exists($record, 'start')) {
-      $values['field_event_when']['value'] = $record->start;
+    // If any values for the date field are being updated, ensure that both
+    // start and end are included in the update values.
+    if (isset($values['field_event_when'])) {
+      // If the event start time is being updated, ensure the end time is
+      // updated too.
+      if (isset($values['field_event_when']['value'])
+        && !isset($values['field_event_when']['end_value'])
+        && property_exists($record, 'end')) {
+        $values['field_event_when']['end_value'] = $record->end;
+      }
+      // If the event end time is being updated, ensure the start time is
+      // updated too.
+      if (isset($values['field_event_when']['end_value'])
+        && !isset($values['field_event_when']['value'])
+        && property_exists($record, 'start')) {
+        $values['field_event_when']['value'] = $record->start;
+      }
     }
   }
 


### PR DESCRIPTION
Resolves #9186 

Hopefully the second time's the charm.

# How to test
- Code review. 
- Login to https://events.uiowa.edu/ (you may have to do this multiple times, the auto-logout is really quick on this site).
- **Note:** When logging in from an event page on the Campus Events website, I encountered the experience multiple times where I was redirected to another (random-seeming) event. So be careful that you are on the event you are expecting before making and save edits to an event.
- Visit https://events.uiowa.edu/event/27927/edit and update the event to include an end time.
- **Note:** There seems to be a slight delay after an event record is changed on the Campus Events website before that change is represented in the API. I was able to work around it by waiting a few extra seconds after making an edit there and then running the import command.
```
ddev blt ds --site commencement.uiowa.edu \
&& ddev drush @commencement.local import-events
```
- Observe that there are 1 or more updates in the command output.
- Review https://commencement.uiowa.ddev.site/ceremonies?session=226 to ensure that the event shows date/times that correspond with what was entered.
```
ddev drush @commencement.local import-events
```
- Observe that there are 0 updates.
- Visit https://events.uiowa.edu/event/27927/edit and update the event to change the start time.
```
ddev drush @commencement.local import-events
```
- Check the ceremonies page again and confirm the start time is updated as expected.
- Visit https://events.uiowa.edu/event/27927/edit and set it back to the original time settings (start: 7pm, end: empty).
```
ddev drush @commencement.local import-events
```
- Check the ceremonies page again and confirm that the details are as expected.

## No regressions
```
ddev blt ds --site classrooms.uiowa.edu && \
ddev blt ds --site emergency.uiowa.edu && \
ddev blt ds --site facilities.uiowa.edu && \
ddev drush @classrooms.local classrooms-buildings && \
ddev drush @classrooms.local classrooms-rooms && \
ddev drush @emergency.local rave-alerts && \
ddev drush @facilities.local fm-buildings && \
ddev drush @facilities.local fm-projects
```
- All import commands run without errors.
- No unexpected import changes (e.g. large number of updates)
