### PR TITLE
Disable security check for time being

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -30,6 +30,9 @@ drush:
   aliases:
     ci: self
   default_alias: self
+disable-targets:
+  tests:
+    security-drupal: true
 tests:
   phpunit:
     - config: '${repo.root}'

--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -30,9 +30,6 @@ drush:
   aliases:
     ci: self
   default_alias: self
-disable-targets:
-  tests:
-    security-drupal: true
 tests:
   phpunit:
     - config: '${repo.root}'

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,10 @@
     },
     "config": {
         "audit": {
-            "abandoned": "ignore"
+            "abandoned": "ignore",
+            "ignore": {
+                "CVE-2025-67746": "Temporarily ignore."
+            }
         },
         "sort-packages": true,
         "platform": {


### PR DESCRIPTION
Builds are failing and the process of updating composer for our project is less than straightforward. This disables the security check to allow for a release.

# How to test

- Code review + build passes
