### PR TITLE
[ITS] Alert icon accessibility fix

### DIFF
--- a/docroot/modules/custom/uiowa_core/uiowa_core.module
+++ b/docroot/modules/custom/uiowa_core/uiowa_core.module
@@ -1897,10 +1897,8 @@ function uiowa_core_set_field_label_icon(array &$variables, string $icon_classes
  *   The Font Awesome class for the field icon.
  * @param string $icon_bg_classes
  *   The Font Awesome class for the background of the field icon.
- * @param string $icon_title
- *   The title attribute value for the field icon.
  */
-function uiowa_core_set_field_icon(array &$variables, string $icon_classes, string $icon_bg_classes = '', string $icon_title = '') : void {
+function uiowa_core_set_field_icon(array &$variables, string $icon_classes, string $icon_bg_classes = '') : void {
   if (!isset($variables['field_icon'])) {
     $variables['field_icon'] = '';
   }
@@ -1911,9 +1909,6 @@ function uiowa_core_set_field_icon(array &$variables, string $icon_classes, stri
     ]);
   if (!empty($icon_bg_classes)) {
     $variables['field_icon_bg'] = $icon_bg_classes;
-  }
-  if (!empty($icon_title)) {
-    $variables['field_icon_title'] = $icon_title;
   }
 }
 

--- a/docroot/sites/its.uiowa.edu/modules/its_core/its_core.module
+++ b/docroot/sites/its.uiowa.edu/modules/its_core/its_core.module
@@ -617,11 +617,11 @@ function its_core_preprocess_field(&$variables, $hook) {
       if ($variables['element']['#view_mode'] == 'teaser') {
         if (!empty($variables['element']['#items']) && !empty($variables['element']['#object']->field_alert_building->getValue())) {
           uiowa_core_set_attributes($variables, 'fa-field-item element--inline field--separator');
-          uiowa_core_set_field_icon($variables, 'fa-circle-info', '', 'Services and buildings affected');
+          uiowa_core_set_field_icon($variables, 'fa-circle-info');
         }
         elseif (!empty($variables['element']['#items']) && empty($variables['element']['#object']->field_alert_building->getValue())) {
           uiowa_core_set_attributes($variables, 'fa-field-item element--inline');
-          uiowa_core_set_field_icon($variables, 'fa-circle-info', '', 'Services affected');
+          uiowa_core_set_field_icon($variables, 'fa-circle-info');
         }
       }
       break;
@@ -630,7 +630,7 @@ function its_core_preprocess_field(&$variables, $hook) {
       if ($variables['element']['#view_mode'] == 'teaser') {
         uiowa_core_set_attributes($variables, 'element--inline');
         if (!empty($variables['element']['#items']) && empty($variables['element']['#object']->field_alert_service_affected->getValue())) {
-          uiowa_core_set_field_icon($variables, 'fa-circle-info', '', 'Buildings affected');
+          uiowa_core_set_field_icon($variables, 'fa-circle-info');
           uiowa_core_set_attributes($variables, 'fa-field-item');
         }
       }

--- a/docroot/themes/custom/uids_base/templates/field/field.html.twig
+++ b/docroot/themes/custom/uids_base/templates/field/field.html.twig
@@ -100,7 +100,7 @@
             <span role="presentation" class="{{ field_icon }} fa-stack-1x"></span>
           </span>
         {% else %}
-          <span role="presentation" {% if field_icon_title %}title="{{ field_icon_title }}"{% endif %} class="field__icon fas {{ field_icon }}"></span>
+          <span role="presentation" class="field__icon fas {{ field_icon }}"></span>
         {% endif %}
       {% endif %}
     {% endblock %}


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/9687. 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev drush @its.local sql-drop -y && ddev blt ds --site=its.uiowa.edu && ddev drush @its.local uli /alerts
```
1. Run Siteimprove plugin on https://its.uiowa.ddev.site/alerts (logged out) and confirm WCAG A - Decorative image is exposed to assistive technologies error is gone. 
2. Inspect code and verify test was run on svg icon markup for the font (logged in is just span version).
3. Inspect code and verify hidden label is rendering `<div class="field__label visually-hidden">Service(s) affected</div>`