### PR TITLE
Skip cancelled Hawk Alerts

### DIFF
--- a/docroot/sites/emergency.uiowa.edu/modules/emergency_core/src/AlertsProcessor.php
+++ b/docroot/sites/emergency.uiowa.edu/modules/emergency_core/src/AlertsProcessor.php
@@ -98,7 +98,7 @@ class AlertsProcessor extends EntityProcessorBase {
     $this->processedRecords[] = $recordSyncKey;
 
     // Alert cancellations should be skipped so they don't
-    // double the existing alert.
+    // create duplicate alerts.
     if ($record['msgType'] === 'Cancel') {
       $this->skipped++;
       static::getLogger('emergency_core')->notice('Alert @identifier skipped (msgType "Cancel").', [

--- a/docroot/sites/emergency.uiowa.edu/modules/emergency_core/src/AlertsProcessor.php
+++ b/docroot/sites/emergency.uiowa.edu/modules/emergency_core/src/AlertsProcessor.php
@@ -97,6 +97,16 @@ class AlertsProcessor extends EntityProcessorBase {
     $recordSyncKey = $record[$this->apiRecordSyncKey];
     $this->processedRecords[] = $recordSyncKey;
 
+    // Alert cancellations should be skipped so they don't
+    // double the existing alert.
+    if ($record['msgType'] === 'Cancel') {
+      $this->skipped++;
+      static::getLogger('emergency_core')->notice('Alert @identifier skipped (msgType "Cancel").', [
+        '@identifier' => $recordSyncKey,
+      ]);
+      return;
+    }
+
     $info = $record['info'];
     $info['identifier'] = $record['identifier'];
     $record = $info;


### PR DESCRIPTION
Resolves #9710 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

```
ddev blt ds --site=emergency.uiowa.edu && ddev drush @emergency.local cset emergency_core.settings rave_endpoint 'https://content.getrave.com/cap/uiowatest' -y &&  ddev drush @emergency.local emergency_core:alerts_import
```
With the current status at the test endpoint, you should see the alert get skipped as it is a "Cancel" type.

In addition to code review, using `xdebug` you can locally alter the retrieved info and change the `msgType` to "Alert" and observe the alert get imported. 