### PR TITLE
Banner videos -- aria-hidden

### DIFF
--- a/docroot/themes/custom/uids_base/assets/video/decorative-video-captions.vtt
+++ b/docroot/themes/custom/uids_base/assets/video/decorative-video-captions.vtt
@@ -1,4 +1,0 @@
-WEBVTT
-
-00:00:00.000 --> 00:00:01.000
-[background video, no audio]

--- a/docroot/themes/custom/uids_base/templates/field/file-video.html.twig
+++ b/docroot/themes/custom/uids_base/templates/field/file-video.html.twig
@@ -31,7 +31,4 @@
   {% for file in files %}
     <source {{ file.source_attributes }} />
   {% endfor %}
-  {% if attributes.storage['data-decorative'] %}
-    <track kind="captions" src="{{ base_path ~ directory }}/assets/video/decorative-video-captions.vtt" srclang="en" label="No audio">
-  {% endif %}
 </video>

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -512,7 +512,7 @@ function uids_base_preprocess_media(array &$variables) {
           if ($parent_entity instanceof BlockContent) {
             // Mark banner videos as decorative since they are background
             // media with no informational content.
-            // @todo Update this to check for an alt desciprition
+            // @todo Update this to check for an alt description
             //   when that option is available.
             $variables['content']['field_media_video_file'][0]['#attributes']['aria-hidden'] = 'true';
             // Play video inline instead of going to native player.

--- a/docroot/themes/custom/uids_base/uids_base.theme
+++ b/docroot/themes/custom/uids_base/uids_base.theme
@@ -510,8 +510,11 @@ function uids_base_preprocess_media(array &$variables) {
         if ($parent instanceof EntityAdapter) {
           $parent_entity = $parent->getEntity();
           if ($parent_entity instanceof BlockContent) {
-            // Flag for the template to add a decorative caption track.
-            $variables['content']['field_media_video_file'][0]['#attributes']['data-decorative'] = 'true';
+            // Mark banner videos as decorative since they are background
+            // media with no informational content.
+            // @todo Update this to check for an alt desciprition
+            //   when that option is available.
+            $variables['content']['field_media_video_file'][0]['#attributes']['aria-hidden'] = 'true';
             // Play video inline instead of going to native player.
             $variables['content']['field_media_video_file'][0]['#attributes']['playsinline'] = 'playsinline';
             // @todo 2020/12/08 Add check to see if video is paused in 'uiowa-video'


### PR DESCRIPTION
Resolves #9168 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

```
ddev blt ds --site=medicine.uiowa.edu
```
Visit https://medicine.uiowa.ddev.site/
Siteimprove browser extension comes up with only AAA issues unrelated to the banner video
Inspect the video--see that the video itself is `aria-hidden="true"`
Inspect the video controls, and see that they are not hidden (and/or tab through the page, and see that the button is focusable)

Any feedback on the reasoning or understanding here: https://github.com/uiowa/uiowa/pull/9649#issuecomment-3991594694