### PR TITLE
Update Paragraphs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -188,7 +188,7 @@
         "drupal/node_view_permissions": "^2.0",
         "drupal/og": "2.x-dev#578b4678",
         "drupal/override_node_options": "^2.4",
-        "drupal/paragraphs": "^1.10",
+        "drupal/paragraphs": "^1.20",
         "drupal/pathauto": "^1.14",
         "drupal/photoswipe": "^5.0",
         "drupal/piwik_pro": "^1.3",
@@ -321,7 +321,6 @@
                 "[3223781]Add Support for <nolink>": "patches/3223781.patch"
             },
             "drupal/paragraphs": {
-                "Better error messages for missing referenced entities": "https://www.drupal.org/files/issues/2022-02-10/3095945-paragraphs-error-message-20.patch",
                 "find the correct revision ID of the parent": "https://www.drupal.org/files/issues/2020-07-08/access-controll-issue-3090200-22.patch"
             },
             "drupal/rabbit_hole": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3cd27e20319a8ee247c073f49f02ad3b",
+    "content-hash": "4c7c7fbdbc006873a009a16d7f83345c",
     "packages": [
         {
             "name": "acquia/blt",
@@ -9367,20 +9367,20 @@
         },
         {
             "name": "drupal/paragraphs",
-            "version": "1.16.0",
+            "version": "1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/paragraphs.git",
-                "reference": "8.x-1.16"
+                "reference": "8.x-1.20"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/paragraphs-8.x-1.16.zip",
-                "reference": "8.x-1.16",
-                "shasum": "48f60810fd8086a52d56e84af8b212cce7a270e8"
+                "url": "https://ftp.drupal.org/files/projects/paragraphs-8.x-1.20.zip",
+                "reference": "8.x-1.20",
+                "shasum": "68051cc8c025aa3f62fd44a219d158361928a4ad"
             },
             "require": {
-                "drupal/core": "^9.3 || ^10",
+                "drupal/core": "^10.3 || ^11",
                 "drupal/entity_reference_revisions": "~1.3"
             },
             "require-dev": {
@@ -9388,11 +9388,12 @@
                 "drupal/diff": "1.x-dev",
                 "drupal/entity_browser": "2.x-dev",
                 "drupal/entity_usage": "2.x-dev",
+                "drupal/feeds": "^3",
                 "drupal/field_group": "3.x-dev",
-                "drupal/inline_entity_form": "1.x-dev",
+                "drupal/inline_entity_form": "3.x-dev",
                 "drupal/paragraphs-paragraphs_library": "*",
                 "drupal/replicate": "1.x-dev",
-                "drupal/search_api": "1.x-dev",
+                "drupal/search_api": "^1",
                 "drupal/search_api_db": "*"
             },
             "suggest": {
@@ -9401,8 +9402,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.16",
-                    "datestamp": "1694007797",
+                    "version": "8.x-1.20",
+                    "datestamp": "1767269542",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
Resolves #9608 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

## Signage

```
ddev blt ds --site=signage.sites.uiowa.edu && ddev drush @sitessignage.local uli
```

https://github.com/uiowa/uiowa/blob/main/docroot/modules/custom/sitenow_signage/js/sign-duration.js

Add a sign and include at least one video and one non-video slide. See that the duration field is visible for the non-video and hidden for video slide
Add existing slides and create a new slide using the inline form. Try rearranging the slides. Save, and view the sign, see that it functions.

## V3

https://github.com/uiowa/uiowa/blob/d55017e5f9ff60467e4e97457f49fd1dc28ac892/docroot/themes/custom/uids_base/scss/admin/_off-canvas.scss#L263
Add a collection with two or more collection items. See that you can still expand, collapse, drag, etc. within the layout builder off-canvas tray
Repeat with slider
Replicate a page with a collection, timeline, or slider, and see that the children components are copied

https://github.com/uiowa/uiowa/blob/d55017e5f9ff60467e4e97457f49fd1dc28ac892/docroot/modules/custom/sitenow_articles/sitenow_articles.module#L615-L634
https://github.com/uiowa/uiowa/blob/d55017e5f9ff60467e4e97457f49fd1dc28ac892/docroot/modules/custom/sitenow_people/sitenow_people.module#L839-L858
https://github.com/uiowa/uiowa/blob/d55017e5f9ff60467e4e97457f49fd1dc28ac892/docroot/modules/custom/sitenow_events/sitenow_events.module#L941-L962
Add an Articles, People, or Events block, and observe that the "Path" field is hidden when the "Display More link" field is unchecked, and visible when checked

## V2

```
ddev blt ds --site=hawkeyemarchingband.uiowa.edu && ddev drush @hawkeyemarchingband.local uli
```
Test all the things

### p2lb

```
ddev drush @hawkeyemarchingband.local config-split:activate p2lb
```
Visit /admin/content/sitenow-converter and convert all the pages
Go to the Converted tab and publish the latest revision for all pages
```
ddev drush @hawkeyemarchingband.local sitenow_p2lb:cleanup
```
See in the terminal output that after node revisions are deleted, lots of paragraph revisions for orphans are deleted
See a clean config import
Poke around at a few pages, and see that it is indeed a v3 site

<details>
<summary>

## AI overview

</summary>

1. **[P2] Paragraphs admin UI customizations are tightly coupled to internal widget markup that changed in 1.19/1.20**
- Your theme/admin and tours rely on internal Paragraphs classes/selectors (`.paragraphs-tabs-wrapper`, `.paragraphs-dropdown`, `.paragraph-top`, `.handle`) in:
  - docroot/themes/custom/uids_base/scss/admin/_off-canvas.scss
  - config/default/tour.tour.content-add.yml
  - config/default/tour.tour.content-edit.yml
- Paragraphs 1.19/1.20 included widget/preprocess markup changes (notably around `field_multiple_value_form` and table handling), so these custom selectors are the most likely regression point after upgrade (visual breakage, tour highlights missing, action/dropdown alignment issues).

2. **[P2] Custom JS behavior depends on Paragraph row class injection that was touched in recent Paragraphs releases**
- docroot/modules/custom/sitenow_signage/js/sign-duration.js checks for `.paragraph-type--slide-video`.
- That class is added via Paragraphs preprocess logic that changed in this upgrade window; if row structure differs in any context (nested forms/legacy widget/off-canvas), this behavior can silently stop toggling duration fields.

3. **[P3] Widget form-alter logic assumes stable Paragraph subform parent structure**
- These hooks build `#states` selectors from `$element['subform']['#parents']`:
  - docroot/modules/custom/sitenow_articles/sitenow_articles.modul
  - docroot/modules/custom/sitenow_people/sitenow_people.module
  - docroot/modules/custom/sitenow_events/sitenow_events.module
- No immediate hard break found, but this is brittle against upstream form-structure changes and should be regression-tested on nested Paragraphs and off-canvas edits.

No hard PHP/API breakpoints jumped out in your custom Paragraph entity usage (`Paragraph::create`, `getParentEntity`, preprocess hooks). Main risk is UI/form-structure coupling, not backend API removal.

Sources:
- [Paragraphs 1.20.0 release](https://www.drupal.org/project/paragraphs/releases/8.x-1.20)
- [Paragraphs 1.19.0 release](https://www.drupal.org/project/paragraphs/releases/8.x-1.19)
- [Issue #3418303 (field_multiple_value_form preprocess compatibility)](https://www.drupal.org/project/paragraphs/issues/3418303)
- [Installed contrib code: paragraphs preprocess implementation](/Users/cskeers/acquia/uiowa/docroot/modules/contrib/paragraphs/paragraphs.module:405)

Suggested next steps:
1. Smoke test node/block forms with nested Paragraphs in both normal and off-canvas contexts.
2. Specifically verify dropdown actions, drag/reorder, and your signage “video hides duration” behavior.
3. If any UI regressions appear, first adjust selector-based custom code (CSS/JS/tour YAML) before touching entity/business logic.
</details>