### PR TITLE
[charts] Pie chart CSS

### DIFF
--- a/docroot/modules/custom/sitenow_charts/css/sitenow_charts.css
+++ b/docroot/modules/custom/sitenow_charts/css/sitenow_charts.css
@@ -1,0 +1,3 @@
+.charts-highchart[data-chart*='"type":"pie"'] {
+  min-height: 600px;
+}

--- a/docroot/modules/custom/sitenow_charts/sitenow_charts.libraries.yml
+++ b/docroot/modules/custom/sitenow_charts/sitenow_charts.libraries.yml
@@ -1,0 +1,5 @@
+chart_overrides:
+  version: 1.x
+  css:
+    theme:
+      css/sitenow_charts.css: {}

--- a/docroot/modules/custom/sitenow_charts/sitenow_charts.module
+++ b/docroot/modules/custom/sitenow_charts/sitenow_charts.module
@@ -13,6 +13,26 @@ use Drupal\Core\Form\FormStateInterface;
 function sitenow_charts_chart_definition_alter(array &$definition, array $element, $chart_id) {
   $chart_type = $definition['chart']['type'] ?? 'unknown';
 
+  // Add responsive settings for pie charts to stack legend on mobile.
+  if ($chart_type === 'pie') {
+    $definition['responsive'] = [
+      'rules' => [
+        [
+          'condition' => [
+            'maxWidth' => 800,
+          ],
+          'chartOptions' => [
+            'legend' => [
+              'align' => 'center',
+              'verticalAlign' => 'bottom',
+              'layout' => 'vertical',
+            ],
+          ],
+        ],
+      ],
+    ];
+  }
+
   // Get the yAxis format if it exists.
   if (!empty($definition['yAxis'][0]['labels']['format'])) {
     $format = $definition['yAxis'][0]['labels']['format'];
@@ -55,7 +75,8 @@ function sitenow_charts_chart_definition_alter(array &$definition, array $elemen
     $definition['yAxis'][0]['labels']['format'] = $format;
   }
 
-  // Handle pie charts separately because they use yaxis element but not yAxis definition.
+  // Handle pie charts separately because they
+  // use yaxis element but not yAxis definition.
   if ($chart_type === 'pie' && isset($element['yaxis'])) {
     $prefix = $element['yaxis']['#prefix'] ?? '';
     $suffix = $element['yaxis']['#suffix'] ?? '';

--- a/docroot/modules/custom/sitenow_charts/sitenow_charts.module
+++ b/docroot/modules/custom/sitenow_charts/sitenow_charts.module
@@ -201,4 +201,9 @@ function sitenow_charts_preprocess_field(&$variables) {
       }
     }
   }
+
+  // Attach the chart overrides library to the field.
+  if ($variables['field_name'] === 'field_sitenow_chart') {
+    $variables['#attached']['library'][] = 'sitenow_charts/chart_overrides';
+  }
 }

--- a/docroot/modules/custom/sitenow_charts/sitenow_charts.module
+++ b/docroot/modules/custom/sitenow_charts/sitenow_charts.module
@@ -13,29 +13,27 @@ use Drupal\Core\Form\FormStateInterface;
 function sitenow_charts_chart_definition_alter(array &$definition, array $element, $chart_id) {
   $chart_type = $definition['chart']['type'] ?? 'unknown';
 
-  // Add responsive settings for pie charts to stack legend on mobile.
+  // Add responsive settings to stack legend on mobile.
   // Only apply if legend is aligned right or left.
-  if ($chart_type === 'pie') {
-    $legend_align = $definition['legend']['align'] ?? '';
+  $legend_align = $definition['legend']['align'] ?? '';
 
-    if (in_array($legend_align, ['right', 'left'])) {
-      $definition['responsive'] = [
-        'rules' => [
-          [
-            'condition' => [
-              'maxWidth' => 800,
-            ],
-            'chartOptions' => [
-              'legend' => [
-                'align' => 'center',
-                'verticalAlign' => 'bottom',
-                'layout' => 'vertical',
-              ],
+  if (in_array($legend_align, ['right', 'left'])) {
+    $definition['responsive'] = [
+      'rules' => [
+        [
+          'condition' => [
+            'maxWidth' => 500,
+          ],
+          'chartOptions' => [
+            'legend' => [
+              'align' => 'center',
+              'verticalAlign' => 'bottom',
+              'layout' => 'vertical',
             ],
           ],
         ],
-      ];
-    }
+      ],
+    ];
   }
 
   // Get the yAxis format if it exists.

--- a/docroot/modules/custom/sitenow_charts/sitenow_charts.module
+++ b/docroot/modules/custom/sitenow_charts/sitenow_charts.module
@@ -14,23 +14,28 @@ function sitenow_charts_chart_definition_alter(array &$definition, array $elemen
   $chart_type = $definition['chart']['type'] ?? 'unknown';
 
   // Add responsive settings for pie charts to stack legend on mobile.
+  // Only apply if legend is aligned right or left.
   if ($chart_type === 'pie') {
-    $definition['responsive'] = [
-      'rules' => [
-        [
-          'condition' => [
-            'maxWidth' => 800,
-          ],
-          'chartOptions' => [
-            'legend' => [
-              'align' => 'center',
-              'verticalAlign' => 'bottom',
-              'layout' => 'vertical',
+    $legend_align = $definition['legend']['align'] ?? '';
+
+    if (in_array($legend_align, ['right', 'left'])) {
+      $definition['responsive'] = [
+        'rules' => [
+          [
+            'condition' => [
+              'maxWidth' => 800,
+            ],
+            'chartOptions' => [
+              'legend' => [
+                'align' => 'center',
+                'verticalAlign' => 'bottom',
+                'layout' => 'vertical',
+              ],
             ],
           ],
         ],
-      ],
-    ];
+      ];
+    }
   }
 
   // Get the yAxis format if it exists.

--- a/docroot/modules/custom/sitenow_charts/sitenow_charts.module
+++ b/docroot/modules/custom/sitenow_charts/sitenow_charts.module
@@ -22,7 +22,7 @@ function sitenow_charts_chart_definition_alter(array &$definition, array $elemen
       'rules' => [
         [
           'condition' => [
-            'maxWidth' => 500,
+            'maxWidth' => 800,
           ],
           'chartOptions' => [
             'legend' => [


### PR DESCRIPTION
This sets a min-height for the pie chart so it is more visible on mobile. 


<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test
```
 ddev blt frontend && ddev blt ds --site=uiowa.edu && ddev drush @home.local uli     /explore/pre-med-programs
```
1. View the pie chart with the mobile emulator.  
2. Remove the CSS and confirm that the pie chart renders extremely small on mobile. 
3. Confirm that if right or left legend is selected, it will be forced to stack for smaller devices. 