### PR TITLE
bump ui_icons

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -11656,17 +11656,17 @@
         },
         {
             "name": "drupal/ui_icons",
-            "version": "1.0.0-beta7",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/ui_icons.git",
-                "reference": "1.0.0-beta7"
+                "reference": "1.0.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/ui_icons-1.0.0-beta7.zip",
-                "reference": "1.0.0-beta7",
-                "shasum": "f8fea111fc4237f8799c470d55b1f38bc9e11ae4"
+                "url": "https://ftp.drupal.org/files/projects/ui_icons-1.0.1.zip",
+                "reference": "1.0.1",
+                "shasum": "306bec5472598a3b430e1d384f10e5d0838817de"
             },
             "require": {
                 "drupal/core": "^10.3 || <11.1",
@@ -11686,11 +11686,11 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.0.0-beta7",
-                    "datestamp": "1739983045",
+                    "version": "1.0.1",
+                    "datestamp": "1770828782",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },


### PR DESCRIPTION
https://git.drupalcode.org/project/ui_icons/-/compare/1.0.0-beta7...1.0.1?from_project_id=120043

We aren't using the submodule that the security issue addresses.

# How to test

<!-- Include detailed steps for how to test this PR. -->
