### PR TITLE
Policy PDF Download Memory Bump

### DIFF
--- a/docroot/sites/policy.uiowa.edu/modules/policy_core/src/Controller/PDFContentController.php
+++ b/docroot/sites/policy.uiowa.edu/modules/policy_core/src/Controller/PDFContentController.php
@@ -155,6 +155,9 @@ class PDFContentController extends ControllerBase implements ContainerInjectionI
    * Batch finished callback.
    */
   public static function batchFinished($success, $results, $operations): void {
+    // Increase the memory limit temporarily for PDF generation.
+    ini_set('memory_limit', '512M');
+
     $messenger = \Drupal::messenger();
     $fs = \Drupal::service('file_system');
 


### PR DESCRIPTION
re-add 49ca0be1d5eede215c78fad3decde4801c9bdfc3 back in after failure in PROD

original conversation: https://github.com/uiowa/uiowa/pull/9193#discussion_r2402924507

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

Deploy to PROD
