### PR TITLE
[menu_block] Added hotfix to get blocks off of visibility_level_parent

### DIFF
--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -684,10 +684,6 @@ function _layout_builder_custom_block_validate(array &$form, FormStateInterface 
         break;
 
       case 'menu_block:main':
-        // Prevent saving a label type that can fatal with current menu_block.
-        if ($form_state->getValue(['settings', 'label_type']) === 'visibility_level_parent') {
-          $form_state->setValue(['settings', 'label_type'], 'block');
-        }
         // If follow is checked...
         if ((int) $form_state->getValue(['settings', 'follow']) === 1) {
           // Set parent to default.

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -480,6 +480,7 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
             // Unset the menu option in the label.
             unset($form['settings']['advanced']['label_type']['#options']['menu']);
             // Hide this option until menu_block fixes initialization of menuRoot.
+            // Fix is being tracked in https://github.com/uiowa/uiowa/issues/9647.
             unset($form['settings']['advanced']['label_type']['#options']['visibility_level_parent']);
             // Default existing blocks off unsupported label type.
             if (($form['settings']['advanced']['label_type']['#default_value'] ?? NULL) === 'visibility_level_parent') {

--- a/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
+++ b/docroot/modules/custom/layout_builder_custom/layout_builder_custom.module
@@ -479,6 +479,12 @@ function layout_builder_custom_form_alter(&$form, FormStateInterface $form_state
             $form['settings']['admin_label']['#plain_text'] .= ' Menu';
             // Unset the menu option in the label.
             unset($form['settings']['advanced']['label_type']['#options']['menu']);
+            // Hide this option until menu_block fixes initialization of menuRoot.
+            unset($form['settings']['advanced']['label_type']['#options']['visibility_level_parent']);
+            // Default existing blocks off unsupported label type.
+            if (($form['settings']['advanced']['label_type']['#default_value'] ?? NULL) === 'visibility_level_parent') {
+              $form['settings']['advanced']['label_type']['#default_value'] = 'block';
+            }
             // Adjust the default text.
             $form['settings']['advanced']['label_type']['#options']['block'] = t('"Section Menu" (default)');
             // Update the description on the label_type.
@@ -677,11 +683,15 @@ function _layout_builder_custom_block_validate(array &$form, FormStateInterface 
         break;
 
       case 'menu_block:main':
+        // Prevent saving a label type that can fatal with current menu_block.
+        if ($form_state->getValue(['settings', 'label_type']) === 'visibility_level_parent') {
+          $form_state->setValue(['settings', 'label_type'], 'block');
+        }
         // If follow is checked...
         if ((int) $form_state->getValue(['settings', 'follow']) === 1) {
           // Set parent to default.
           $form_state->setValue(['settings', 'parent'], 'main:');
-          // Set level = 2.
+          // Set level = 1.
           $form_state->setValue(['settings', 'level'], 1);
         }
         break;

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -4713,33 +4713,3 @@ function sitenow_update_10034() {
 
   return t('No webform handlers required attachment changes.');
 }
-
-/**
- * Move menu block labels off unsupported visibility level parent option.
- */
-function sitenow_update_10035() {
-  $updated_components = 0;
-
-  // Target Layout Builder components for menu_block:main.
-  _update_all_blocks_by_plugin_id('menu_block:main', function (&$component, $block = NULL) use (&$updated_components) {
-    $configuration = $component->get('configuration');
-    if (!is_array($configuration)) {
-      return;
-    }
-
-    if (($configuration['label_type'] ?? '') !== 'visibility_level_parent') {
-      return;
-    }
-
-    $configuration['label_type'] = 'block';
-    $component->setConfiguration($configuration);
-    $updated_components++;
-  });
-
-  return t(
-    'Updated @count menu block component(s) from "visibility_level_parent" to "block".',
-    [
-      '@count' => $updated_components,
-    ]
-  );
-}

--- a/docroot/profiles/custom/sitenow/sitenow.install
+++ b/docroot/profiles/custom/sitenow/sitenow.install
@@ -4713,3 +4713,33 @@ function sitenow_update_10034() {
 
   return t('No webform handlers required attachment changes.');
 }
+
+/**
+ * Move menu block labels off unsupported visibility level parent option.
+ */
+function sitenow_update_10035() {
+  $updated_components = 0;
+
+  // Target Layout Builder components for menu_block:main.
+  _update_all_blocks_by_plugin_id('menu_block:main', function (&$component, $block = NULL) use (&$updated_components) {
+    $configuration = $component->get('configuration');
+    if (!is_array($configuration)) {
+      return;
+    }
+
+    if (($configuration['label_type'] ?? '') !== 'visibility_level_parent') {
+      return;
+    }
+
+    $configuration['label_type'] = 'block';
+    $component->setConfiguration($configuration);
+    $updated_components++;
+  });
+
+  return t(
+    'Updated @count menu block component(s) from "visibility_level_parent" to "block".',
+    [
+      '@count' => $updated_components,
+    ]
+  );
+}


### PR DESCRIPTION
Related to https://github.com/uiowa/uiowa/issues/9647. 

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
 ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli /policy-manual/table-contents/active-menu-item-not-showing-title-if-it-has-no-children
```
1. Code review
2. Confirm that sandbox page no longer is WSOD
3. Confirm `visibility_level_parent` option is not available.
