### PR TITLE
Vertical video heading

### DIFF
--- a/docroot/themes/custom/uids_base/templates/block/block--inline-block--uiowa-vertical-video.html.twig
+++ b/docroot/themes/custom/uids_base/templates/block/block--inline-block--uiowa-vertical-video.html.twig
@@ -58,9 +58,9 @@
     </div>
     {% if video_title is not empty %}
       <div class="highlight__wrapper">
-        <h3 class="highlight__title">
+        <span class="highlight__title">
           <span class="headline__heading">{{ video_title }}</span>
-        </h3>
+        </span>
       </div>
     {% endif %}
   </div>


### PR DESCRIPTION
Resolves #8515 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
```
ddev blt ds --site=uiowa.edu
```
Compare the vertical videos on https://home.uiowa.ddev.site/ to https://uiowa.edu/
Use the Siteimprove browser extension, and see that you get "Content missing after heading" flagged for at least one of the vertical videos on the live site, but not the local

View the Accessibility DOM, user Voiceover, or other preferred tools to check for any differences in navigation of the page