### PR TITLE
[Registrar] Updated correspondence cleanup with Dispatch VISIBLE+TAG filter

### DIFF
--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/registrar_core.module
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/registrar_core.module
@@ -141,8 +141,11 @@ function registrar_core_post_submit(&$form, FormStateInterface $form_state) {
 
 /**
  * Retrieve correspondence data from Dispatch.
+ *
+ * @param int $timestamp
+ *   The UNIX timestamp after which records should be retrieved.
  */
-function registrar_core_fetch_correspondence_from_dispatch() {
+function registrar_core_fetch_correspondence_from_dispatch(int $timestamp) {
   $logger = \Drupal::logger('registrar_core');
   $logger->notice('Fetching correspondence archives.');
 
@@ -151,8 +154,6 @@ function registrar_core_fetch_correspondence_from_dispatch() {
   // so stale local rows can be removed.
   $visible_archive_urls = [];
   $database = \Drupal::database();
-  // Two-year retention window (63,072,000 seconds).
-  $cutoff = time() - 63072000;
   $endpoint = 'https://apps.its.uiowa.edu/dispatch/api/v1/';
   $dispatch_params = [
     'VISIBLE' => 'true',
@@ -173,7 +174,7 @@ function registrar_core_fetch_correspondence_from_dispatch() {
     // Fetched archives are in descending chronological order
     // and we're only keeping ones that are younger than the cutoff,
     // so once we've hit one that is older, we know we're done processing.
-    if (strtotime($archive->createdOn) < $cutoff) {
+    if (strtotime($archive->createdOn) < $timestamp) {
       break;
     }
     $key = basename($archive_url);
@@ -217,7 +218,7 @@ function registrar_core_fetch_correspondence_from_dispatch() {
   // Remove rows in the retention window
   // that Dispatch no longer reports as visible.
   $delete_query = $database->delete('correspondence_archives')
-    ->condition('timestamp', $cutoff, '>=');
+    ->condition('timestamp', $timestamp, '>=');
   // If Dispatch returned visible URLs, delete only rows not in that list.
   if (!empty($visible_archive_urls)) {
     $delete_query->condition('url', $visible_archive_urls, 'NOT IN');
@@ -283,9 +284,11 @@ function registrar_core_cron() {
   $last_run = \Drupal::state()->get('registrar_core_daily_last');
 
   if (!$last_run || $request_date > $last_run) {
-    registrar_core_fetch_correspondence_from_dispatch();
-    // Prune entries older than 2 years (63072000 seconds).
-    registrar_core_prune_correspondence(time() - 63072000);
+    // Two-year retention window (63,072,000 seconds).
+    $timestamp = time() - 63072000;
+    registrar_core_fetch_correspondence_from_dispatch($timestamp);
+    // Prune entries older than the retention window.
+    registrar_core_prune_correspondence($timestamp);
 
     \Drupal::state()->set('registrar_core_daily_last', $request_date);
   }

--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/registrar_core.module
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/registrar_core.module
@@ -147,7 +147,8 @@ function registrar_core_fetch_correspondence_from_dispatch() {
   $logger->notice('Fetching correspondence archives.');
 
   $rows = [];
-  // Track currently visible Dispatch archive URLs so stale local rows can be removed.
+  // Track currently visible Dispatch archive URLs
+  // so stale local rows can be removed.
   $visible_archive_urls = [];
   $database = \Drupal::database();
   // Two-year retention window (63,072,000 seconds).
@@ -160,7 +161,8 @@ function registrar_core_fetch_correspondence_from_dispatch() {
   $query = UrlHelper::buildQuery($dispatch_params);
   $archives = registrar_core_dispatch_get_data("{$endpoint}archives?{$query}");
 
-  // If the API call fails, abort cleanup to avoid deleting valid local cache rows.
+  // If the API call fails, abort cleanup
+  // to avoid deleting valid local cache rows.
   if (!is_array($archives)) {
     $logger->warning('Unable to retrieve correspondence archives.');
     return;
@@ -169,11 +171,8 @@ function registrar_core_fetch_correspondence_from_dispatch() {
   foreach ($archives as $archive_url) {
     $archive = registrar_core_dispatch_get_data($archive_url);
     // Fetched archives are in descending chronological order
-    // and we're only keeping ones that are 2 years or younger,
-    // so once we've hit one that is older than 2 years old
-// Fetched archives are in descending chronological order
-// and we're only keeping ones that are younger than the cutoff,
-// so once we've hit one that is older, we know we're done processing.
+    // and we're only keeping ones that are younger than the cutoff,
+    // so once we've hit one that is older, we know we're done processing.
     if (strtotime($archive->createdOn) < $cutoff) {
       break;
     }
@@ -215,7 +214,8 @@ function registrar_core_fetch_correspondence_from_dispatch() {
     $query->execute();
   }
 
-  // Remove rows in the retention window that Dispatch no longer reports as visible.
+  // Remove rows in the retention window
+  // that Dispatch no longer reports as visible.
   $delete_query = $database->delete('correspondence_archives')
     ->condition('timestamp', $cutoff, '>=');
   // If Dispatch returned visible URLs, delete only rows not in that list.

--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/registrar_core.module
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/registrar_core.module
@@ -171,7 +171,9 @@ function registrar_core_fetch_correspondence_from_dispatch() {
     // Fetched archives are in descending chronological order
     // and we're only keeping ones that are 2 years or younger,
     // so once we've hit one that is older than 2 years old
-    // (63072000 seconds) we know we're done processing.
+// Fetched archives are in descending chronological order
+// and we're only keeping ones that are younger than the cutoff,
+// so once we've hit one that is older, we know we're done processing.
     if (strtotime($archive->createdOn) < $cutoff) {
       break;
     }

--- a/docroot/sites/registrar.uiowa.edu/modules/registrar_core/registrar_core.module
+++ b/docroot/sites/registrar.uiowa.edu/modules/registrar_core/registrar_core.module
@@ -147,7 +147,11 @@ function registrar_core_fetch_correspondence_from_dispatch() {
   $logger->notice('Fetching correspondence archives.');
 
   $rows = [];
+  // Track currently visible Dispatch archive URLs so stale local rows can be removed.
+  $visible_archive_urls = [];
   $database = \Drupal::database();
+  // Two-year retention window (63,072,000 seconds).
+  $cutoff = time() - 63072000;
   $endpoint = 'https://apps.its.uiowa.edu/dispatch/api/v1/';
   $dispatch_params = [
     'VISIBLE' => 'true',
@@ -156,8 +160,10 @@ function registrar_core_fetch_correspondence_from_dispatch() {
   $query = UrlHelper::buildQuery($dispatch_params);
   $archives = registrar_core_dispatch_get_data("{$endpoint}archives?{$query}");
 
-  if (empty($archives)) {
+  // If the API call fails, abort cleanup to avoid deleting valid local cache rows.
+  if (!is_array($archives)) {
     $logger->warning('Unable to retrieve correspondence archives.');
+    return;
   }
 
   foreach ($archives as $archive_url) {
@@ -166,11 +172,13 @@ function registrar_core_fetch_correspondence_from_dispatch() {
     // and we're only keeping ones that are 2 years or younger,
     // so once we've hit one that is older than 2 years old
     // (63072000 seconds) we know we're done processing.
-    if (strtotime($archive->createdOn) < time() - 63072000) {
+    if (strtotime($archive->createdOn) < $cutoff) {
       break;
     }
     $key = basename($archive_url);
     $url = "https://apps.its.uiowa.edu/dispatch/archive/{$key}";
+    // Remember every visible URL inside the retention window.
+    $visible_archive_urls[] = $url;
     $communication = registrar_core_dispatch_get_data($archive->communication);
     $campaign = registrar_core_dispatch_get_data($communication->campaign);
 
@@ -194,16 +202,31 @@ function registrar_core_fetch_correspondence_from_dispatch() {
       'tags' => implode(' ', $campaign->tags),
     ];
   }
-  $query = $database->upsert('correspondence_archives')
-    ->fields(['timestamp', 'from_name', 'subject', 'url', 'audience', 'tags'])
-    ->key('url');
-  foreach ($rows as $row) {
-    $query->values($row);
+  // Upsert still refreshes current visible rows.
+  if (!empty($rows)) {
+    $query = $database->upsert('correspondence_archives')
+      ->fields(['timestamp', 'from_name', 'subject', 'url', 'audience', 'tags'])
+      ->key('url');
+    foreach ($rows as $row) {
+      $query->values($row);
+    }
+    $query->execute();
   }
-  $query->execute();
+
+  // Remove rows in the retention window that Dispatch no longer reports as visible.
+  $delete_query = $database->delete('correspondence_archives')
+    ->condition('timestamp', $cutoff, '>=');
+  // If Dispatch returned visible URLs, delete only rows not in that list.
+  if (!empty($visible_archive_urls)) {
+    $delete_query->condition('url', $visible_archive_urls, 'NOT IN');
+  }
+  $deleted = $delete_query->execute();
 
   $logger->notice(t('@count archives upserted.', [
     '@count' => count($rows),
+  ]));
+  $logger->notice(t('@count archives removed because they are no longer visible in Dispatch.', [
+    '@count' => $deleted,
   ]));
 }
 


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/9650. 

Fixes an issue for when the "Hide Issue" flag in Dispatch is set and removes it from the public archives and thus giving us a broken link on the correspondence page.

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
 ddev blt ds --site=registrar.uiowa.edu && ddev drush @registrar.local uli  /correspondence
```
1. Search for [Accessible Content Project Resources](https://apps.its.uiowa.edu/dispatch/archive/accessible-content-resources-W8ZwwvE) and confirm the link is broken. 
2. Add Dispatch key from https://registrar.uiowa.edu/admin/config/sitenow/sitenow-dispatch to https://registrar.uiowa.ddev.site/admin/config/sitenow/sitenow-dispatch
```
ddev drush @registrar.local state:set registrar_core_daily_last 2000-01-01  && ddev drush @registrar.local  cron
```
1. Confirm broken link has been removed. 
2. You should see a message ` [notice] 17 archives removed because they are no longer visible in Dispatch.`
3. The 17 items are being removed because the sync now performs both inclusion and cleanup using the same Dispatch filter (VISIBLE=true&TAG=registrar). Those params already existed before, but previously the code only upserted returned rows and never deleted rows that dropped out of that filtered result set (except age-based pruning), so stale entries accumulated. With the new cleanup, Drupal now deletes correspondence_archives rows in the 2-year window when their URL is no longer returned by that filtered API query. That means items can be pruned even if their public archive URL still loads, if they are no longer in the filtered Dispatch set (for example, no longer tagged registrar); truly hidden items are removed for the same reason.

**Example pruned item(s):**
```
{
    "slug": "academic-calendar-replication-review-D0jBzLn",
    "title": "REMINDER: Review Your 2026 Academic Calendar Dates",
    "createdOn": "2025-07-24T11:32:23-0500",
    "hidden": false,
    "tags": [
        null
    ]
}
{
    "slug": "accessible-content-resources-W8ZwwvE",
    "title": "Accessible Content Project Resources",
    "createdOn": "2025-11-12T12:53:30-0600",
    "hidden": true,
    "tags": [
        null
    ]
}
```
**Example item with tags that is not pruned:**
```

{
    "slug": "textbook-assignment-reminder--instructors--summer-GYvyyRL",
    "title": "Summer 2026 Textbook Assignment Reminder - Instructors",
    "createdOn": "2026-02-23T13:01:50-0600",
    "hidden": false,
    "tags": [
        "faculty/staff",
        "registrar"
    ]
}
```
