### PR TITLE
remove text-transform from ckeditor's version of the table caption

### DIFF
--- a/docroot/themes/custom/uids_base/scss/sitenow_wysiwyg.scss
+++ b/docroot/themes/custom/uids_base/scss/sitenow_wysiwyg.scss
@@ -73,7 +73,6 @@
       text-align: center;
       font-size: 1rem;
       color: #fff;
-      text-transform: uppercase;
       background-color: #333;
       font-weight: bold;
       em, strong, sup, sub {


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

```
ddev blt frontend && ddev blt ds --site=dentistry.uiowa.edu && ddev drush @dentistry.local uli node/1346/layout
```

See that the table captions are not all caps.