### PR TITLE
Backend primary/secondary tabs - check for routes and unset if none

### DIFF
--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -657,6 +657,23 @@ function uiowa_core_preprocess_field(&$variables) {
  */
 function uiowa_core_preprocess_page(&$variables) {
   $current_route = \Drupal::routeMatch();
+
+  // Unset local tasks on admin routes with no tasks to prevent empty
+  // wrappers that fail accessibility scans (Siteimprove).
+  // See https://www.drupal.org/project/drupal/issues/953034.
+  $admin_context = \Drupal::service('router.admin_context');
+  if ($admin_context->isAdminRoute()) {
+    $route_name = $current_route->getRouteName();
+    // Check local tasks for current route.
+    $local_task_manager = \Drupal::service('plugin.manager.menu.local_task');
+    $tasks = $local_task_manager->getLocalTasksForRoute($route_name);
+    // Unset since there are no tasks to render. Brilliant.
+    if (empty($tasks)) {
+      unset($variables['page']['header']['claro_primary_local_tasks']);
+      unset($variables['page']['pre_content']['claro_secondary_local_tasks']);
+    }
+  }
+
   $node = $current_route->getParameter('node');
 
   $view_id = Drupal::request()->attributes->get('view_id');


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/9563

Adds _temporary_ logic to look up tabs for the route on whether the primary and secondary buckets are needed for render.

# How to test

On `main`:

```
ddev blt di --site=default && ddev drush @default.local uli admin/config/sitenow/uiowa-articles
```

With the siteimprove browser extension, there is like five container empty issues, one of which are the primary tabs. The others are related to CKEditor.

On `empty_tasks_a11y_fix`

```
ddev drush @default.local cr
```

Re-run the extension on the page and see that the primary tabs issue is resolved leaving the CKEditor items.

The code only removes the tab regions where there is no tabs to display:

Go to https://default.uiowa.ddev.site/admin/content and see that there are still primary and secondary tabs.
Go to https://default.uiowa.ddev.site/admin/config/sitenow/sitenow-dispatch and see there are still primary tabs there.
