### PR TITLE
[Transportation] Allow cost calculator changes to persist

### DIFF
--- a/config/sites/transportation.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/transportation.uiowa.edu/config_split.config_split.site.yml
@@ -16,5 +16,6 @@ theme: {  }
 complete_list:
   - config_split.config_split.site
 partial_list:
+  - config_ignore.settings
   - core.entity_view_display.node.page.default
   - user.role.webmaster

--- a/config/sites/transportation.uiowa.edu/config_split.patch.config_ignore.settings.yml
+++ b/config/sites/transportation.uiowa.edu/config_split.patch.config_ignore.settings.yml
@@ -1,0 +1,4 @@
+adding:
+  ignored_config_entities:
+    - transportation_calculator.settings
+removing: {  }


### PR DESCRIPTION
Webmasters can use the config page at /admin/config/sitenow/cost-calculator-settings to edit the cost calculator settings, but these settings are currently removed during deployment.

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

```
ddev blt ds --site=transportation.uiowa.edu && ddev drush @transportation.local uli /admin/config/sitenow/cost-calculator-settings
```
No sync issues
Edit the settings and change something like the Parking Cost.
Visit the calculator at https://transportation.uiowa.ddev.site/cost-calculator and see the changes are reflected

```
ddev drush @transportation.local cst
```
See that there are no changes to config listed