### PR TITLE
media_entity_instagram removal - reorder when the entities are deleted

### DIFF
--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -4521,6 +4521,19 @@ function sitenow_update_10031() {
     ->execute()
     ->fetchAll();
 
+  // Clean up media entities now that they are no longer referenced.
+  $storage = $entity_type_manager->getStorage('media');
+  $mids = $storage->getQuery()
+    ->condition('bundle', 'instagram')
+    ->accessCheck(FALSE)
+    ->execute();
+
+  if (!empty($mids)) {
+    $entities = $storage->loadMultiple($mids);
+    $storage->delete($entities);
+    \Drupal::logger('sitenow')->notice('Deleted @count Instagram media entities.', ['@count' => count($mids)]);
+  }
+
   // Early exit if no placement.
   if (empty($usages)) {
     return;
@@ -4608,18 +4621,5 @@ function sitenow_update_10031() {
         }
       }
     }
-  }
-
-  // Clean up media entities now that they are no longer referenced.
-  $storage = $entity_type_manager->getStorage('media');
-  $mids = $storage->getQuery()
-    ->condition('bundle', 'instagram')
-    ->accessCheck(FALSE)
-    ->execute();
-
-  if (!empty($mids)) {
-    $entities = $storage->loadMultiple($mids);
-    $storage->delete($entities);
-    \Drupal::logger('sitenow')->notice('Deleted @count Instagram media entities.', ['@count' => count($mids)]);
   }
 }


### PR DESCRIPTION
Delete the instagram entities (if any) after the usage lookup but before the early exit if there is no usage.

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

Run on these sites. Some have entities but no usage. Some have entities and usage. One is a v2 site with entities.

```
ddev blt ds --site=admissions.uiowa.edu && ddev blt ds --site=advisingcenter.uiowa.edu && ddev blt ds --site=sandbox.uiowa.edu && ddev blt ds --site=hawkeyemarchingband.uiowa.edu
```

Should be no import errors. Run `ddev blt ds --site=admissions.uiowa.edu` on `main` and you should get an error.
