### PR TITLE
[Facilities] Remove alert help text (deploy on/after Feb 11)

### DIFF
--- a/docroot/sites/facilities.uiowa.edu/modules/facilities_core/facilities_core.module
+++ b/docroot/sites/facilities.uiowa.edu/modules/facilities_core/facilities_core.module
@@ -100,13 +100,6 @@ function facilities_core_form_alter(&$form, FormStateInterface $form_state, $for
           ':input[name="field_alert_override_building[value]"]' => ['checked' => TRUE],
         ],
       ];
-
-      $email = 'FM-Strat-Communication-Group@iowa.uiowa.edu';
-      $link = Link::fromTextAndUrl($email, Url::fromUri('mailto:' . $email))->toString();
-      $form['moderation_state']['widget'][0]['state']['#description'] = t('<p>After saving your alert in the review state, notify the Strategic Communications team at @link.</p>', [
-        '@link' => $link,
-      ]);
-
       break;
 
     case 'node_named_building_form':


### PR DESCRIPTION
Relates to #9400 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

```
ddev blt ds --site=facilities.uiowa.edu &&
ddev drush @facilities.local uli /node/add/alert
```
Scroll to the bottom, and see that the help message is no longer there.
Edit an existing alert, and see that there is no help message.

The help message in question:
<img width="891" height="228" alt="image" src="https://github.com/user-attachments/assets/4f5c6a3c-a642-4e9e-8f5d-6e8742a24080" />
