### PR TITLE
[htaccess] CIF redirect

### DIFF
--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -2,20 +2,6 @@
 # Apache/PHP/Drupal settings:
 #
 
-# Block these IP addresses.
-# https://docs.acquia.com/cloud-platform/arch/security/restrict/#blocking-by-ip-with-mod-rewrite-in-htaccess
-<ifmodule mod_setenvif.c>
-SetEnvIf AH_CLIENT_IP ^193\.42\.33\.66$ DENY=1
-SetEnvIf AH_CLIENT_IP ^47\.76\.209\.138$ DENY=1
-SetEnvIf AH_CLIENT_IP ^47\.76\.99\.127$ DENY=1
-SetEnvIf AH_CLIENT_IP ^91\.108\.194\.40$ DENY=1
-SetEnvIf AH_CLIENT_IP ^47\.76\.220\.119$ DENY=1
-SetEnvIf AH_CLIENT_IP ^47\.76\.222\.244$ DENY=1
-Order allow,deny
-Allow From All
-Deny from env=DENY
-</ifmodule>
-
 # Protect files and directories from prying eyes.
 <FilesMatch "\.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock)|web\.config|yarn\.lock|package\.json)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$">
   <IfModule mod_authz_core.c>
@@ -52,12 +38,6 @@ AddEncoding gzip svgz
   # Cache all files for 1 year after access.
   ExpiresDefault "access plus 1 year"
 
-  # Media entity document file types get 1-hour cache for file overwrites.
-  <FilesMatch "\.(txt|rtf|doc|docx|ppt|pptx|csv|xls|xlsx|pdf|odf|odg|odp|ods|odt|fodt|fods|fodp|fodg|key|numbers|pages|vtt|zip|json|ics|ical)$">
-    ExpiresActive On
-    ExpiresDefault "access plus 1 hour"
-  </FilesMatch>
-
   <FilesMatch \.php$>
     # Do not allow PHP scripts to be cached unless they explicitly send cache
     # headers themselves. Otherwise all scripts would have to overwrite the
@@ -79,114 +59,6 @@ AddEncoding gzip svgz
 # Various rewrite rules.
 <IfModule mod_rewrite.c>
   RewriteEngine on
-
-  # Return a 403 for autodiscover requests.
-  RewriteCond %{REQUEST_URI} /autodiscover/autodiscover.xml [NC]
-  RewriteRule ^ - [F,L]
-
-  # Redirect http(s)://www.domain.com to https://domain.com.
-  RewriteCond %{HTTP_HOST} !\.acquia-sites\.com [NC]
-  RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
-  RewriteRule ^(.*)$ https://%1%{REQUEST_URI} [L,R=301]
-
-  # Redirect all traffic from HTTP to HTTPS.
-  RewriteCond %{HTTP_HOST} !\.acquia-sites\.com [NC]
-  RewriteCond %{HTTPS} off
-  RewriteCond %{HTTP:X-Forwarded-Proto} !https
-  RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
-
-  # Redirect legacy stories site for the homepage.
-  RewriteCond %{HTTP_HOST} ^uiowa.edu$
-  RewriteRule ^stories(.*)$  https://stories.uiowa.edu$1 [R,L]
-
-  # Redirect engineering.uiowa.edu/~ to user.engineering.uiowa.edu for Engineering
-  RewriteCond %{HTTP_HOST} engineering\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteCond %{REQUEST_FILENAME} !-f
-  RewriteCond %{REQUEST_FILENAME} !-d
-  RewriteCond %{REQUEST_URI} /~(.*)
-  RewriteRule ^(.*)$ https://user.engineering.uiowa.edu/$1 [L,R=301]
-
-  # Redirect veterans.org.uiowa.edu to veterans.uiowa.edu/uiva.
-  RewriteCond %{HTTP_HOST} veterans.org.uiowa.edu [NC]
-  RewriteRule ^ https://veterans.uiowa.edu/uiva%{REQUEST_URI} [L,R=301]
-
-  # Redirect trans-resources.org.uiowa.edu to uihc.org/educational-resources/information-transgender-individuals.
-  RewriteCond %{HTTP_HOST} ^trans-resources\.org\.uiowa\.edu$ [NC]
-  RewriteRule ^(.*)$ https://uihc.org/educational-resources/information-transgender-individuals/ [R=301,L]
-
-  # Redirect iconsortium.subst-abuse.uiowa.edu to icsa.uiowa.edu
-  RewriteCond %{HTTP_HOST} iconsortium\.subst-abuse\.uiowa\.edu$ [NC]
-  RewriteRule ^ https://icsa.uiowa.edu/ [L,R=301]
-
-  # Redirect www.(cs|math|stat).uiowa.edu/~ to homepage.divms.uiowa.edu for CS, Math, Stats
-  RewriteCond %{HTTP_HOST} ^(www\.)?(cs|math|stat)\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteCond %{REQUEST_FILENAME} !-f
-  RewriteCond %{REQUEST_FILENAME} !-d
-  RewriteCond %{REQUEST_URI} /~(.*)
-  RewriteRule ^(.*)$ http://homepage.divms.uiowa.edu/$1 [L,R=301]
-
-  # Redirect physics.uiowa.edu/~ to homepage.physics.uiowa.edu for Physics and Astronomy
-  RewriteCond %{HTTP_HOST} physics\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteCond %{REQUEST_FILENAME} !-f
-  RewriteCond %{REQUEST_FILENAME} !-d
-  RewriteCond %{REQUEST_URI} /~(.*)
-  RewriteRule ^(.*)$ http://homepage.physics.uiowa.edu/$1 [L,R=301]
-
-  # Redirect physics.uiowa.edu/itu/* to itu.physics.uiowa.edu/* for Physics and Astronomy ITU
-  RewriteCond %{HTTP_HOST} physics\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteCond %{REQUEST_URI} ^/itu/(.*) [NC,OR]
-  RewriteCond %{REQUEST_URI} ^/itu$ [NC]
-  RewriteRule ^itu(.*)$ https://itu.physics.uiowa.edu/$1 [L,R=301]
-
-  # Redirect www and writinguniversity.org to writing.uiowa.edu.
-  # Preserve path and query.
-  RewriteCond %{HTTP_HOST} ^(www\.|)writinguniversity\.org$ [NC]
-  RewriteRule ^(.*)$ https://writing.uiowa.edu/$1 [L,R=301]
-
-  # Redirect www and writinguniversity.uiowa.edu to writing.uiowa.edu.
-  # Preserve path and query, exclude prod.
-  RewriteCond %{HTTP_HOST} ^(www\.|)writinguniversity\.((stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteRule ^(.*)$ https://writing.uiowa.edu/$1 [L,R=301]
-
-  # Redirect rules for diversity.uiowa.edu.
-  RewriteCond %{HTTP_HOST} diversity\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteRule ^johndeerescholars$ https://provost.uiowa.edu/johndeerescholars [R=301,L]
-
-  RewriteCond %{HTTP_HOST} diversity\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteRule ^programs/student-support/trio-student-support-services$ https://uc.uiowa.edu/trio-student-support-services [R=301,L]
-
-  RewriteCond %{HTTP_HOST} diversity\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteRule ^report$ https://ocrc.uiowa.edu/report [R=301,L]
-
-  RewriteCond %{HTTP_HOST} diversity\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteRule ^programs/high-school-hawkeyes/trio-upward-bound$ https://uc.uiowa.edu/students/trio-upward-bound [R=301,L]
-
-  RewriteCond %{HTTP_HOST} diversity\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteRule ^(.*)$ https://ocrc.uiowa.edu/ [R=301,L]
-
-  # Redirect rules for the IIHR.
-  RewriteCond %{HTTP_HOST} iihr\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteRule ^igs/geosam/(.*)$ https://igs.iihr.uiowa.edu/igs/geosam/$1 [R=301,L]
-
-  RewriteCond %{HTTP_HOST} iihr\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteRule ^igs/geocore/(.*)$ https://igs.iihr.uiowa.edu/igs/geocore/$1 [R=301,L]
-
-  RewriteCond %{HTTP_HOST} iihr\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteRule ^igs/publications/(.*)$ https://igs.iihr.uiowa.edu/igs/publications/$1 [R=301,L]
-
-  # Redirect rules for medicine
-  RewriteCond %{HTTP_HOST} ^(www\.)?medicine\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteRule ^iowaprotocols/?$ https://iowaprotocols.medicine.uiowa.edu [R=301,L]
-
-  RewriteCond %{HTTP_HOST} ^(www\.)?medicine\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteRule ^iowaprotocols/content(/.*)?$ https://iowaprotocols.medicine.uiowa.edu/protocols$1 [R=301,L]
-
-  RewriteCond %{HTTP_HOST} ^(www\.)?medicine\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteRule ^iowaprotocols/(.+)$ https://iowaprotocols.medicine.uiowa.edu/protocols/$1 [R=301,L]
-
-  # Redirect opsmanual.uiowa.edu to policy.uiowa.edu.
-  RewriteCond %{HTTP_HOST} opsmanual\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
-  RewriteRule ^(.*)$ https://policy.uiowa.edu/$1 [L,R=301]
 
   # Set "protossl" to "s" if we were accessed via https://.  This is used later
   # if you enable "www." stripping or enforcement, in order to ensure that
@@ -296,10 +168,6 @@ AddEncoding gzip svgz
       # Force proxies to cache gzipped & non-gzipped css/js files separately.
       Header append Vary Accept-Encoding
     </FilesMatch>
-    # Set CORS for JSON files.
-    <FilesMatch "\.json$">
-      Header set Access-Control-Allow-Origin "*"
-    </FilesMatch>
   </IfModule>
 </IfModule>
 
@@ -315,7 +183,4 @@ AddEncoding gzip svgz
   Header always set X-Content-Type-Options nosniff
   # Disable Proxy header, since it's an attack vector.
   RequestHeader unset Proxy
-  # Declare HTTP Strict Transport Security (STS) header as recommended by Acquia.
-  # https://acquia.my.site.com/s/article/360004119254-How-To-enable-HSTS-for-your-Drupal-site.
-  Header always set Strict-Transport-Security "max-age=31536000;"
 </IfModule>

--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -2,6 +2,20 @@
 # Apache/PHP/Drupal settings:
 #
 
+# Block these IP addresses.
+# https://docs.acquia.com/cloud-platform/arch/security/restrict/#blocking-by-ip-with-mod-rewrite-in-htaccess
+<ifmodule mod_setenvif.c>
+SetEnvIf AH_CLIENT_IP ^193\.42\.33\.66$ DENY=1
+SetEnvIf AH_CLIENT_IP ^47\.76\.209\.138$ DENY=1
+SetEnvIf AH_CLIENT_IP ^47\.76\.99\.127$ DENY=1
+SetEnvIf AH_CLIENT_IP ^91\.108\.194\.40$ DENY=1
+SetEnvIf AH_CLIENT_IP ^47\.76\.220\.119$ DENY=1
+SetEnvIf AH_CLIENT_IP ^47\.76\.222\.244$ DENY=1
+Order allow,deny
+Allow From All
+Deny from env=DENY
+</ifmodule>
+
 # Protect files and directories from prying eyes.
 <FilesMatch "\.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock)|web\.config|yarn\.lock|package\.json)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$">
   <IfModule mod_authz_core.c>
@@ -38,6 +52,12 @@ AddEncoding gzip svgz
   # Cache all files for 1 year after access.
   ExpiresDefault "access plus 1 year"
 
+  # Media entity document file types get 1-hour cache for file overwrites.
+  <FilesMatch "\.(txt|rtf|doc|docx|ppt|pptx|csv|xls|xlsx|pdf|odf|odg|odp|ods|odt|fodt|fods|fodp|fodg|key|numbers|pages|vtt|zip|json|ics|ical)$">
+    ExpiresActive On
+    ExpiresDefault "access plus 1 hour"
+  </FilesMatch>
+
   <FilesMatch \.php$>
     # Do not allow PHP scripts to be cached unless they explicitly send cache
     # headers themselves. Otherwise all scripts would have to overwrite the
@@ -59,6 +79,114 @@ AddEncoding gzip svgz
 # Various rewrite rules.
 <IfModule mod_rewrite.c>
   RewriteEngine on
+
+  # Return a 403 for autodiscover requests.
+  RewriteCond %{REQUEST_URI} /autodiscover/autodiscover.xml [NC]
+  RewriteRule ^ - [F,L]
+
+  # Redirect http(s)://www.domain.com to https://domain.com.
+  RewriteCond %{HTTP_HOST} !\.acquia-sites\.com [NC]
+  RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
+  RewriteRule ^(.*)$ https://%1%{REQUEST_URI} [L,R=301]
+
+  # Redirect all traffic from HTTP to HTTPS.
+  RewriteCond %{HTTP_HOST} !\.acquia-sites\.com [NC]
+  RewriteCond %{HTTPS} off
+  RewriteCond %{HTTP:X-Forwarded-Proto} !https
+  RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
+  # Redirect legacy stories site for the homepage.
+  RewriteCond %{HTTP_HOST} ^uiowa.edu$
+  RewriteRule ^stories(.*)$  https://stories.uiowa.edu$1 [R,L]
+
+  # Redirect engineering.uiowa.edu/~ to user.engineering.uiowa.edu for Engineering
+  RewriteCond %{HTTP_HOST} engineering\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteCond %{REQUEST_URI} /~(.*)
+  RewriteRule ^(.*)$ https://user.engineering.uiowa.edu/$1 [L,R=301]
+
+  # Redirect trans-resources.org.uiowa.edu to uihc.org/educational-resources/information-transgender-individuals.
+  RewriteCond %{HTTP_HOST} ^trans-resources\.org\.uiowa\.edu$ [NC]
+  RewriteRule ^(.*)$ https://uihc.org/educational-resources/information-transgender-individuals/ [R=301,L]
+
+  # Redirect iconsortium.subst-abuse.uiowa.edu to icsa.uiowa.edu
+  RewriteCond %{HTTP_HOST} iconsortium\.subst-abuse\.uiowa\.edu$ [NC]
+  RewriteRule ^ https://icsa.uiowa.edu/ [L,R=301]
+
+  # Redirect www.(cs|math|stat).uiowa.edu/~ to homepage.divms.uiowa.edu for CS, Math, Stats
+  RewriteCond %{HTTP_HOST} ^(www\.)?(cs|math|stat)\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteCond %{REQUEST_URI} /~(.*)
+  RewriteRule ^(.*)$ http://homepage.divms.uiowa.edu/$1 [L,R=301]
+
+  # Redirect physics.uiowa.edu/~ to homepage.physics.uiowa.edu for Physics and Astronomy
+  RewriteCond %{HTTP_HOST} physics\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteCond %{REQUEST_URI} /~(.*)
+  RewriteRule ^(.*)$ http://homepage.physics.uiowa.edu/$1 [L,R=301]
+
+  # Redirect physics.uiowa.edu/itu/* to itu.physics.uiowa.edu/* for Physics and Astronomy ITU
+  RewriteCond %{HTTP_HOST} physics\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteCond %{REQUEST_URI} ^/itu/(.*) [NC,OR]
+  RewriteCond %{REQUEST_URI} ^/itu$ [NC]
+  RewriteRule ^itu(.*)$ https://itu.physics.uiowa.edu/$1 [L,R=301]
+
+  # Redirect www and writinguniversity.org to writing.uiowa.edu.
+  # Preserve path and query.
+  RewriteCond %{HTTP_HOST} ^(www\.|)writinguniversity\.org$ [NC]
+  RewriteRule ^(.*)$ https://writing.uiowa.edu/$1 [L,R=301]
+
+  # Redirect www and writinguniversity.uiowa.edu to writing.uiowa.edu.
+  # Preserve path and query, exclude prod.
+  RewriteCond %{HTTP_HOST} ^(www\.|)writinguniversity\.((stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^(.*)$ https://writing.uiowa.edu/$1 [L,R=301]
+
+  # Redirect rules for diversity.uiowa.edu.
+  RewriteCond %{HTTP_HOST} diversity\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^johndeerescholars$ https://provost.uiowa.edu/johndeerescholars [R=301,L]
+
+  RewriteCond %{HTTP_HOST} diversity\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^programs/student-support/trio-student-support-services$ https://uc.uiowa.edu/trio-student-support-services [R=301,L]
+
+  RewriteCond %{HTTP_HOST} diversity\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^report$ https://ocrc.uiowa.edu/report [R=301,L]
+
+  RewriteCond %{HTTP_HOST} diversity\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^programs/high-school-hawkeyes/trio-upward-bound$ https://uc.uiowa.edu/students/trio-upward-bound [R=301,L]
+
+  RewriteCond %{HTTP_HOST} diversity\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^(.*)$ https://ocrc.uiowa.edu/ [R=301,L]
+
+  # Redirect rules for the IIHR.
+  RewriteCond %{HTTP_HOST} iihr\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^igs/geosam/(.*)$ https://igs.iihr.uiowa.edu/igs/geosam/$1 [R=301,L]
+
+  RewriteCond %{HTTP_HOST} iihr\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^igs/geocore/(.*)$ https://igs.iihr.uiowa.edu/igs/geocore/$1 [R=301,L]
+
+  RewriteCond %{HTTP_HOST} iihr\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^igs/publications/(.*)$ https://igs.iihr.uiowa.edu/igs/publications/$1 [R=301,L]
+
+  # Redirect rules for medicine
+  RewriteCond %{HTTP_HOST} ^(www\.)?medicine\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^iowaprotocols/?$ https://iowaprotocols.medicine.uiowa.edu [R=301,L]
+
+  RewriteCond %{HTTP_HOST} ^(www\.)?medicine\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^iowaprotocols/content(/.*)?$ https://iowaprotocols.medicine.uiowa.edu/protocols$1 [R=301,L]
+
+  RewriteCond %{HTTP_HOST} ^(www\.)?medicine\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^iowaprotocols/(.+)$ https://iowaprotocols.medicine.uiowa.edu/protocols/$1 [R=301,L]
+
+  # Redirect opsmanual.uiowa.edu to policy.uiowa.edu.
+  RewriteCond %{HTTP_HOST} opsmanual\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^(.*)$ https://policy.uiowa.edu/$1 [L,R=301]
+
+  # Redirect intellectualfreedom.center.uiowa.edu to cif.uiowa.edu.
+  RewriteCond %{HTTP_HOST} intellectualfreedom\.center\.uiowa\.edu$ [NC]
+  RewriteRule ^(.*)$ https://cif.uiowa.edu/$1 [L,R=301]
 
   # Set "protossl" to "s" if we were accessed via https://.  This is used later
   # if you enable "www." stripping or enforcement, in order to ensure that
@@ -168,6 +296,10 @@ AddEncoding gzip svgz
       # Force proxies to cache gzipped & non-gzipped css/js files separately.
       Header append Vary Accept-Encoding
     </FilesMatch>
+    # Set CORS for JSON files.
+    <FilesMatch "\.json$">
+      Header set Access-Control-Allow-Origin "*"
+    </FilesMatch>
   </IfModule>
 </IfModule>
 
@@ -183,4 +315,7 @@ AddEncoding gzip svgz
   Header always set X-Content-Type-Options nosniff
   # Disable Proxy header, since it's an attack vector.
   RequestHeader unset Proxy
+  # Declare HTTP Strict Transport Security (STS) header as recommended by Acquia.
+  # https://acquia.my.site.com/s/article/360004119254-How-To-enable-HSTS-for-your-Drupal-site.
+  Header always set Strict-Transport-Security "max-age=31536000;"
 </IfModule>

--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -106,6 +106,10 @@ AddEncoding gzip svgz
   RewriteCond %{REQUEST_URI} /~(.*)
   RewriteRule ^(.*)$ https://user.engineering.uiowa.edu/$1 [L,R=301]
 
+  # Redirect veterans.org.uiowa.edu to veterans.uiowa.edu/uiva.
+  RewriteCond %{HTTP_HOST} veterans.org.uiowa.edu [NC]
+  RewriteRule ^ https://veterans.uiowa.edu/uiva%{REQUEST_URI} [L,R=301]
+
   # Redirect trans-resources.org.uiowa.edu to uihc.org/educational-resources/information-transgender-individuals.
   RewriteCond %{HTTP_HOST} ^trans-resources\.org\.uiowa\.edu$ [NC]
   RewriteRule ^(.*)$ https://uihc.org/educational-resources/information-transgender-individuals/ [R=301,L]
@@ -183,10 +187,6 @@ AddEncoding gzip svgz
   # Redirect opsmanual.uiowa.edu to policy.uiowa.edu.
   RewriteCond %{HTTP_HOST} opsmanual\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
   RewriteRule ^(.*)$ https://policy.uiowa.edu/$1 [L,R=301]
-
-  # Redirect intellectualfreedom.center.uiowa.edu to cif.uiowa.edu.
-  RewriteCond %{HTTP_HOST} intellectualfreedom\.center\.uiowa\.edu$ [NC]
-  RewriteRule ^(.*)$ https://cif.uiowa.edu/$1 [L,R=301]
 
   # Set "protossl" to "s" if we were accessed via https://.  This is used later
   # if you enable "www." stripping or enforcement, in order to ensure that

--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -2,6 +2,20 @@
 # Apache/PHP/Drupal settings:
 #
 
+# Block these IP addresses.
+# https://docs.acquia.com/cloud-platform/arch/security/restrict/#blocking-by-ip-with-mod-rewrite-in-htaccess
+<ifmodule mod_setenvif.c>
+SetEnvIf AH_CLIENT_IP ^193\.42\.33\.66$ DENY=1
+SetEnvIf AH_CLIENT_IP ^47\.76\.209\.138$ DENY=1
+SetEnvIf AH_CLIENT_IP ^47\.76\.99\.127$ DENY=1
+SetEnvIf AH_CLIENT_IP ^91\.108\.194\.40$ DENY=1
+SetEnvIf AH_CLIENT_IP ^47\.76\.220\.119$ DENY=1
+SetEnvIf AH_CLIENT_IP ^47\.76\.222\.244$ DENY=1
+Order allow,deny
+Allow From All
+Deny from env=DENY
+</ifmodule>
+
 # Protect files and directories from prying eyes.
 <FilesMatch "\.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock)|web\.config|yarn\.lock|package\.json)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$">
   <IfModule mod_authz_core.c>
@@ -38,6 +52,12 @@ AddEncoding gzip svgz
   # Cache all files for 1 year after access.
   ExpiresDefault "access plus 1 year"
 
+  # Media entity document file types get 1-hour cache for file overwrites.
+  <FilesMatch "\.(txt|rtf|doc|docx|ppt|pptx|csv|xls|xlsx|pdf|odf|odg|odp|ods|odt|fodt|fods|fodp|fodg|key|numbers|pages|vtt|zip|json|ics|ical)$">
+    ExpiresActive On
+    ExpiresDefault "access plus 1 hour"
+  </FilesMatch>
+
   <FilesMatch \.php$>
     # Do not allow PHP scripts to be cached unless they explicitly send cache
     # headers themselves. Otherwise all scripts would have to overwrite the
@@ -59,6 +79,114 @@ AddEncoding gzip svgz
 # Various rewrite rules.
 <IfModule mod_rewrite.c>
   RewriteEngine on
+
+  # Return a 403 for autodiscover requests.
+  RewriteCond %{REQUEST_URI} /autodiscover/autodiscover.xml [NC]
+  RewriteRule ^ - [F,L]
+
+  # Redirect http(s)://www.domain.com to https://domain.com.
+  RewriteCond %{HTTP_HOST} !\.acquia-sites\.com [NC]
+  RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
+  RewriteRule ^(.*)$ https://%1%{REQUEST_URI} [L,R=301]
+
+  # Redirect all traffic from HTTP to HTTPS.
+  RewriteCond %{HTTP_HOST} !\.acquia-sites\.com [NC]
+  RewriteCond %{HTTPS} off
+  RewriteCond %{HTTP:X-Forwarded-Proto} !https
+  RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
+  # Redirect legacy stories site for the homepage.
+  RewriteCond %{HTTP_HOST} ^uiowa.edu$
+  RewriteRule ^stories(.*)$  https://stories.uiowa.edu$1 [R,L]
+
+  # Redirect engineering.uiowa.edu/~ to user.engineering.uiowa.edu for Engineering
+  RewriteCond %{HTTP_HOST} engineering\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteCond %{REQUEST_URI} /~(.*)
+  RewriteRule ^(.*)$ https://user.engineering.uiowa.edu/$1 [L,R=301]
+
+  # Redirect trans-resources.org.uiowa.edu to uihc.org/educational-resources/information-transgender-individuals.
+  RewriteCond %{HTTP_HOST} ^trans-resources\.org\.uiowa\.edu$ [NC]
+  RewriteRule ^(.*)$ https://uihc.org/educational-resources/information-transgender-individuals/ [R=301,L]
+
+  # Redirect iconsortium.subst-abuse.uiowa.edu to icsa.uiowa.edu
+  RewriteCond %{HTTP_HOST} iconsortium\.subst-abuse\.uiowa\.edu$ [NC]
+  RewriteRule ^ https://icsa.uiowa.edu/ [L,R=301]
+
+  # Redirect www.(cs|math|stat).uiowa.edu/~ to homepage.divms.uiowa.edu for CS, Math, Stats
+  RewriteCond %{HTTP_HOST} ^(www\.)?(cs|math|stat)\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteCond %{REQUEST_URI} /~(.*)
+  RewriteRule ^(.*)$ http://homepage.divms.uiowa.edu/$1 [L,R=301]
+
+  # Redirect physics.uiowa.edu/~ to homepage.physics.uiowa.edu for Physics and Astronomy
+  RewriteCond %{HTTP_HOST} physics\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteCond %{REQUEST_URI} /~(.*)
+  RewriteRule ^(.*)$ http://homepage.physics.uiowa.edu/$1 [L,R=301]
+
+  # Redirect physics.uiowa.edu/itu/* to itu.physics.uiowa.edu/* for Physics and Astronomy ITU
+  RewriteCond %{HTTP_HOST} physics\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteCond %{REQUEST_URI} ^/itu/(.*) [NC,OR]
+  RewriteCond %{REQUEST_URI} ^/itu$ [NC]
+  RewriteRule ^itu(.*)$ https://itu.physics.uiowa.edu/$1 [L,R=301]
+
+  # Redirect www and writinguniversity.org to writing.uiowa.edu.
+  # Preserve path and query.
+  RewriteCond %{HTTP_HOST} ^(www\.|)writinguniversity\.org$ [NC]
+  RewriteRule ^(.*)$ https://writing.uiowa.edu/$1 [L,R=301]
+
+  # Redirect www and writinguniversity.uiowa.edu to writing.uiowa.edu.
+  # Preserve path and query, exclude prod.
+  RewriteCond %{HTTP_HOST} ^(www\.|)writinguniversity\.((stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^(.*)$ https://writing.uiowa.edu/$1 [L,R=301]
+
+  # Redirect rules for diversity.uiowa.edu.
+  RewriteCond %{HTTP_HOST} diversity\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^johndeerescholars$ https://provost.uiowa.edu/johndeerescholars [R=301,L]
+
+  RewriteCond %{HTTP_HOST} diversity\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^programs/student-support/trio-student-support-services$ https://uc.uiowa.edu/trio-student-support-services [R=301,L]
+
+  RewriteCond %{HTTP_HOST} diversity\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^report$ https://ocrc.uiowa.edu/report [R=301,L]
+
+  RewriteCond %{HTTP_HOST} diversity\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^programs/high-school-hawkeyes/trio-upward-bound$ https://uc.uiowa.edu/students/trio-upward-bound [R=301,L]
+
+  RewriteCond %{HTTP_HOST} diversity\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^(.*)$ https://ocrc.uiowa.edu/ [R=301,L]
+
+  # Redirect rules for the IIHR.
+  RewriteCond %{HTTP_HOST} iihr\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^igs/geosam/(.*)$ https://igs.iihr.uiowa.edu/igs/geosam/$1 [R=301,L]
+
+  RewriteCond %{HTTP_HOST} iihr\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^igs/geocore/(.*)$ https://igs.iihr.uiowa.edu/igs/geocore/$1 [R=301,L]
+
+  RewriteCond %{HTTP_HOST} iihr\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^igs/publications/(.*)$ https://igs.iihr.uiowa.edu/igs/publications/$1 [R=301,L]
+
+  # Redirect rules for medicine
+  RewriteCond %{HTTP_HOST} ^(www\.)?medicine\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^iowaprotocols/?$ https://iowaprotocols.medicine.uiowa.edu [R=301,L]
+
+  RewriteCond %{HTTP_HOST} ^(www\.)?medicine\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^iowaprotocols/content(/.*)?$ https://iowaprotocols.medicine.uiowa.edu/protocols$1 [R=301,L]
+
+  RewriteCond %{HTTP_HOST} ^(www\.)?medicine\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^iowaprotocols/(.+)$ https://iowaprotocols.medicine.uiowa.edu/protocols/$1 [R=301,L]
+
+  # Redirect opsmanual.uiowa.edu to policy.uiowa.edu.
+  RewriteCond %{HTTP_HOST} ^opsmanual\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
+  RewriteRule ^(.*)$ https://policy.uiowa.edu/$1 [L,R=301]
+
+  # Redirect intellectualfreedom.center.uiowa.edu to cif.uiowa.edu.
+  RewriteCond %{HTTP_HOST} ^intellectualfreedom\.center\.uiowa\.edu$ [NC]
+  RewriteRule ^(.*)$ https://cif.uiowa.edu/$1 [L,R=301]
 
   # Set "protossl" to "s" if we were accessed via https://.  This is used later
   # if you enable "www." stripping or enforcement, in order to ensure that
@@ -168,6 +296,10 @@ AddEncoding gzip svgz
       # Force proxies to cache gzipped & non-gzipped css/js files separately.
       Header append Vary Accept-Encoding
     </FilesMatch>
+    # Set CORS for JSON files.
+    <FilesMatch "\.json$">
+      Header set Access-Control-Allow-Origin "*"
+    </FilesMatch>
   </IfModule>
 </IfModule>
 
@@ -183,4 +315,7 @@ AddEncoding gzip svgz
   Header always set X-Content-Type-Options nosniff
   # Disable Proxy header, since it's an attack vector.
   RequestHeader unset Proxy
+  # Declare HTTP Strict Transport Security (STS) header as recommended by Acquia.
+  # https://acquia.my.site.com/s/article/360004119254-How-To-enable-HSTS-for-your-Drupal-site.
+  Header always set Strict-Transport-Security "max-age=31536000;"
 </IfModule>

--- a/patches/core_htaccess.patch
+++ b/patches/core_htaccess.patch
@@ -1,5 +1,5 @@
 diff --git a/docroot/.htaccess b/docroot/.htaccess
-index 4031da475..ddd081a5e 100644
+index 4031da475..d1b0cb226 100644
 --- a/docroot/.htaccess
 +++ b/docroot/.htaccess
 @@ -2,6 +2,20 @@
@@ -65,6 +65,10 @@ index 4031da475..ddd081a5e 100644
 +  RewriteCond %{REQUEST_FILENAME} !-d
 +  RewriteCond %{REQUEST_URI} /~(.*)
 +  RewriteRule ^(.*)$ https://user.engineering.uiowa.edu/$1 [L,R=301]
++
++  # Redirect veterans.org.uiowa.edu to veterans.uiowa.edu/uiva.
++  RewriteCond %{HTTP_HOST} veterans.org.uiowa.edu [NC]
++  RewriteRule ^ https://veterans.uiowa.edu/uiva%{REQUEST_URI} [L,R=301]
 +
 +  # Redirect trans-resources.org.uiowa.edu to uihc.org/educational-resources/information-transgender-individuals.
 +  RewriteCond %{HTTP_HOST} ^trans-resources\.org\.uiowa\.edu$ [NC]
@@ -143,10 +147,6 @@ index 4031da475..ddd081a5e 100644
 +  # Redirect opsmanual.uiowa.edu to policy.uiowa.edu.
 +  RewriteCond %{HTTP_HOST} opsmanual\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
 +  RewriteRule ^(.*)$ https://policy.uiowa.edu/$1 [L,R=301]
-+
-+  # Redirect intellectualfreedom.center.uiowa.edu to cif.uiowa.edu.
-+  RewriteCond %{HTTP_HOST} intellectualfreedom\.center\.uiowa\.edu$ [NC]
-+  RewriteRule ^(.*)$ https://cif.uiowa.edu/$1 [L,R=301]
 +
    # Set "protossl" to "s" if we were accessed via https://.  This is used later
    # if you enable "www." stripping or enforcement, in order to ensure that

--- a/patches/core_htaccess.patch
+++ b/patches/core_htaccess.patch
@@ -1,5 +1,5 @@
 diff --git a/docroot/.htaccess b/docroot/.htaccess
-index 4031da475..d1b0cb226 100644
+index 4031da475..ddd081a5e 100644
 --- a/docroot/.htaccess
 +++ b/docroot/.htaccess
 @@ -2,6 +2,20 @@
@@ -65,10 +65,6 @@ index 4031da475..d1b0cb226 100644
 +  RewriteCond %{REQUEST_FILENAME} !-d
 +  RewriteCond %{REQUEST_URI} /~(.*)
 +  RewriteRule ^(.*)$ https://user.engineering.uiowa.edu/$1 [L,R=301]
-+
-+  # Redirect veterans.org.uiowa.edu to veterans.uiowa.edu/uiva.
-+  RewriteCond %{HTTP_HOST} veterans.org.uiowa.edu [NC]
-+  RewriteRule ^ https://veterans.uiowa.edu/uiva%{REQUEST_URI} [L,R=301]
 +
 +  # Redirect trans-resources.org.uiowa.edu to uihc.org/educational-resources/information-transgender-individuals.
 +  RewriteCond %{HTTP_HOST} ^trans-resources\.org\.uiowa\.edu$ [NC]
@@ -147,6 +143,10 @@ index 4031da475..d1b0cb226 100644
 +  # Redirect opsmanual.uiowa.edu to policy.uiowa.edu.
 +  RewriteCond %{HTTP_HOST} opsmanual\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
 +  RewriteRule ^(.*)$ https://policy.uiowa.edu/$1 [L,R=301]
++
++  # Redirect intellectualfreedom.center.uiowa.edu to cif.uiowa.edu.
++  RewriteCond %{HTTP_HOST} intellectualfreedom\.center\.uiowa\.edu$ [NC]
++  RewriteRule ^(.*)$ https://cif.uiowa.edu/$1 [L,R=301]
 +
    # Set "protossl" to "s" if we were accessed via https://.  This is used later
    # if you enable "www." stripping or enforcement, in order to ensure that

--- a/patches/core_htaccess.patch
+++ b/patches/core_htaccess.patch
@@ -1,5 +1,5 @@
 diff --git a/docroot/.htaccess b/docroot/.htaccess
-index 4031da475..d1b0cb226 100644
+index 4031da475..f3d9f9e3d 100644
 --- a/docroot/.htaccess
 +++ b/docroot/.htaccess
 @@ -2,6 +2,20 @@
@@ -65,10 +65,6 @@ index 4031da475..d1b0cb226 100644
 +  RewriteCond %{REQUEST_FILENAME} !-d
 +  RewriteCond %{REQUEST_URI} /~(.*)
 +  RewriteRule ^(.*)$ https://user.engineering.uiowa.edu/$1 [L,R=301]
-+
-+  # Redirect veterans.org.uiowa.edu to veterans.uiowa.edu/uiva.
-+  RewriteCond %{HTTP_HOST} veterans.org.uiowa.edu [NC]
-+  RewriteRule ^ https://veterans.uiowa.edu/uiva%{REQUEST_URI} [L,R=301]
 +
 +  # Redirect trans-resources.org.uiowa.edu to uihc.org/educational-resources/information-transgender-individuals.
 +  RewriteCond %{HTTP_HOST} ^trans-resources\.org\.uiowa\.edu$ [NC]
@@ -145,8 +141,12 @@ index 4031da475..d1b0cb226 100644
 +  RewriteRule ^iowaprotocols/(.+)$ https://iowaprotocols.medicine.uiowa.edu/protocols/$1 [R=301,L]
 +
 +  # Redirect opsmanual.uiowa.edu to policy.uiowa.edu.
-+  RewriteCond %{HTTP_HOST} opsmanual\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
++  RewriteCond %{HTTP_HOST} ^opsmanual\.((prod|stage|dev)\.drupal\.)?uiowa\.edu$ [NC]
 +  RewriteRule ^(.*)$ https://policy.uiowa.edu/$1 [L,R=301]
++
++  # Redirect intellectualfreedom.center.uiowa.edu to cif.uiowa.edu.
++  RewriteCond %{HTTP_HOST} ^intellectualfreedom\.center\.uiowa\.edu$ [NC]
++  RewriteRule ^(.*)$ https://cif.uiowa.edu/$1 [L,R=301]
 +
    # Set "protossl" to "s" if we were accessed via https://.  This is used later
    # if you enable "www." stripping or enforcement, in order to ensure that


### PR DESCRIPTION
Relates to #9780 
Relates to #9743 
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

Review and test with:

<!-- Include detailed steps for how to test this PR. -->
https://htaccess.madewithlove.com?share=0ddbe5f9-ecfc-42d1-a401-ff3e0a6c63b7

the veterans.org.uiowa.edu redirect should be removed completely.
`intellectualfreedom.center.uiowa.edu/*` should redirect to `cif.uiowa.edu/*`, including path-matching
Subdomains from it, like `unintended.intellectualfreedom.center.uiowa.edu/*` should not be redirected.

Similarly, the `opsmanual.uiowa.edu/*` redirect should still work, directing to `policy.uiowa.edu/*`, 
where subdomains from it, like `unintended.opsmanual.uiowa.edu/*` should not be redirected.

Note: As is, it's not available to test in dev https://iowaweb.slack.com/archives/C0164FNN1PV/p1777651380456819