### PR TITLE
upgrade entity_usage to beta28

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5780,38 +5780,39 @@
         },
         {
             "name": "drupal/entity_usage",
-            "version": "2.0.0-beta16",
+            "version": "2.0.0-beta28",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/entity_usage.git",
-                "reference": "8.x-2.0-beta16"
+                "reference": "8.x-2.0-beta28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/entity_usage-8.x-2.0-beta16.zip",
-                "reference": "8.x-2.0-beta16",
-                "shasum": "af6533149a0926d2d539f279e7e08073f8f08c55"
+                "url": "https://ftp.drupal.org/files/projects/entity_usage-8.x-2.0-beta28.zip",
+                "reference": "8.x-2.0-beta28",
+                "shasum": "7e97367d1c583a41dfab91226e4f688309ae2ce7"
             },
             "require": {
-                "drupal/core": "^10.2 || ^11"
+                "drupal/core": "^10.3 || ^11"
             },
             "require-dev": {
                 "drupal/block_field": "~1.0",
-                "drupal/ckeditor": "^1.0",
-                "drupal/dynamic_entity_reference": "~1.0 || ^2.0 || ^4.0",
+                "drupal/dynamic_entity_reference": "^3.0",
                 "drupal/entity_browser": "~2.0",
-                "drupal/entity_browser_block": "~1.0",
-                "drupal/entity_embed": "~1.0",
+                "drupal/entity_browser_block": "~1.0 || ^2.0",
+                "drupal/entity_embed": "^1.7",
                 "drupal/entity_reference_revisions": "~1.0",
                 "drupal/inline_entity_form": "^1.0@RC || ^3.0@RC",
                 "drupal/paragraphs": "~1.0",
-                "drupal/webform": "^6.0.0-alpha4"
+                "drupal/redirect": "^1.11",
+                "drupal/trash": "~3.0",
+                "drupal/webform": "^6.0.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.0-beta16",
-                    "datestamp": "1733149424",
+                    "version": "8.x-2.0-beta28",
+                    "datestamp": "1771495229",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."


### PR DESCRIPTION
Changelog: https://git.drupalcode.org/project/entity_usage/-/compare/8.x-2.0-beta16...8.x-2.0-beta28?from_project_id=22086

Resolves https://github.com/uiowa/uiowa/issues/9722
Resolves https://github.com/uiowa/uiowa/issues/6509

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

## Existing site

`ddev blt ds --site=sandbox.uiowa.edu`

No config import errors, database updates run successfully.
Re-save admin/config/entity-usage/settings and `drush cex`. Should be identical.
Inspecting the usage table for media or nodes should be more illustrative. Instead of just saying `Content`, it includes the bundle (e.g. Content: Article). Publish status is now consistent across entities and points at the parent entity not the media entity state and updates if the parent entity is unpublished, even if the usage is tied to a previous revision.

Same issue of --Restricted Access-- still occurs when the media entity is attached to a block that is no longer part of the node. Until the page is deleted, that block entity still exists and won't let go of the media usage. https://github.com/uiowa/uiowa/issues/9636

## New install usage

Tests concerns around https://github.com/uiowa/uiowa/issues/9722#issuecomment-4194616762

`ddev blt di --site=default && ddev drush @default.local uli node/4/usage`
See that Demo article is listed in the usage table.
Go to https://default.uiowa.ddev.site/media/8/edit/usage and see two rows of usage.