### PR TITLE
Academic dates and other child heading sizes

### DIFF
--- a/docroot/modules/custom/sitenow_events/sitenow_events.module
+++ b/docroot/modules/custom/sitenow_events/sitenow_events.module
@@ -527,7 +527,10 @@ function sitenow_events_build_card(array $event): array {
   $card = [
     '#type' => 'card',
     '#attributes' => $event['attributes'] ?? [],
-    '#title' => $event['title'],
+    '#headline' => [
+      'headline_text' => $event['title'],
+      'headline_level' => $event['heading_size'],
+    ],
     '#url' => $event['url'],
     '#headline_level' => $event['heading_size'],
     '#prefix' => '<div class="column-container">',

--- a/docroot/modules/custom/sitenow_events/sitenow_events.module
+++ b/docroot/modules/custom/sitenow_events/sitenow_events.module
@@ -530,6 +530,7 @@ function sitenow_events_build_card(array $event): array {
     '#headline' => [
       'headline_text' => $event['title'],
       'headline_level' => $event['heading_size'],
+      'headline_class' => 'headline headline--serif',
     ],
     '#url' => $event['url'],
     '#headline_level' => $event['heading_size'],

--- a/docroot/modules/custom/uiowa_hours/src/Form/HoursFilterForm.php
+++ b/docroot/modules/custom/uiowa_hours/src/Form/HoursFilterForm.php
@@ -196,16 +196,19 @@ class HoursFilterForm extends FormBase {
       $render['closed'] = [
         '#type' => 'card',
         '#attributes' => $attributes,
-        '#title' => $this->t('@start@end', [
-          '@start' => date('F j, Y', $start),
-          '@end' => $end === $start ? NULL : ' - ' . date('F j, Y', $end),
-        ]),
+        '#headline' => [
+          'headline_text' => $this->t('@start@end', [
+            '@start' => date('F j, Y', $start),
+            '@end' => $end === $start ? NULL : ' - ' . date('F j, Y', $end),
+          ]),
+          'headline_level' => $block_config['child_heading_size'],
+          'headline_class' => 'headline--serif',
+        ],
         '#content' => [
           'times' => [
             '#markup' => $this->t('<span class="badge badge--orange">Closed</span>'),
           ],
         ],
-        '#headline_level' => $block_config['child_heading_size'],
       ];
     }
     else {
@@ -224,7 +227,14 @@ class HoursFilterForm extends FormBase {
         $render['hours'][$key] = [
           '#type' => 'card',
           '#attributes' => $attributes,
-          '#title' => date('F j, Y', strtotime($key)),
+          '#headline' => [
+            'headline_text' => $this->t('@start@end', [
+              '@start' => date('F j, Y', $start),
+              '@end' => $end === $start ? NULL : ' - ' . date('F j, Y', $end),
+            ]),
+            'headline_level' => $block_config['child_heading_size'],
+            'headline_class' => 'headline--serif',
+          ],
           '#content' => [
             'times' => [
               '#theme' => 'item_list',
@@ -234,7 +244,6 @@ class HoursFilterForm extends FormBase {
               ],
             ],
           ],
-          '#headline_level' => $block_config['child_heading_size'],
         ];
 
         foreach ($date as $time) {

--- a/docroot/modules/custom/uiowa_hours/src/Form/HoursFilterForm.php
+++ b/docroot/modules/custom/uiowa_hours/src/Form/HoursFilterForm.php
@@ -202,7 +202,7 @@ class HoursFilterForm extends FormBase {
             '@end' => $end === $start ? NULL : ' - ' . date('F j, Y', $end),
           ]),
           'headline_level' => $block_config['child_heading_size'],
-          'headline_class' => 'headline--serif',
+          'headline_class' => 'headline headline--serif',
         ],
         '#content' => [
           'times' => [
@@ -233,7 +233,7 @@ class HoursFilterForm extends FormBase {
               '@end' => $end === $start ? NULL : ' - ' . date('F j, Y', $end),
             ]),
             'headline_level' => $block_config['child_heading_size'],
-            'headline_class' => 'headline--serif',
+            'headline_class' => 'headline headline--serif',
           ],
           '#content' => [
             'times' => [

--- a/docroot/modules/custom/uiowa_maui/src/Form/AcademicDatesForm.php
+++ b/docroot/modules/custom/uiowa_maui/src/Form/AcademicDatesForm.php
@@ -163,11 +163,15 @@ class AcademicDatesForm extends FormBase {
           $form['dates-wrapper']['dates'][$key] = [
             '#type' => 'card',
             '#attributes' => $attributes,
-            '#title' => $this->t('@start@end', [
-              '@start' => date('F j, Y', $start),
-              '@end' => $end === $start ? '' : ' - ' . date('F j, Y', $end),
-            ]),
             '#content' => [$item],
+            '#headline' => [
+              'headline_level' => $child_heading_size,
+              'headline_text' => $this->t('@start@end', [
+                '@start' => date('F j, Y', $start),
+                '@end' => $end === $start ? '' : ' - ' . date('F j, Y', $end),
+              ]),
+              'headline_class' => 'headline--serif',
+            ],
           ];
         }
       }

--- a/docroot/modules/custom/uiowa_maui/src/Form/AcademicDatesForm.php
+++ b/docroot/modules/custom/uiowa_maui/src/Form/AcademicDatesForm.php
@@ -170,7 +170,7 @@ class AcademicDatesForm extends FormBase {
                 '@start' => date('F j, Y', $start),
                 '@end' => $end === $start ? '' : ' - ' . date('F j, Y', $end),
               ]),
-              'headline_class' => 'headline--serif',
+              'headline_class' => 'headline headline--serif',
             ],
           ];
         }


### PR DESCRIPTION
Resolves #9099 
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

```
ddev blt ds --site=grad.uiowa.edu &&
ddev blt ds --site=recserv.uiowa.edu &&
ddev blt ds --site=stanleymuseum.uiowa.edu &&
ddev drush @grad.local uli /academics/deadlines &&
ddev drush @recserv.local uli / &&
ddev drush @stanleymuseum.local uli /events
```

For each of the three pages, check against their prod equivalents
Each child item (Academic Date, Hours Date, and Events Event) should have a heading level one below the parent heading
Edit the page layout and adjust the heading for the related block; the children heading levels should adjust to match

For the Academic Dates (the grad.uiowa.edu/academics/deadlines example), if you use the Site Improve browser extension and scan the page, you should no longer receive the "Content missing after heading" issue, as opposed to prod