### PR TITLE
[hotfix] block library access - add these permissions back

### DIFF
--- a/config/default/user.role.editor.yml
+++ b/config/default/user.role.editor.yml
@@ -75,6 +75,7 @@ weight: -6
 is_admin: false
 permissions:
   - 'access administration pages'
+  - 'access block library'
   - 'access content'
   - 'access content overview'
   - 'access contextual links'

--- a/config/default/user.role.publisher.yml
+++ b/config/default/user.role.publisher.yml
@@ -29,6 +29,7 @@ dependencies:
   module:
     - administerusersbyrole
     - antibot
+    - block_content
     - content_moderation
     - contextual
     - entity_browser
@@ -59,6 +60,7 @@ weight: -5
 is_admin: null
 permissions:
   - 'access administration pages'
+  - 'access block library'
   - 'access content'
   - 'access content overview'
   - 'access contextual links'

--- a/config/default/user.role.webmaster.yml
+++ b/config/default/user.role.webmaster.yml
@@ -101,6 +101,7 @@ is_admin: false
 permissions:
   - 'access administration pages'
   - 'access any webform configuration'
+  - 'access block library'
   - 'access content'
   - 'access content overview'
   - 'access contextual links'


### PR DESCRIPTION
Rolling back https://github.com/uiowa/uiowa/pull/9364

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

On `main`

```
ddev blt di --site=default && ddev drush @default.local uli admin/people
```

- Create and masquerade as an editor
- Go to node/1/layout and try to add a media image to an image block. see the console error similar to the screenshot below.

Checkout `hotfix_restore_block_library_access` and run `ddev drush @default.local cim`
Refresh the page and try to add the same image as before.
