### PR TITLE
Signage - Search + group names link on all groups block

### DIFF
--- a/config/sites/signage.sites.uiowa.edu/views.view.signage_groups.yml
+++ b/config/sites/signage.sites.uiowa.edu/views.view.signage_groups.yml
@@ -76,7 +76,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: false
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -175,7 +175,7 @@ display:
         type: basic
         options:
           submit_button: Apply
-          reset_button: false
+          reset_button: true
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
           expose_sort_order: true
@@ -228,6 +228,54 @@ display:
           value:
             signage_group: signage_group
           group: 1
+        combine:
+          id: combine
+          table: views
+          field: combine
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: combine
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: combine_op
+            label: Search
+            description: ''
+            use_operator: false
+            operator: combine_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: search
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              viewer: '0'
+              editor: '0'
+              publisher: '0'
+              webmaster: '0'
+              administrator: '0'
+              sign_manager: '0'
+            placeholder: 'Group name'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          fields:
+            title: title
       filter_groups:
         operator: AND
         groups:
@@ -283,6 +331,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
@@ -320,6 +369,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions

--- a/config/sites/signage.sites.uiowa.edu/views.view.signage_groups.yml
+++ b/config/sites/signage.sites.uiowa.edu/views.view.signage_groups.yml
@@ -188,7 +188,20 @@ display:
       cache:
         type: tag
         options: {  }
-      empty: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'There are currently no results to display.'
+            format: filtered_html
+          tokenize: false
       sorts:
         title:
           id: title


### PR DESCRIPTION
Adds linking from group names to the group pages. Adds a search filter.

# How to test

```
ddev blt ds --site signage.sites.uiowa.edu
```
- Visit https://sitessignage.uiowa.ddev.site/groups
- Confirm group names link to group pages. Group pages will still show access denied.
- Test search works.