### PR TITLE
Updated brand icon version

### DIFF
--- a/docroot/themes/custom/uids_base/package.json
+++ b/docroot/themes/custom/uids_base/package.json
@@ -4,7 +4,7 @@
   "license": "ISC",
   "dependencies": {
     "@uiowa/uids4": "https://github.com/uiowa/uids.git#cb08e63",
-    "@uiowa/brand-icons": "https://github.com/uiowa/brand-icons.git#95911bc",
+    "@uiowa/brand-icons": "https://github.com/uiowa/brand-icons.git#68dbc06",
     "autoprefixer": "^9.8.8",
     "cssnano": "^7.0.7",
     "postcss": "^8.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1208,9 +1208,9 @@
   dependencies:
     "@types/node" "*"
 
-"@uiowa/brand-icons@https://github.com/uiowa/brand-icons.git#95911bc":
+"@uiowa/brand-icons@https://github.com/uiowa/brand-icons.git#68dbc06":
   version "1.0.0"
-  resolved "https://github.com/uiowa/brand-icons.git#95911bc3c2e54594247d2fb97c0edd4b449f0164"
+  resolved "https://github.com/uiowa/brand-icons.git#68dbc06e24021dd7b37a9d3c70c34b22b11ed9c1"
   dependencies:
     core-js "^3.8.3"
     fs "0.0.1-security"


### PR DESCRIPTION

Resolves https://github.com/uiowa/uiowa/issues/9596. 

Updating the icons that were changed in https://github.com/uiowa/brand-icons/pull/39.

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

- Confirm commit hash matches latest commit in https://github.com/uiowa/brand-icons. 
- Delete `assets/icons/` directory
```
ddev blt frontend && ddev blt ds --site=sandbox.uiowa.edu && ddev drush @sandbox.local uli /
```
- Add a card, add a icon, search for a new icon like `hat`, `sound wave`, or `toilet paper`. 
