### PR TITLE
A11y tweaks for superfish and offcanvas menus

### DIFF
--- a/docroot/themes/custom/uids_base/templates/navigation/superfish-menu-items.html.twig
+++ b/docroot/themes/custom/uids_base/templates/navigation/superfish-menu-items.html.twig
@@ -1,0 +1,78 @@
+{#
+/**
+ * @file
+ * Default theme implementation of Superfish menu items.
+ *
+ * Available variables:
+ * - html_id: Unique menu item identifier.
+ * - item_class: Menu item classes.
+ * - link: Link element.
+ * - link_menuparent: Link element, when a menu parent.
+ * - children: Menu item children.
+ * - multicolumn_wrapper: Whether the menu item contains a column.
+ * - multicolumn_column: Whether the menu item contains a column.
+ * - multicolumn_content: Whether the menu item contains a column.
+ *
+ * @see template_preprocess_superfish_menu_items()
+ *
+ * @ingroup themeable
+ */
+#}
+{% set classes = [] %}
+{% for item in menu_items %}
+
+<li{{ item.attributes }}>
+
+  {% if item.multicolumn_column %}
+  <div class="sf-multicolumn-column">
+    {% endif %}
+
+    {# Parent items get a toggleable element #}
+    {% if item.children is not empty %}
+      {{ item.link_menuparent|merge({
+        '#attributes': {
+          'role': 'button',
+          'aria-haspopup': 'true',
+          'aria-expanded': 'false'
+        }
+      }) }}
+    {% else %}
+      {{ item.link }}
+    {% endif %}
+
+    {# Multicolumn wrapper #}
+    {% if item.multicolumn_wrapper %}
+    <ul class="sf-multicolumn">
+      <li class="sf-multicolumn-wrapper {{ item.item_class }}">
+        {% endif %}
+
+        {# Children #}
+        {% if item.children is not empty %}
+        {% if item.multicolumn_content %}
+        <ol>
+          {% else %}
+          <ul>
+            {% endif %}
+
+            {{ item.children }}
+
+            {% if item.multicolumn_content %}
+        </ol>
+        {% else %}
+    </ul>
+    {% endif %}
+    {% endif %}
+
+    {% if item.multicolumn_wrapper %}
+  </li>
+  </ul>
+  {% endif %}
+
+  {% if item.multicolumn_column %}
+    </div>
+  {% endif %}
+
+  </li>
+
+{% endfor %}
+

--- a/docroot/themes/custom/uids_base/templates/navigation/superfish.html.twig
+++ b/docroot/themes/custom/uids_base/templates/navigation/superfish.html.twig
@@ -18,7 +18,7 @@
 
 <nav aria-label="Main">
   <h2 class="visually-hidden">Site Main Navigation</h2>
-  <ul id="{{ id }}" class="{{ menu_classes }}" role="menu">
+  <ul id="{{ id }}" class="{{ menu_classes }}">
     {{ menu_items }}
   </ul>
 </nav>

--- a/docroot/themes/custom/uids_base/templates/navigation/toggle-nav--drawer.html.twig
+++ b/docroot/themes/custom/uids_base/templates/navigation/toggle-nav--drawer.html.twig
@@ -1,4 +1,4 @@
-<div class="o-canvas__drawer o-canvas__menu" aria-labelledby="o-canvas__menulabel">
+<div class="o-canvas__drawer o-canvas__menu">
     <div class="drawer-content">
         <h2 id="o-canvas__menulabel" class="element-invisible">Menu Drawer Options</h2>
         {% block drawer %}


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/9475
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

Forking the superfish templates to undo a change to the the module https://github.com/uiowa/uiowa/issues/4973#issuecomment-3513999394

https://github.com/uiowa/uiowa/issues/9475#issuecomment-3739314701


# How to test

First, confirm with the SiteImprove extension that shl.uiowa.edu has ~7 container element is empty (role=menu) instances.

```
ddev blt ds --site=shl.uiowa.edu
```

Without authenticating to reduce noise, go to https://shl.uiowa.ddev.site/ and run the Siteimprove widget. There should be no container element is empty issues.

Obermann has content issues as noise but can be checked as well.

Now login and change the menu to horizontal and toggle.

```
ddev drush @shl.local uli
```

For the toggle menu, open it up. Scan. Expand a menu. Scan. There should be no additional issues for each scan.

No ariahaspopup issue because I added role=button to the markup for the div.

**Bonus points**: Interact with the menus using VoiceOver and note that it is still keyboard operable and that links and number items is still indicated.


