### PR TITLE
Update link for classroom

### DIFF
--- a/config/sites/classrooms.uiowa.edu/field.field.node.room.field_room_guide.yml
+++ b/config/sites/classrooms.uiowa.edu/field.field.node.room.field_room_guide.yml
@@ -18,7 +18,7 @@ translatable: false
 default_value:
   -
     attributes: {  }
-    uri: 'https://teach.uiowa.edu/basic-university-classroom-guide'
+    uri: 'https://teach.its.uiowa.edu/learning-spaces-technology/classroom-guides'
     title: 'Technology Guide'
     options: {  }
 default_value_callback: ''

--- a/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/classrooms_core.install
+++ b/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/classrooms_core.install
@@ -152,3 +152,22 @@ function classrooms_core_update_9003(&$sandbox) {
   }
 
 }
+/**/
+function classrooms_core_update_9004() {
+  $database = \Drupal::database();
+  $old = 'https://teach.uiowa.edu/basic-university-classroom-guide';
+  $new = 'https://teach.its.uiowa.edu/learning-spaces-technology/classroom-guides';
+
+  $tables = [
+    'node__field_room_guide',
+    'node_revision__field_room_guide',
+  ];
+
+  foreach ($tables as $table) {
+    $database->update($table)
+      ->fields(['field_room_guide_uri' => $new])
+      ->condition('field_room_guide_uri', $old)
+      ->execute();
+  }
+  \Drupal::service('cache.render')->invalidateAll();
+}

--- a/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/classrooms_core.install
+++ b/docroot/sites/classrooms.uiowa.edu/modules/classrooms_core/classrooms_core.install
@@ -152,7 +152,10 @@ function classrooms_core_update_9003(&$sandbox) {
   }
 
 }
-/**/
+
+/**
+ * Update old room guide link to new destination.
+ */
 function classrooms_core_update_9004() {
   $database = \Drupal::database();
   $old = 'https://teach.uiowa.edu/basic-university-classroom-guide';


### PR DESCRIPTION
# How to test

On `main`

```
ddev blt ds --site=classrooms.uiowa.edu 
```
- Go to https://classrooms.uiowa.ddev.site/abw-240
- Hover over the  Technology guide to inspect the link and cache the page. Refresh the page to ensure it is cached.

<img width="630" height="590" alt="Screenshot 2025-10-29 at 5 10 46 PM" src="https://github.com/user-attachments/assets/894ffc8c-94b6-4a58-94ea-d039bf008ebd" />

On `update-link-for-classroom`, run to test the update hook 

```
ddev drush @classrooms.local updb 
```

- go back to https://classrooms.uiowa.ddev.site/abw-240 and refresh.
- Hover over the  Technology guide to test the link 
<img width="630" height="590" alt="Screenshot 2025-10-29 at 5 10 46 PM" src="https://github.com/user-attachments/assets/894ffc8c-94b6-4a58-94ea-d039bf008ebd" />

- You can check the db tables to see that it only changed the one link and not the other values for the field. Using a db visualizer of your choice or

```
ddev sequelace 
```

<img width="1913" height="954" alt="Screenshot 2025-10-29 at 5 13 36 PM" src="https://github.com/user-attachments/assets/c8bf5d42-f881-41e1-a036-c51c491080ea" />

- Create a new room. See that the new link is the default value for the field.
