### PR TITLE
Banner video - adds track element to indicate no audio

### DIFF
--- a/docroot/themes/custom/uids_base/assets/video/decorative-video-captions.vtt
+++ b/docroot/themes/custom/uids_base/assets/video/decorative-video-captions.vtt
@@ -1,0 +1,4 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:01.000
+[background video, no audio]

--- a/docroot/themes/custom/uids_base/templates/field/file-video.html.twig
+++ b/docroot/themes/custom/uids_base/templates/field/file-video.html.twig
@@ -32,6 +32,6 @@
     <source {{ file.source_attributes }} />
   {% endfor %}
   {% if attributes.storage['data-decorative'] %}
-    <track kind="captions" src="{{ base_path ~ directory }}/assets/video/decorative-video-captions.vtt" srclang="en" label="No audio" default>
+    <track kind="captions" src="{{ base_path ~ directory }}/assets/video/decorative-video-captions.vtt" srclang="en" label="No audio">
   {% endif %}
 </video>

--- a/docroot/themes/custom/uids_base/templates/field/file-video.html.twig
+++ b/docroot/themes/custom/uids_base/templates/field/file-video.html.twig
@@ -31,4 +31,7 @@
   {% for file in files %}
     <source {{ file.source_attributes }} />
   {% endfor %}
+  {% if attributes.storage['data-decorative'] %}
+    <track kind="captions" src="{{ base_path ~ directory }}/assets/video/decorative-video-captions.vtt" srclang="en" label="No audio" default>
+  {% endif %}
 </video>

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -513,9 +513,8 @@ function uids_base_preprocess_media(array &$variables) {
         if ($parent instanceof EntityAdapter) {
           $parent_entity = $parent->getEntity();
           if ($parent_entity instanceof BlockContent) {
-            // Mark banner videos as decorative since they are background
-            // media with no informational content.
-            $variables['attributes']['aria-hidden'] = 'true';
+            // Flag for the template to add a decorative caption track.
+            $variables['content']['field_media_video_file'][0]['#attributes']['data-decorative'] = 'true';
             // Play video inline instead of going to native player.
             $variables['content']['field_media_video_file'][0]['#attributes']['playsinline'] = 'playsinline';
             // @todo 2020/12/08 Add check to see if video is paused in 'uiowa-video'


### PR DESCRIPTION
Related to #9168

# How to test

- Code review
```
ddev blt ds --site medicine.uiowa.edu && ddev drush @medicine.local uli / 
```
- Confirm the video has the `<track>` element.

Need to go to production to see whether it addresses the Siteimprove flag.