### PR TITLE
Vertical video

### DIFF
--- a/docroot/modules/custom/sitenow_signage/sass/signage.scss
+++ b/docroot/modules/custom/sitenow_signage/sass/signage.scss
@@ -163,6 +163,9 @@ div.bg--black .signage__table {
 
 // Increase font sizes for vertical displays.
 .signage--vertical {
+  .media--type-remote-video.media--view-mode-vertical {
+    max-width: 100%;
+  }
   .signage__table {
     caption {
       font-size: variables.$h3-font-size;

--- a/docroot/modules/custom/sitenow_signage/sitenow_signage.module
+++ b/docroot/modules/custom/sitenow_signage/sitenow_signage.module
@@ -743,6 +743,33 @@ function sitenow_signage_preprocess_paragraph(&$variables) {
       }
       break;
 
+    case 'slide_video':
+      if (isset($variables['content']['field_slide_video'])) {
+
+        // Get the sign node from the current route.
+        $sign_node = \Drupal::routeMatch()->getParameter('node');
+
+        if ($sign_node && $sign_node->bundle() == 'sign') {
+          $variables['#cache']['tags'][] = 'node:' . $sign_node->id();
+
+          // Check if we have a sign node with vertical orientation.
+          if (sitenow_signage_get_orientation($sign_node) === 'vertical') {
+
+            $view_builder = \Drupal::entityTypeManager()->getViewBuilder('media');
+
+            foreach ($variables['content']['field_slide_video'] as $delta => &$item) {
+              if (is_numeric($delta)) {
+                $media_entity = $paragraph->get('field_slide_video')->get($delta)->entity;
+                if ($media_entity) {
+                  $item = $view_builder->view($media_entity, 'vertical');
+                }
+              }
+            }
+          }
+        }
+      }
+      break;
+
     case 'slide_events':
       $filters = [
         'audiences' => sitenow_signage_value_query_string($paragraph?->field_slide_events_audiences?->getValue()),


### PR DESCRIPTION
Resolves to https://github.com/uiowa/uiowa/issues/9336. 

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt frontend && ddev blt ds --site=signage.sites.uiowa.edu && ddev drush @sitessignage.local uli /sign/uisma-gallery-9-1
```
1. Confirm the video displays in 9/16 aspect ratio if "Vertical" sign orientation is selected. 
2. Switch back to horizontal and vertical and verify there's no caching. 
3. Test with Vimeo https://sandbox.prod.drupal.uiowa.edu/media-vertical-vimeo-and-youtube. 
4. Check out instructions on https://github.com/uiowa/uiowa/pull/9124. 