### PR TITLE
Hours aria-live field input error.

### DIFF
--- a/docroot/modules/custom/uiowa_hours/src/Form/HoursFilterForm.php
+++ b/docroot/modules/custom/uiowa_hours/src/Form/HoursFilterForm.php
@@ -100,7 +100,7 @@ class HoursFilterForm extends FormBase {
       '#attributes' => [
         'role' => 'region',
         'aria-label' => 'Hours',
-        'aria-live' => 'assertive',
+        'aria-live' => 'polite',
         'id' => $result_id,
         'class' => [
           'uiowa-hours-container',


### PR DESCRIPTION

After doing [some research on aria-live values](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-live#values) and discussing it with the team, I have changed the `aria-live` attribute's value to `polite`, as we do not need it to be an imperative interruption to the flow of a screen reader.

## To test

1. `ddev blt ds --site=recserv.uiowa.edu && ddev drush @recserv.local uli /hours`
2. Run the siteimprove checker
3. Observe no more yelling!