### PR TITLE
[transportation.uiowa.edu] Update hook fix for accordions

### DIFF
--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -184,8 +184,9 @@ function _update_all_blocks_by_plugin_id($block_plugin_ids, callable $process): 
               'allowed_classes' => TRUE,
             ]);
           }
-          else {
-            $block = NULL;
+
+          if (!$block instanceof BlockContentInterface) {
+            continue;
           }
 
           call_user_func_array($process, [&$component, $block]);
@@ -4368,7 +4369,7 @@ function sitenow_update_10028() {
   if (!empty($to_uninstall)) {
     \Drupal::service('module_installer')->uninstall($to_uninstall, TRUE);
     $logger->notice('Disabled the following modules: @modules', [
-      '@modules' => implode(', ', $to_uninstall)
+      '@modules' => implode(', ', $to_uninstall),
     ]);
   }
 
@@ -4659,9 +4660,6 @@ function sitenow_update_10032() {
   // Load and update all collections blocks on the site
   // and set the default label color to gray.
   _update_all_blocks_by_plugin_id('inline_block:uiowa_collection', function (&$component, $block) {
-    if ($block === NULL) {
-      return;
-    }
     $block->set('field_accordion_label_color', 'gray');
     $block->save();
   });

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -4659,6 +4659,9 @@ function sitenow_update_10032() {
   // Load and update all collections blocks on the site
   // and set the default label color to gray.
   _update_all_blocks_by_plugin_id('inline_block:uiowa_collection', function (&$component, $block) {
+    if ($block === NULL) {
+      return;
+    }
     $block->set('field_accordion_label_color', 'gray');
     $block->save();
   });


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/9551. 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
 ddev blt ds --site=transportation.uiowa.edu   && ddev drush @transportation.local uli     /node/561/layout
```
1. Confirm update hook works and that update to the helper function is correct.
2. Confirm editing existing accordion shows color options compared to prod. 

The issue is that tempstore contains block references for nodes that were deleted. When loadRevision() tries to load these blocks without their parent node context, it returns NULL.

Running this will show you that there is a deleted node with collection revisions that will expire on 2/3/26.  So if a code deployment rolls out on the 4th, the update hook will likely run as expected. 

```
SELECT 
    kve.name as tempstore_key,
    SUBSTRING_INDEX(SUBSTRING_INDEX(kve.name, '.', 2), '.', -1) as deleted_node_id,
    FROM_UNIXTIME(kve.expire) as expires_on
FROM key_value_expire kve
WHERE kve.collection = 'tempstore.shared.layout_builder.section_storage.overrides'
  AND kve.value LIKE '%inline_block:uiowa_collection%'
  AND SUBSTRING_INDEX(SUBSTRING_INDEX(kve.name, '.', 2), '.', -1) NOT IN (
    SELECT nid FROM node_field_data
  );
```
