### PR TITLE
Update message on facilities

### DIFF
--- a/docroot/sites/facilities.uiowa.edu/modules/facilities_core/facilities_core.module
+++ b/docroot/sites/facilities.uiowa.edu/modules/facilities_core/facilities_core.module
@@ -350,7 +350,7 @@ function facilities_core_preprocess_field(&$variables) {
       $details = [
         '#type' => 'details',
         '#title' => 'Disclaimer Statement',
-        '#markup' => '<small>Public operating hours for campus buildings are displayed, excluding holidays and special events. These hours do not represent office business hours. Access to buildings during closed hours is permitted via the Iowa One Card for approved faculty, staff, and students. For Hospital 24/7 entrances, visitor guidelines, and information, please visit the <a href="https://uihc.org/visitor-guidelines-ui-health-care">UI Health Care website</a>.</small>',
+        '#markup' => '<small>Public operating hours for campus buildings are displayed, excluding holidays, academic breaks, and special events. These hours do not represent office business hours. Access to buildings during closed hours is permitted via the Iowa One Card for approved faculty, staff, and students. For Hospital 24/7 entrances, visitor guidelines, and information, please visit the <a href="https://uihc.org/visitor-guidelines-ui-health-care">UI Health Care website</a>.</small>',
       ];
 
       // Append the details element to the field content.


### PR DESCRIPTION
Resolves #9682
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev blt ds --site=facilities.uiowa.edu && ddev drush @facilities.local uli building/0046
```

Confirm the Hours disclaimer statement change on building pages (e.g. Iowa Memorial Union) matches the text in the issue summary.
