### PR TITLE
[charts] adjusted min-height for pie chart

### DIFF
--- a/docroot/modules/custom/sitenow_charts/css/sitenow_charts.css
+++ b/docroot/modules/custom/sitenow_charts/css/sitenow_charts.css
@@ -1,3 +1,5 @@
-.charts-highchart[data-chart*='"type":"pie"'] {
-  min-height: 600px;
+@media (max-width: 800px) {
+  .charts-highchart[data-chart*='"type":"pie"'] {
+    min-height: 600px;
+  }
 }


### PR DESCRIPTION
This adjustment only sets a min-height to match the breakpoint for switching to "Vertical" legend orientation in the previous pull request https://github.com/uiowa/uiowa/pull/9578. 

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

- Code review.  

Optional test:

```
 ddev blt frontend && ddev blt ds --site=uiowa.edu && ddev drush @home.local uli    /explore/pre-med/what-is-the-best-major-for-pre-med
```

Goes from:
<img width="1410" height="611" alt="Screenshot 2026-02-09 at 2 19 20 PM" src="https://github.com/user-attachments/assets/29fca64f-c3f8-4ad0-9bc3-d25216c7792e" />



To:

<img width="1365" height="483" alt="Screenshot 2026-02-09 at 2 19 12 PM" src="https://github.com/user-attachments/assets/4d807eca-500d-41ed-8562-a62821cbb03d" />

