### PR TITLE
[Charts] Added ability to add pie chart

### DIFF
--- a/docroot/modules/custom/sitenow_charts/sitenow_charts.module
+++ b/docroot/modules/custom/sitenow_charts/sitenow_charts.module
@@ -54,6 +54,22 @@ function sitenow_charts_chart_definition_alter(array &$definition, array $elemen
     }
     $definition['yAxis'][0]['labels']['format'] = $format;
   }
+
+  // Handle pie charts separately because they use yaxis element but not yAxis definition.
+  if ($chart_type === 'pie' && isset($element['yaxis'])) {
+    $prefix = $element['yaxis']['#prefix'] ?? '';
+    $suffix = $element['yaxis']['#suffix'] ?? '';
+    $decimal_count = $element['yaxis']['#decimal_count'] ?? 0;
+
+    if ($prefix || $suffix || $decimal_count) {
+      // Build the format string based on decimal count.
+      $format_spec = $decimal_count > 0 ? "{point.y:,.{$decimal_count}f}" : '{point.y:,.0f}';
+      $value_format = $prefix . $format_spec . $suffix;
+
+      // Apply to tooltips.
+      $definition['tooltip']['pointFormat'] = '<b>' . $value_format . ' ({point.percentage:.1f}%)</b><br/>';
+    }
+  }
 }
 
 /**
@@ -89,7 +105,7 @@ function sitenow_charts_chart_alter(array &$element, $chart_id) {
  */
 function sitenow_charts_charts_plugin_supported_chart_types_alter(array &$types, string $chart_plugin_id) {
   // Limit to specific chart types.
-  $allowed_types = ['line', 'column', 'bar', 'dumbbell'];
+  $allowed_types = ['line', 'column', 'bar', 'pie', 'dumbbell'];
   $types = array_intersect($types, $allowed_types);
 }
 
@@ -136,6 +152,14 @@ function sitenow_charts_field_widget_complete_form_alter(&$field_widget_complete
             $element[$delta]['config']['library_type_options']['low_color']['#element_validate'][] = function (&$element, FormStateInterface $form_state) {
               $form_state->setValueForElement($element, '#000000');
             };
+          }
+          // Hide min_color field.
+          if (isset($element[$delta]['config']['library_type_options']['min_color'])) {
+            $element[$delta]['config']['library_type_options']['min_color']['#access'] = FALSE;
+          }
+          // Hide max_color field.
+          if (isset($element[$delta]['config']['library_type_options']['max_color'])) {
+            $element[$delta]['config']['library_type_options']['max_color']['#access'] = FALSE;
           }
           // Hide color inputs in the data collector table.
           if (isset($element[$delta]['config']['series']['data_collector_table'])) {


### PR DESCRIPTION
Pillar project team has requested to use the pie chart. 


<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test
**uiowa.edu (Has existing chart page)**
```
 ddev composer install && ddev blt ds --site=uiowa.edu && ddev drush @home.local uli /node/431/layout
```
1. Add a chart block, select "pie" option 
2. Upload a file below
3. Confirm that minimum and maximum colors (in screenshot below) are not allowed to be selected.
4. Adjust "Categories are identified by" to "first row" to get it to accurately display as a pie chart
5. Confirm you can add prefix and suffix and they will display in the tooltip
6. Confirm comma is added to dollar values
7. Check existing chart like https://uiowa.edu/explore/biomedical-engineering-degree/what-are-the-different-types-of-biomedical-engineering and see that prefix/suffix in tooltip still works
<img width="444" height="389" alt="Screenshot 2026-01-29 at 4 35 09 PM" src="https://github.com/user-attachments/assets/e0cb5f85-f010-46c0-9567-98e92293bde0" />


## CSV
Test using this file below:

- [pie.csv](https://github.com/user-attachments/files/24949625/pie.csv)


