### PR TITLE
Dependency updates: editor_advanced_link and linkit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -292,9 +292,6 @@
             "drupal/draggableviews": {
                 "Completely hide the weights field for anonymous users": "https://www.drupal.org/files/issues/2021-08-31/3229357-7.patch"
             },
-            "drupal/editor_advanced_link": {
-                "[3371633] Fix for new window option not rendering under the\n advanced group on initial dialog open.": "patches/14.patch"
-            },
             "drupal/entity_reference_revisions": {
                 "[3201705] Orphan purger : if entity's parent is invalid (NULL), dig deeper": "patches/3201705.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -7932,30 +7932,26 @@
         },
         {
             "name": "drupal/linkit",
-            "version": "7.0.4",
+            "version": "7.0.13",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/linkit.git",
-                "reference": "7.0.4"
+                "reference": "7.0.13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/linkit-7.0.4.zip",
-                "reference": "7.0.4",
-                "shasum": "cb112f26b1475f6857c9012880ec17f1636dd053"
+                "url": "https://ftp.drupal.org/files/projects/linkit-7.0.13.zip",
+                "reference": "7.0.13",
+                "shasum": "918d001248b4a394eb1c4e097e7d243959280489"
             },
             "require": {
                 "drupal/core": "^10.1 || ^11"
             },
-            "require-dev": {
-                "drupal/ckeditor": "*",
-                "drupal/imce": "*"
-            },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "7.0.4",
-                    "datestamp": "1745413700",
+                    "version": "7.0.13",
+                    "datestamp": "1773055628",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c7c7fbdbc006873a009a16d7f83345c",
+    "content-hash": "872e4712f019df857a1a027041af2115",
     "packages": [
         {
             "name": "acquia/blt",
@@ -5431,30 +5431,32 @@
         },
         {
             "name": "drupal/editor_advanced_link",
-            "version": "2.2.6",
+            "version": "2.2.9",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/editor_advanced_link.git",
-                "reference": "2.2.6"
+                "reference": "2.2.9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/editor_advanced_link-2.2.6.zip",
-                "reference": "2.2.6",
-                "shasum": "f6d7c437900f288b1e735b4faf2decc99bdd30e8"
+                "url": "https://ftp.drupal.org/files/projects/editor_advanced_link-2.2.9.zip",
+                "reference": "2.2.9",
+                "shasum": "fc1a4c6ad69a4bfc820ecfd0df47fbc7f5d6a885"
             },
             "require": {
-                "drupal/core": "^10.2 || ^11.0"
+                "drupal/core": "^10.2 <10.5 || ^11 <11.2"
+            },
+            "conflict": {
+                "drupal/core": "^10 >=10.5 || ^11 >=11.2"
             },
             "require-dev": {
-                "drupal/ckeditor": "*",
                 "phpro/grumphp": "^2.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.2.6",
-                    "datestamp": "1723183019",
+                    "version": "2.2.9",
+                    "datestamp": "1758044012",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5475,7 +5477,7 @@
                     "homepage": "https://www.drupal.org/user/673120"
                 }
             ],
-            "description": "Editor Advanced link",
+            "description": "Add title, target etc. attributes to Text Editor''s link dialog if the text format allows them.",
             "homepage": "https://www.drupal.org/project/editor_advanced_link",
             "support": {
                 "source": "https://git.drupalcode.org/project/editor_advanced_link"

--- a/config/default/filter.format.full_html.yml
+++ b/config/default/filter.format.full_html.yml
@@ -126,6 +126,7 @@ filters:
     weight: -50
     settings:
       title: true
+      media_substitution: metadata
   media_embed:
     id: media_embed
     provider: media

--- a/config/default/filter.format.minimal.yml
+++ b/config/default/filter.format.minimal.yml
@@ -94,3 +94,4 @@ filters:
     weight: -50
     settings:
       title: true
+      media_substitution: metadata

--- a/config/default/filter.format.minimal_plus.yml
+++ b/config/default/filter.format.minimal_plus.yml
@@ -94,3 +94,4 @@ filters:
     weight: -50
     settings:
       title: true
+      media_substitution: metadata


### PR DESCRIPTION
# How to test

For editor_advanced_link:
- open a page and go to edit the layout
- add a text block
- for minimal and minimal + html formats:
    - create a link and set advanced values
        - title, aria-label, id, rel, target
    - ensure advanced is above the check and close buttons
    - once you set all values, save the link.
    - open the link again, check all your values work.
    - edit an existing link and see all values are maintained.
    - confirm no browser console errors.
- for filtered html and full html
    - do the above but there is also a class field in advanced.
- confirm on render all links render correctly.

For linkit:
- open a page and go to edit the layout
- add a text block
- For minimal, minimal+, filtered_html, and full_html
- Open the link dialog and confirm Linkit autocomplete appears.
- Search and insert each of these link types:
    - node
    - media
    - webform
    - front page
- save and ensure all values are maintained.