### PR TITLE
Adding arrow key controls to slides.

### DIFF
--- a/docroot/modules/custom/sitenow_signage/js/slideshow.js
+++ b/docroot/modules/custom/sitenow_signage/js/slideshow.js
@@ -39,10 +39,9 @@
           drag: false,
           speed: 1500,
           slideFocus: false,
-          arrows: false,
+          arrows: true,
           pagination: false,
           rewind: true,
-          keyboard: 'focused'
         });
 
         // Set up initial video states before mounting.
@@ -67,30 +66,6 @@
         });
 
         splide.mount();
-
-        // The controller has functions to go forward and back in the carousel.
-        const controller = splide.Components.Controller;
-
-        ['keydown'].forEach(function(event) {
-          window.addEventListener(event, function(event) {
-            const key = event.key;
-
-            const callback = {
-              "ArrowLeft"  : this.leftHandler,
-              "ArrowRight" : this.rightHandler,
-            }[key]
-            callback?.(event);
-
-            this.leftHandler = function(event) {
-              const prev = controller.getPrev();
-              controller.go(prev);
-            }
-            this.rightHandler = function(event) {
-              const next = controller.getNext();
-              controller.go(next);
-            }
-          });
-        });
       });
 
       /**

--- a/docroot/modules/custom/sitenow_signage/js/slideshow.js
+++ b/docroot/modules/custom/sitenow_signage/js/slideshow.js
@@ -39,9 +39,10 @@
           drag: false,
           speed: 1500,
           slideFocus: false,
-          arrows: true,
           pagination: false,
           rewind: true,
+          arrows: false,
+          keyboard: 'global'
         });
 
         // Set up initial video states before mounting.
@@ -66,13 +67,6 @@
         });
 
         splide.mount();
-
-        // Destroy the arrows if user is not logged in.
-        const isUserLogged = document.querySelector('body.user-logged-in');
-        console.log(isUserLogged);
-        if(!isUserLogged) {
-          splide.Components.Arrows.destroy();
-        }
       });
 
       /**

--- a/docroot/modules/custom/sitenow_signage/js/slideshow.js
+++ b/docroot/modules/custom/sitenow_signage/js/slideshow.js
@@ -8,6 +8,10 @@
     attach: function (context, settings) {
       context.querySelectorAll('.signage__slideshow').forEach(function (element) {
 
+
+
+
+
         // Override prefers-reduced-motion for Splide.
         const originalMatchMedia = window.matchMedia;
         window.matchMedia = function (query) {
@@ -38,6 +42,7 @@
           arrows: false,
           pagination: false,
           rewind: true,
+          keyboard: 'focused'
         });
 
         // Set up initial video states before mounting.
@@ -62,6 +67,30 @@
         });
 
         splide.mount();
+
+        // The controller has functions to go forward and back in the carousel.
+        const controller = splide.Components.Controller;
+
+        ['keydown'].forEach(function(event) {
+          window.addEventListener(event, function(event) {
+            const key = event.key;
+
+            const callback = {
+              "ArrowLeft"  : this.leftHandler,
+              "ArrowRight" : this.rightHandler,
+            }[key]
+            callback?.(event);
+
+            this.leftHandler = function(event) {
+              const prev = controller.getPrev();
+              controller.go(prev);
+            }
+            this.rightHandler = function(event) {
+              const next = controller.getNext();
+              controller.go(next);
+            }
+          });
+        });
       });
 
       /**

--- a/docroot/modules/custom/sitenow_signage/js/slideshow.js
+++ b/docroot/modules/custom/sitenow_signage/js/slideshow.js
@@ -66,6 +66,13 @@
         });
 
         splide.mount();
+
+        // Destroy the arrows if user is not logged in.
+        const isUserLogged = document.querySelector('body.user-logged-in');
+        console.log(isUserLogged);
+        if(!isUserLogged) {
+          splide.Components.Arrows.destroy();
+        }
       });
 
       /**

--- a/docroot/modules/custom/sitenow_signage/js/slideshow.js
+++ b/docroot/modules/custom/sitenow_signage/js/slideshow.js
@@ -43,7 +43,7 @@
           rewind: true,
           arrows: false,
           keyboard: 'global',
-          role: 'marquee'
+          role: 'group'
         });
 
         // Set up initial video states before mounting.

--- a/docroot/modules/custom/sitenow_signage/js/slideshow.js
+++ b/docroot/modules/custom/sitenow_signage/js/slideshow.js
@@ -42,7 +42,8 @@
           pagination: false,
           rewind: true,
           arrows: false,
-          keyboard: 'global'
+          keyboard: 'global',
+          role: 'marquee'
         });
 
         // Set up initial video states before mounting.

--- a/docroot/modules/custom/sitenow_signage/js/slideshow.js
+++ b/docroot/modules/custom/sitenow_signage/js/slideshow.js
@@ -8,10 +8,6 @@
     attach: function (context, settings) {
       context.querySelectorAll('.signage__slideshow').forEach(function (element) {
 
-
-
-
-
         // Override prefers-reduced-motion for Splide.
         const originalMatchMedia = window.matchMedia;
         window.matchMedia = function (query) {

--- a/docroot/modules/custom/sitenow_signage/sass/signage.scss
+++ b/docroot/modules/custom/sitenow_signage/sass/signage.scss
@@ -17,6 +17,20 @@ $pitch-gray: color.scale(variables.$blk, $lightness: 13%);
     text-transform: uppercase;
     padding: 1.4rem 2rem .85rem;
   }
+
+  .splide__arrow {
+    transition: opacity 0.1s ease-in-out;
+    opacity: 0;
+    background-color: white;
+    transform-origin: center;
+    border: 1px solid transparent;
+  }
+
+  &:hover {
+    .splide__arrow {
+      opacity: 1;
+    }
+  }
 }
 
 // Empty sign block iowa logo.

--- a/docroot/modules/custom/sitenow_signage/sass/signage.scss
+++ b/docroot/modules/custom/sitenow_signage/sass/signage.scss
@@ -17,20 +17,6 @@ $pitch-gray: color.scale(variables.$blk, $lightness: 13%);
     text-transform: uppercase;
     padding: 1.4rem 2rem .85rem;
   }
-
-  .splide__arrow {
-    transition: opacity 0.1s ease-in-out;
-    opacity: 0;
-    background-color: white;
-    transform-origin: center;
-    border: 1px solid transparent;
-  }
-
-  &:hover {
-    .splide__arrow {
-      opacity: 1;
-    }
-  }
 }
 
 // Empty sign block iowa logo.


### PR DESCRIPTION
tracks #9327

## To test
1. Sync down signage!
2. Make or go to a sign.
3. Ensure focus is on the slideshow by clicking it
4. use keyboard right arrow and left arrow to see if you can navigate between slides.
5. Run an accessibility scan of the page to ensure nothing is bonkers broken.
6. Review the [marquee role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/marquee_role) and offer opinion on whether you think this is correct or not.
    7. Siteimprove was flagging this for not having the correct role beforehand, so that is why I tried to change it to the correct role.[ I did research on live region roles to try and fix this.](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#4._live_region_roles)