### PR TITLE
Splide/Signage Reduced Motion Override

### DIFF
--- a/docroot/modules/custom/sitenow_signage/js/slideshow.js
+++ b/docroot/modules/custom/sitenow_signage/js/slideshow.js
@@ -7,6 +7,23 @@
   Drupal.behaviors.signageSlideshow = {
     attach: function (context, settings) {
       context.querySelectorAll('.signage__slideshow').forEach(function (element) {
+
+        // Override prefers-reduced-motion for Splide.
+        const originalMatchMedia = window.matchMedia;
+        window.matchMedia = function (query) {
+          if (query === '(prefers-reduced-motion: reduce)') {
+            return {
+              matches: false,
+              media: query,
+              onchange: null,
+              addEventListener: () => {},
+              removeEventListener: () => {},
+              dispatchEvent: () => false,
+            };
+          }
+          return originalMatchMedia(query);
+        };
+
         // Get the first slide interval from drupalSettings, fallback to 5000.
         const firstSlideInterval = settings.signageSlideshow?.firstSlideInterval || 5000;
         // Initialize Splide with the settings.


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

On `main`

```
ddev blt ds --site=signage.sites.uiowa.edu
```

As an anonymous user visiting https://sitessignage.uiowa.ddev.site/sign/master-mcu-onstage, open up Chrome's inspector tools, go to More Tools -> Rendering and turn on the prefers reduce motion option. Reload the page and wait. The slides do not transition.

On `splide_reduced_motion_override`

`ddev blt frontend && ddev drush @sitessignage.local cr`

Reload the page. It should transition the slides.
