### PR TITLE
Piwikpro for more of sitenow beyond ccom

### DIFF
--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -19,6 +19,7 @@ ignored_config_entities:
   - 'config_split.config_split.grad_person_extended:status'
   - 'config_split.config_split.p2lb:status'
   - 'config_split.config_split.periodical:status'
+  - 'config_split.config_split.piwikpro:status'
   - 'config_split.config_split.profiles:status'
   - 'config_split.config_split.scholarship:status'
   - 'config_split.config_split.signage:status'

--- a/config/default/config_split.config_split.piwikpro.yml
+++ b/config/default/config_split.config_split.piwikpro.yml
@@ -1,19 +1,19 @@
-uuid: 9c723b89-48f9-4562-a000-1a89b5797ec8
+uuid: 1ebdf029-6047-4db5-be22-85b9140821e3
 langcode: en
 status: false
 dependencies: {  }
-id: ccom
-label: CCOM
+id: piwikpro
+label: PiwikPro
 description: ''
 weight: 80
 stackable: true
 no_patching: false
 storage: folder
-folder: ../config/features/ccom
+folder: ../config/features/piwikpro
 module:
-  ccom_core: 0
   piwik_pro: 0
   sitenow_piwikpro: 0
 theme: {  }
 complete_list: {  }
-partial_list: {  }
+partial_list:
+  - 'user.role.*'

--- a/config/features/piwikpro/.htaccess
+++ b/config/features/piwikpro/.htaccess
@@ -1,0 +1,24 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>

--- a/config/features/piwikpro/README.md
+++ b/config/features/piwikpro/README.md
@@ -1,0 +1,14 @@
+# Functionality
+* Enables the `sitenow_piwikpro` and `piwikpro` module.
+* Allows webmasters to configure PiwikPRO settings through the UI.
+
+# Setup
+
+Splits enabled through config split do not trigger the install hooks which will turn off uiowa_core's Google Tag and Campus GTM functionality.
+
+In order to ensure full expected functionality, enable the `sitenow_piwikpro` module and then activate the `piwikpro` split.
+
+```
+drush en sitenow_piwikpro
+drush config-split:activate piwikpro
+```

--- a/config/features/piwikpro/config_split.patch.user.role.webmaster.yml
+++ b/config/features/piwikpro/config_split.patch.user.role.webmaster.yml
@@ -1,0 +1,7 @@
+adding:
+  dependencies:
+    module:
+      - piwik_pro
+  permissions:
+    - 'administer piwik pro'
+removing: {  }

--- a/docroot/modules/custom/ccom_core/ccom_core.info.yml
+++ b/docroot/modules/custom/ccom_core/ccom_core.info.yml
@@ -3,3 +3,5 @@ description: 'Customizations for CCOM sites on the SiteNow platform.'
 type: module
 core_version_requirement: ^9.2 || ^10
 package: CCOM
+dependencies:
+  - sitenow_piwikpro

--- a/docroot/modules/custom/ccom_core/ccom_core.services.yml
+++ b/docroot/modules/custom/ccom_core/ccom_core.services.yml
@@ -1,6 +1,0 @@
-services:
-  ccom_core.piwik_pro_override:
-    class: Drupal\ccom_core\ConfigOverride\PiwikProOverride
-    arguments: [ '@request_stack' ]
-    tags:
-      - { name: config.factory.override }

--- a/docroot/modules/custom/sitenow_piwikpro/sitenow_piwikpro.info.yml
+++ b/docroot/modules/custom/sitenow_piwikpro/sitenow_piwikpro.info.yml
@@ -1,5 +1,5 @@
-name: "SiteNow Piwik Pro"
-description: 'Customized implementation of PiwikPro on SiteNow.'
+name: "SiteNow PiwikPRO"
+description: 'Customized implementation of PiwikPRO on SiteNow.'
 type: module
 core_version_requirement: ^10 || ^11
 package: SiteNow

--- a/docroot/modules/custom/sitenow_piwikpro/sitenow_piwikpro.info.yml
+++ b/docroot/modules/custom/sitenow_piwikpro/sitenow_piwikpro.info.yml
@@ -1,0 +1,7 @@
+name: "SiteNow Piwik Pro"
+description: 'Customized implementation of PiwikPro on SiteNow.'
+type: module
+core_version_requirement: ^10 || ^11
+package: SiteNow
+dependencies:
+  - piwik_pro

--- a/docroot/modules/custom/sitenow_piwikpro/sitenow_piwikpro.install
+++ b/docroot/modules/custom/sitenow_piwikpro/sitenow_piwikpro.install
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Install update uninstall functions for the CCOM Core module.
+ * Install update uninstall functions for the SiteNow PiwikPRO module.
  */
 
 /**

--- a/docroot/modules/custom/sitenow_piwikpro/sitenow_piwikpro.install
+++ b/docroot/modules/custom/sitenow_piwikpro/sitenow_piwikpro.install
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @file
+ * Install update uninstall functions for the CCOM Core module.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function sitenow_piwikpro_install() {
+  // Set the uiowa_core setting so that the campus-wide
+  // gtm does not get included on page load.
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('uiowa_core.settings');
+  $config->set('uiowa_core.campus_gtm', 0)
+    ->save();
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function sitenow_piwikpro_uninstall() {
+  // Set the uiowa_core setting so that the campus-wide
+  // gtm will again be included on page load.
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('uiowa_core.settings');
+  $config->set('uiowa_core.campus_gtm', 1)
+    ->save();
+
+  \Drupal::messenger()->addStatus(__FUNCTION__);
+}

--- a/docroot/modules/custom/sitenow_piwikpro/sitenow_piwikpro.services.yml
+++ b/docroot/modules/custom/sitenow_piwikpro/sitenow_piwikpro.services.yml
@@ -1,0 +1,6 @@
+services:
+  sitenow_piwikpro.piwik_pro_override:
+    class: Drupal\sitenow_piwikpro\ConfigOverride\PiwikProOverride
+    arguments: [ '@request_stack' ]
+    tags:
+      - { name: config.factory.override }

--- a/docroot/modules/custom/sitenow_piwikpro/src/ConfigOverride/PiwikProOverride.php
+++ b/docroot/modules/custom/sitenow_piwikpro/src/ConfigOverride/PiwikProOverride.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\ccom_core\ConfigOverride;
+namespace Drupal\sitenow_piwikpro\ConfigOverride;
 
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/9557
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

I made some guesses as to how all this should work. This results in no change to the ccom_core websites with a minimum one-step (optional two-step) process for other websites.

# How to test

```
ddev drush @medicinepathology.local cr && ddev blt ds --site=pathology.medicine.uiowa.edu && ddev drush @medicinepathology.local uli admin/config/services/piwik-pro
```

See that `sitenow_piwikpro` is installed during config import.

piwik_pro module is still enabled and configuration is in place for a ccom split site. Masquerade as a webmaster to make sure you can't access admin/config/services/piwik-pro

**Because the class file is moved, there is a window where ccom_core sites could error before they receive the `cr` on deployment, so this should probably be deployed off-peak time.**

See that piwik_pro assets aren't being loaded in Dev Tools Sources tab despite having credentials. Xdebug from PiwikProOverride to see it step through and evaluate that it is not PROD.

```
ddev blt ds --site=default && ddev drush @default.local en sitenow_piwikpro && ddev drush @default.local config-split:activate piwikpro && ddev drush @default.local uli --uid=11 admin/config/services/piwik-pro
```

Ensures the uiowa_core settings are unchecked (module install) and the webmaster permission (split activate) is imported.

Go to https://default.uiowa.ddev.site/admin/config/sitenow/uiowa-core to see both Google Tag Manager and Campus GTM are unchecked.

Just the piwikpro split can be activated, but the automated uncheck of the uiowa_core settings does not occur.
