### PR TITLE
[Commencement] Bump up the items per page

### DIFF
--- a/config/sites/commencement.uiowa.edu/views.view.program_archive.yml
+++ b/config/sites/commencement.uiowa.edu/views.view.program_archive.yml
@@ -367,8 +367,8 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          handler: 'default:media'
           widget: autocomplete
+          handler: 'default:media'
           handler_settings:
             target_bundles:
               file: file

--- a/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventsProcessor.php
+++ b/docroot/sites/commencement.uiowa.edu/modules/commencement_core/src/EventsProcessor.php
@@ -76,7 +76,7 @@ class EventsProcessor extends EntityProcessorBase {
             'department' => 329,
             'type' => 28,
           ],
-          'items_per_page' => 100,
+          'items_per_page' => 150,
         ],
       ]);
       if (property_exists($response, 'events') && is_array($response->events)) {


### PR DESCRIPTION
Resolves #9694 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

On `main`

```
ddev blt ds --site=commencement.uiowa.edu && ddev drush @commencement.local import:events && ddev drush @commencement.local uli /admin/content
```
See that there are probably no new events created. Check out the admin content page, see that there are no unpublished events.

```
git checkout commencement-events-pager-bump && git pull && ddev drush @commencement.local import:events
```
See that there is at least one new event created. Check out the admin content page, and see that there is at least one new unpublished event