### PR TITLE
Admissions - remove hcaptcha

### DIFF
--- a/config/sites/admissions.uiowa.edu/config_split.config_split.site.yml
+++ b/config/sites/admissions.uiowa.edu/config_split.config_split.site.yml
@@ -12,7 +12,6 @@ storage: folder
 folder: ../config/sites/admissions.uiowa.edu
 module:
   entity_print_views: 0
-  hcaptcha: 0
   leaflet: 0
   taxonomy_path_breadcrumb: 0
   weight: 0
@@ -85,7 +84,6 @@ complete_list:
   - views.view.2_plus_2_majors
   - views.view.community_colleges_taxonomy_term
 partial_list:
-  - captcha.settings
   - core.entity_form_display.node.event.default
   - core.entity_view_display.block_content.uiowa_events.default
   - core.entity_view_display.node.event.default

--- a/config/sites/admissions.uiowa.edu/config_split.patch.captcha.settings.yml
+++ b/config/sites/admissions.uiowa.edu/config_split.patch.captcha.settings.yml
@@ -1,4 +1,0 @@
-adding:
-  default_challenge: hcaptcha/hCaptcha
-removing:
-  default_challenge: captcha/Math

--- a/config/sites/admissions.uiowa.edu/hcaptcha.settings.yml
+++ b/config/sites/admissions.uiowa.edu/hcaptcha.settings.yml
@@ -1,5 +1,0 @@
-hcaptcha_src: 'https://hcaptcha.com/1/api.js'
-widget:
-  theme: ''
-  size: ''
-  tabindex: null


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/9436
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt ds --site=admissions.uiowa.edu
```

- Go to admin/modules and see that the hcaptcha module is not installed.
- Inspect the config/sites/admissions.uiowa.edu directory for `hcaptcha`
- See that the contact form and gap form are both using turnstile instead.
  - https://admissions.uiowa.ddev.site/form/gap-year-policy
  - https://admissions.uiowa.ddev.site/form/contact-us 
- Bonus: inspect the database and see that there are no webform.webform config rows with hcaptcha in the serialized data.
