### PR TITLE
[Fire log] A11y fix

### DIFF
--- a/docroot/themes/custom/uids_base/package.json
+++ b/docroot/themes/custom/uids_base/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "ISC",
   "dependencies": {
-    "@uiowa/uids4": "https://github.com/uiowa/uids.git#718c2ec",
+    "@uiowa/uids4": "https://github.com/uiowa/uids.git#4208942",
     "@uiowa/brand-icons": "https://github.com/uiowa/brand-icons.git#95911bc",
     "autoprefixer": "^9.8.8",
     "cssnano": "^7.0.7",

--- a/docroot/themes/custom/uids_base/package.json
+++ b/docroot/themes/custom/uids_base/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "ISC",
   "dependencies": {
-    "@uiowa/uids4": "https://github.com/uiowa/uids.git#v4.0.0-alpha12",
+    "@uiowa/uids4": "https://github.com/uiowa/uids.git#718c2ec",
     "@uiowa/brand-icons": "https://github.com/uiowa/brand-icons.git#95911bc",
     "autoprefixer": "^9.8.8",
     "cssnano": "^7.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1221,9 +1221,9 @@
     vue-router "^4.0.3"
     vue-toggle-component "^1.0.16"
 
-"@uiowa/uids4@https://github.com/uiowa/uids.git#v4.0.0-alpha11":
+"@uiowa/uids4@https://github.com/uiowa/uids.git#718c2ec":
   version "4.0.0-alpha10"
-  resolved "https://github.com/uiowa/uids.git#9857bb4cff0682393573f8a8a7425d7803b6435b"
+  resolved "https://github.com/uiowa/uids.git#718c2ec1676c5b97829e0382ebeebe3d628cb6d5"
   dependencies:
     vue "^3.4.15"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1221,9 +1221,9 @@
     vue-router "^4.0.3"
     vue-toggle-component "^1.0.16"
 
-"@uiowa/uids4@https://github.com/uiowa/uids.git#718c2ec":
+"@uiowa/uids4@https://github.com/uiowa/uids.git#4208942":
   version "4.0.0-alpha10"
-  resolved "https://github.com/uiowa/uids.git#718c2ec1676c5b97829e0382ebeebe3d628cb6d5"
+  resolved "https://github.com/uiowa/uids.git#42089428a53ee61fd07f937784fa3a1e3e0ce023"
   dependencies:
     vue "^3.4.15"
 


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/9366. 

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
 ddev blt frontend && ddev blt ds --site=safety.uiowa.edu && ddev drush @safety.local uli /fire-log
```
- Review https://github.com/uiowa/uids/pull/1018. 
- Run Siteimprove scan on the fire log and https://safety.uiowa.ddev.site/crime-log and confirm that scrollable element is not keyboard accessible message is gone. 
- A11y fix taken from `max-height` example from https://codepen.io/aardrian/pen/VwYyVJY from https://adrianroselli.com/2020/01/fixed-table-headers.html. 
