### PR TITLE
Facilities named buildings honoree heading mismatch.

### DIFF
--- a/config/sites/facilities.uiowa.edu/views.view.named_building_details.yml
+++ b/config/sites/facilities.uiowa.edu/views.view.named_building_details.yml
@@ -107,7 +107,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<h4 class=\"headline headline--serif headline--underline headline--center\">\r\n<span class=\"headline__heading\">{{ field_building_honoree_name }} {{ field_building_honoree_last_name }}</span>\r\n</h4>"
+            text: "<h2 class=\"headline headline--serif headline--underline headline--center\">\r\n<span class=\"headline__heading\">{{ field_building_honoree_name }} {{ field_building_honoree_last_name }}</span>\r\n</h2>"
             make_link: false
             path: ''
             absolute: false

--- a/config/sites/facilities.uiowa.edu/views.view.named_building_details.yml
+++ b/config/sites/facilities.uiowa.edu/views.view.named_building_details.yml
@@ -107,7 +107,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<h2 class=\"headline headline--serif headline--underline headline--center\">\r\n<span class=\"headline__heading\">{{ field_building_honoree_name }} {{ field_building_honoree_last_name }}</span>\r\n</h2>"
+            text: "<h2 class=\"h4 headline headline--serif headline--underline headline--center\">\r\n<span class=\"headline__heading\">{{ field_building_honoree_name }} {{ field_building_honoree_last_name }}</span>\r\n</h2>"
             make_link: false
             path: ''
             absolute: false


### PR DESCRIPTION
Tracks #9313

# How to test

1. sync facilities
2. go to this page https://facilities.uiowa.ddev.site/named-building/lindquist-center
3. run the siteimprove plugin
4. observe no error as listed in #9313
5. Inspect the headline of the honoree name and ensure that it doesn't have a nested h4 anymore and compare that to the live site which does.
