### PR TITLE
[CKEditor] Interactive element size adjustments

### DIFF
--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -2087,7 +2087,7 @@ function uiowa_core_scheduler_help_text(array &$form): void {
       $additional_help_text = t('Note: this content will be @stateed at the top of the hour after the time you select. (e.g., 2:43 p.m. will go live at 3:00 p.m.).', [
         '@state' => $state,
       ]);
-      $form["{$state}_on"]['widget'][0]['value']['#description'] .= '<p>' . $additional_help_text . '</p>';
+      $form["{$state}_on"]['widget'][0]['value']['#description'] .= '<div>' . $additional_help_text . '</div>';
       // If moderation is enabled, hide the publish/unpublish state fields.
       $form["{$state}_state"]['#attributes']['class'] = (!empty($form["{$state}_state"]['#attributes']['class']) ? array_merge($form["{$state}_state"]['#attributes']['class'], $hide_classes) : $hide_classes);
     }

--- a/docroot/themes/custom/uids_base/scss/sitenow_wysiwyg.scss
+++ b/docroot/themes/custom/uids_base/scss/sitenow_wysiwyg.scss
@@ -218,6 +218,11 @@
   flex-wrap: wrap!important;
 }
 
+// @todo remove when https://github.com/ckeditor/ckeditor5/issues/18215 is resolved.
+.ck.ck-splitbutton>.ck-splitbutton__arrow {
+  min-width: 24px!important;
+}
+
 .ck.ck-link-form.ck-link-form_layout-vertical button.ck-media-library {
   color: #00558c;
   span {

--- a/docroot/themes/custom/uids_base/scss/sitenow_wysiwyg.scss
+++ b/docroot/themes/custom/uids_base/scss/sitenow_wysiwyg.scss
@@ -225,6 +225,8 @@
 
 // Add extra padding to the "About text formats" link text for formatted text fields.
 // Minimum size for interactive elements is 44px by 44px.
+// This is an override of the Claro admin theme, and can be removed if
+// it gets adjusted upstream.
 .filter-help>a {
   padding: 1rem 0;
 }

--- a/docroot/themes/custom/uids_base/scss/sitenow_wysiwyg.scss
+++ b/docroot/themes/custom/uids_base/scss/sitenow_wysiwyg.scss
@@ -223,6 +223,12 @@
   min-width: 24px!important;
 }
 
+// Add extra padding to the "About text formats" link text for formatted text fields.
+// Minimum size for interactive elements is 44px by 44px.
+.filter-help>a {
+  padding: 1rem 0;
+}
+
 .ck.ck-link-form.ck-link-form_layout-vertical button.ck-media-library {
   color: #00558c;
   span {


### PR DESCRIPTION
Resolves #9504 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->
```
ddev blt frontend
```
Sync a site of your choice.
Edit a node, block, or anything else with a formatted text field.
Compare against a prod version, and see if you notice the differences (there are visual differences, but hopefully they are not jarring)
Run the Siteimprove browser extension
See that the "About text formats" link is not flagged as "Interactive element does not meet enhanced size (AAA)".
When a Filtered HTML (or above) format is selected, see that there are not a slew of "Interactive element does not meet minimum size nor spacing (AA)" targeting the dropdown arrow (for instance, next to the bulleted list toolbar buttons)
See that the "Note: This content will be published..." text is not flagged for "Line height is below minimum value (AAA)" on content with scheduling options (eg Article)