### PR TITLE
Menu focus indicator fix - hover background color for focus too

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/menus/superfish/superfish.scss
+++ b/docroot/themes/custom/uids_base/scss/components/menus/superfish/superfish.scss
@@ -442,6 +442,7 @@ ul.sf-accordion ul:focus-within {
     text-decoration: underline;
     cursor: pointer;
     outline: none;
+    background: #e1e1e1;
   }
 
   &:hover {


### PR DESCRIPTION
Relates to https://github.com/uiowa/uiowa/issues/9665

Can't test SI locally yet as the browser extension doesn't pick this up, but https://github.com/Siteimprove/alfa/blob/main/packages/alfa-rules/src/sia-r65/rule.ts reveals what SI checks for related to this. Ultimately a guess and check right now.

Here is what the menu looks like now for focus. I left the existing bold text for `nolink` items and matched the background color to other hover style definitions within docroot/themes/custom/uids_base/scss/components/menus

<img width="691" height="391" alt="Screenshot 2026-03-19 at 11 57 02 AM" src="https://github.com/user-attachments/assets/2cc4505c-6fdc-4b82-a358-4df8cd813667" />
<img width="754" height="330" alt="Screenshot 2026-03-19 at 11 57 18 AM" src="https://github.com/user-attachments/assets/6e2e8980-9426-41a1-bc92-78938018997c" />
<img width="450" height="174" alt="Screenshot 2026-03-19 at 11 57 07 AM" src="https://github.com/user-attachments/assets/06ba0a7a-d9a1-41f9-b712-80e12e3c819d" />


# How to test

```
ddev blt frontend && ddev blt ds --site=obgyn.medicine.uiowa.edu
```

Compare https://medicineobgyn.uiowa.ddev.site/ and https://obgyn.medicine.uiowa.edu/ keyboard focus styles for the horizontal menu. Trying to avoid radical design changes but provide a "toggle" to satisfy rule 65.

# Follow-up

Keeping the issue open, review the site improve scans after deployment to see if this resolves the issue.
