### PR TITLE
Block add - remove button and restrict route

### DIFF
--- a/docroot/modules/custom/uiowa_core/src/Routing/UiowaCoreRouteSubscriber.php
+++ b/docroot/modules/custom/uiowa_core/src/Routing/UiowaCoreRouteSubscriber.php
@@ -27,6 +27,8 @@ class UiowaCoreRouteSubscriber extends RouteSubscriberBase {
       // Global theme settings.
       'system.theme_settings',
       'ui_suite.index',
+      // Block add.
+      'block_content.add_page',
     ];
 
     // Restrict access to these routes for non-admins.

--- a/docroot/modules/custom/uiowa_core/src/Routing/UiowaCoreRouteSubscriber.php
+++ b/docroot/modules/custom/uiowa_core/src/Routing/UiowaCoreRouteSubscriber.php
@@ -29,6 +29,7 @@ class UiowaCoreRouteSubscriber extends RouteSubscriberBase {
       'ui_suite.index',
       // Block add.
       'block_content.add_page',
+      'block_content.add_form',
     ];
 
     // Restrict access to these routes for non-admins.

--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -1919,6 +1919,14 @@ function uiowa_core_config_schema_info_alter(&$schemas) {
 }
 
 /**
+ * Implements hook_menu_local_actions_alter().
+ */
+function uiowa_core_menu_local_actions_alter(array &$local_actions) {
+  // Remove "Add content block" from the block library for now.
+  unset($local_actions['block_content_add_action']);
+}
+
+/**
  * Fast object to array conversion function.
  *
  * Helper function to convert objects recursively to arrays.


### PR DESCRIPTION
With https://github.com/uiowa/uiowa/pull/9364 and https://github.com/uiowa/uiowa/pull/9376 we noticed that `admin/content/block` is more visible under the content overview area than where it was under structure. We currently don't have a situation where folks should be creating block_content outside of layout builder. The footer contact block is currently the exception but already exists and is installed with the website.

This PR removes the "Add content block" button from this overview page which is needed for the contact block and apparently needed for basic layout builder operations. It also limits access to the route the button leads to which allows the creation of block_content outside of LB.

To fully test, an editor should still have the ability to add media references to a block and save a block in layout builder.

This might be a path towards https://github.com/uiowa/uiowa/issues/2096 but right now it is only going to cause confusion and orphaned content.

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

On `main`

As an editor, you can see the blocks tab in the content overview and visit it. There you see the footer contact block. Great. Not so great for now is that you can see the option to create a new content block and access the route /block/add.

On `restrict_block_add`

`drush cr` the site you are masquerading as an editor with. Refresh the block content overview page. The button should be gone. As an editor you should also be getting an access denied on /block/add or something like /block/add/uiowa_button. Okay, but are you still able to work with layout builder? Go to a layout builder page and try to add a block that has a media image reference field. If you are successful, then I'd say this is a decent stop gap solution to wrangling this core update until we are ready for it.
