### PR TITLE
Remove access to block content overview

### DIFF
--- a/config/default/user.role.editor.yml
+++ b/config/default/user.role.editor.yml
@@ -20,6 +20,8 @@ dependencies:
     - block_content.type.uiowa_text_area
     - block_content.type.uiowa_timeline
     - core.entity_view_display.node.page.default
+    - entity_browser.browser.featured_content_browser
+    - entity_browser.browser.media_wysiwyg_browser
     - filter.format.basic
     - filter.format.filtered_html
     - filter.format.minimal
@@ -73,7 +75,6 @@ weight: -6
 is_admin: false
 permissions:
   - 'access administration pages'
-  - 'access block library'
   - 'access content'
   - 'access content overview'
   - 'access contextual links'

--- a/config/default/user.role.publisher.yml
+++ b/config/default/user.role.publisher.yml
@@ -5,6 +5,8 @@ dependencies:
   config:
     - core.entity_view_display.fragment.region_item.default
     - core.entity_view_display.fragment.region_item_after_content.default
+    - entity_browser.browser.featured_content_browser
+    - entity_browser.browser.media_wysiwyg_browser
     - filter.format.basic
     - filter.format.filtered_html
     - filter.format.minimal

--- a/config/default/user.role.webmaster.yml
+++ b/config/default/user.role.webmaster.yml
@@ -25,6 +25,8 @@ dependencies:
     - core.entity_view_display.fragment.region_item.default
     - core.entity_view_display.fragment.region_item_after_content.default
     - core.entity_view_display.node.page.default
+    - entity_browser.browser.featured_content_browser
+    - entity_browser.browser.media_wysiwyg_browser
     - filter.format.basic
     - filter.format.filtered_html
     - filter.format.minimal
@@ -99,7 +101,6 @@ is_admin: false
 permissions:
   - 'access administration pages'
   - 'access any webform configuration'
-  - 'access block library'
   - 'access content'
   - 'access content overview'
   - 'access contextual links'


### PR DESCRIPTION
This change removes access to the block content overview page. It appears that when the block content overview was split out from the block types in Structure, we didn't catch that it was accessible to users.

# How to test
```
ddev blt ds --site hr.uiowa.edu && ddev drush @hr.local uli admin/people
```
- Masquerade as @mkyoder or another webmaster.
- https://hr.uiowa.ddev.site/admin/content/block should not be allowed anymore.
- Check that you can still edit the footer contact block via the contextual link and/or the link on the basic site settings config page.
