### PR TITLE
Search label - Color contrast

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/search-toggle.scss
+++ b/docroot/themes/custom/uids_base/scss/components/search-toggle.scss
@@ -98,12 +98,10 @@ $search-img-path: '../../images/search-01.svg';
   }
 
   span {
-    //@include utilities.element-invisible;
-    display: none;
+    @include utilities.element-invisible;
 
     @include utilities.breakpoint(md) {
-      //@include utilities.element-invisible-off;
-      display: inline;
+      @include utilities.element-invisible-off;
       overflow: unset;
       position: unset !important;
       display: inline-block;


### PR DESCRIPTION
Relates to https://github.com/uiowa/uiowa/issues/9460

Going to leave the issue open after merge and deployment to check in on the fix in PROD.

# How to test

On `main`

```
ddev blt frontend && ddev blt ds --site=provost.uiowa.edu
```

Shrink viewport to mobile and scan using the SiteImprove widget. If you can't recreate the issue locally, just note there is no difference in how the search label's visibility changes compared to main when you checkout `search_toggle_color_contrast`.

On `search_toggle_color_contrast`

```
ddev blt frontend && ddev drush @provost.local cr
```

Shrink viewport to mobile and scan using the SiteImprove widget. If you had reproduced the issue locally, this _should_ fix it.