### PR TITLE
Added element invisible off for focus on breadcrumb

### DIFF
--- a/docroot/themes/custom/uids_base/scss/layouts/onecol--background.scss
+++ b/docroot/themes/custom/uids_base/scss/layouts/onecol--background.scss
@@ -81,8 +81,27 @@
 
     &:focus-within {
       @include utilities.element-invisible-off;
+      padding-left: .2rem;
+      a {
+        background: variables.$gray-light;
+        padding: .2rem;
+      }
     }
   }
+  // Featured images have a black background set making
+  // links white so the breadcrumb background needs to be
+  // black in order to be visible.
+ &.layout--title--with-background {
+   .block-system-breadcrumb-block {
+     @include utilities.element-invisible;
+
+     &:focus-within {
+       a {
+         background: variables.$secondary;
+       }
+     }
+   }
+ }
 }
 
 // Fix for featured image banners on custom content types.

--- a/docroot/themes/custom/uids_base/scss/layouts/onecol--background.scss
+++ b/docroot/themes/custom/uids_base/scss/layouts/onecol--background.scss
@@ -93,10 +93,9 @@
   // black in order to be visible.
  &.layout--title--with-background {
    .block-system-breadcrumb-block {
-     @include utilities.element-invisible;
 
      &:focus-within {
-       a {
+       li, a {
          background: variables.$secondary;
        }
      }

--- a/docroot/themes/custom/uids_base/scss/layouts/onecol--background.scss
+++ b/docroot/themes/custom/uids_base/scss/layouts/onecol--background.scss
@@ -93,7 +93,6 @@
   // black in order to be visible.
  &.layout--title--with-background {
    .block-system-breadcrumb-block {
-
      &:focus-within {
        li, a {
          background: variables.$secondary;

--- a/docroot/themes/custom/uids_base/scss/layouts/onecol--background.scss
+++ b/docroot/themes/custom/uids_base/scss/layouts/onecol--background.scss
@@ -78,6 +78,10 @@
 .layout--title--hidden {
   .block-system-breadcrumb-block {
     @include utilities.element-invisible;
+
+    &:focus-within {
+      @include utilities.element-invisible-off;
+    }
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/9417. 

# How to test
## Test with short breadcrumb with page title hidden and no featured image
```
ddev blt frontend && ddev blt ds --site=stories.uiowa.edu   && ddev drush @stories.local uli /writing-across-disciplines-among-elite-company-usnwr-rankings-2025-26
```
1. Tab through and confirm "Home" shows on focus. Confirm that the breadcrumb link text is black and the background is gray. 
2. There doesn't appear to be a Siteimprove issue associated with this so manual testing is key. 
## Test with short breadcrumb with page title hidden on top of featured image
```
ddev blt frontend &&  ddev blt ds --site=sandbox.uiowa.edu   && ddev drush @sandbox.local uli /testing-accordions-sia-r113
```
1. Tab through until you get to the breadcrumb. Confirm breadcrumb sits on top of the featured image and is visible with black background and white link text. 

## Test with longer breadcrumb with page title hidden on top of featured image
```
ddev blt frontend && ddev blt ds --site=sandbox.uiowa.edu   && ddev drush @sandbox.local uli /catalog-style-guide/catalog-grid-and-filtering-examples/test-breadcrumbs-focus-within
```
1. Confirm you can tab through multiple links in the breadcrumb path once focused. 