### PR TITLE
Smart trim for CLAS Policy book pages

### DIFF
--- a/config/sites/policy.clas.uiowa.edu/core.entity_view_display.node.book.teaser.yml
+++ b/config/sites/policy.clas.uiowa.edu/core.entity_view_display.node.book.teaser.yml
@@ -11,7 +11,7 @@ dependencies:
     - field.field.node.book.rabbit_hole__settings
     - node.type.book
   module:
-    - text
+    - smart_trim
     - user
 _core:
   default_config_hash: krIbNOdqw4vMF3Ty8qAW6AxgxmdBig5XuQRBW8-HYCU
@@ -21,10 +21,27 @@ bundle: book
 mode: teaser
 content:
   body:
-    type: text_summary_or_trimmed
+    type: smart_trim
     label: hidden
     settings:
-      trim_length: 600
+      trim_length: 20
+      trim_type: words
+      trim_suffix: ''
+      wrap_output: false
+      wrap_class: trimmed
+      more:
+        display_link: false
+        target_blank: false
+        link_trim_only: false
+        class: more-link
+        text: More
+        aria_label: 'Read more about [node:title]'
+        token_browser: ''
+      summary_handler: full
+      trim_options:
+        text: false
+        trim_zero: false
+        replace_tokens: false
     third_party_settings: {  }
     weight: 100
     region: content

--- a/config/sites/policy.clas.uiowa.edu/core.entity_view_display.node.book.teaser.yml
+++ b/config/sites/policy.clas.uiowa.edu/core.entity_view_display.node.book.teaser.yml
@@ -26,7 +26,7 @@ content:
     settings:
       trim_length: 20
       trim_type: words
-      trim_suffix: ''
+      trim_suffix: ...
       wrap_output: false
       wrap_class: trimmed
       more:


### PR DESCRIPTION
This is a fix for how book page teasers are being trimmed on the CLAS Policy website.

# How to test

```
ddev blt ds --site policy.clas.uiowa.edu
```
- Check https://claspolicy.uiowa.ddev.site/book-tags/salary and make sure there are no hidden links using the SI browser scan tool.
- Check other taxonomy term pages to ensure this generally looks okay.