### PR TITLE
[Signage] Add room number to events slides

### DIFF
--- a/config/sites/signage.sites.uiowa.edu/core.entity_form_display.paragraph.slide_events.default.yml
+++ b/config/sites/signage.sites.uiowa.edu/core.entity_form_display.paragraph.slide_events.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.paragraph.slide_events.field_slide_events_interests
     - field.field.paragraph.slide_events.field_slide_events_keywords
     - field.field.paragraph.slide_events.field_slide_events_location
+    - field.field.paragraph.slide_events.field_slide_events_room_num
     - field.field.paragraph.slide_events.field_slide_events_types
     - paragraphs.paragraphs_type.slide_events
 id: paragraph.slide_events.default
@@ -53,6 +54,13 @@ content:
     weight: 5
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_slide_events_room_num:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_slide_events_types:
     type: options_select

--- a/config/sites/signage.sites.uiowa.edu/core.entity_view_display.paragraph.slide_events.default.yml
+++ b/config/sites/signage.sites.uiowa.edu/core.entity_view_display.paragraph.slide_events.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.paragraph.slide_events.field_slide_events_interests
     - field.field.paragraph.slide_events.field_slide_events_keywords
     - field.field.paragraph.slide_events.field_slide_events_location
+    - field.field.paragraph.slide_events.field_slide_events_room_num
     - field.field.paragraph.slide_events.field_slide_events_types
     - paragraphs.paragraphs_type.slide_events
 id: paragraph.slide_events.default
@@ -33,5 +34,6 @@ hidden:
   field_slide_events_interests: true
   field_slide_events_keywords: true
   field_slide_events_location: true
+  field_slide_events_room_num: true
   field_slide_events_types: true
   search_api_excerpt: true

--- a/config/sites/signage.sites.uiowa.edu/field.field.paragraph.slide_events.field_slide_events_room_num.yml
+++ b/config/sites/signage.sites.uiowa.edu/field.field.paragraph.slide_events.field_slide_events_room_num.yml
@@ -1,0 +1,23 @@
+uuid: 477b2918-cd3d-44ad-89b2-1c7ed2058903
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_slide_events_room_num
+    - paragraphs.paragraphs_type.slide_events
+id: paragraph.slide_events.field_slide_events_room_num
+field_name: field_slide_events_room_num
+entity_type: paragraph
+bundle: slide_events
+label: 'Display room number'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sites/signage.sites.uiowa.edu/field.storage.paragraph.field_slide_events_room_num.yml
+++ b/config/sites/signage.sites.uiowa.edu/field.storage.paragraph.field_slide_events_room_num.yml
@@ -1,0 +1,18 @@
+uuid: edc3397a-6dc9-4c68-9d88-0bf7a5cae64c
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_slide_events_room_num
+field_name: field_slide_events_room_num
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/sitenow_events/sitenow_events.module
+++ b/docroot/modules/custom/sitenow_events/sitenow_events.module
@@ -518,7 +518,7 @@ function sitenow_events_preprocess_node__event(&$variables) {
 /**
  * Helper function to build out card renders from event data.
  */
-function sitenow_events_build_card(array $event): array {
+function sitenow_events_build_card(array $event, bool $include_room_number = FALSE): array {
 
   // Construct event link based on site-wide configuration.
   $external_link = ($event['sitenow_events_config']->get('event_link') === 'event-link-external');
@@ -598,14 +598,21 @@ function sitenow_events_build_card(array $event): array {
       '#markup' => t('Virtual'),
     ];
   }
-  elseif (!is_null($event["location_name"])) {
+  elseif (!is_null($event['location_name'])) {
+    // If we're including the room number,
+    // append it to the location name.
+    $location_name = $event['location_name'];
+    if ($include_room_number && !is_null($event['room_number'])) {
+      $location_name = implode(' - ', [$location_name, $event['room_number']]);
+    }
+
     $card['#meta']['icon'] = [
       '#type' => 'markup',
       '#markup' => '<span role="presentation" class="fas fa-map-marker-alt"></span>',
     ];
     $card['#meta']['location'] = [
       '#type' => 'markup',
-      '#markup' => $event['location_name'],
+      '#markup' => $location_name,
     ];
   }
 

--- a/docroot/modules/custom/sitenow_signage/sitenow_signage.module
+++ b/docroot/modules/custom/sitenow_signage/sitenow_signage.module
@@ -824,6 +824,15 @@ function sitenow_signage_preprocess_paragraph(&$variables) {
             }
           }
 
+          // If it is marked to display the room number,
+          // append it to the location name before
+          // creating the card.
+          if ($paragraph?->field_slide_events_room_num?->value) {
+            if (!is_null($event['location_name']) && !is_null($event['room_number'])) {
+              $event['location_name'] = implode(' - ', [$event['location_name'], $event['room_number']]);
+            }
+          }
+
           $variables['content'][] = sitenow_events_build_card($event);
         }
       }

--- a/docroot/modules/custom/sitenow_signage/sitenow_signage.module
+++ b/docroot/modules/custom/sitenow_signage/sitenow_signage.module
@@ -824,16 +824,8 @@ function sitenow_signage_preprocess_paragraph(&$variables) {
             }
           }
 
-          // If it is marked to display the room number,
-          // append it to the location name before
-          // creating the card.
-          if ($paragraph?->field_slide_events_room_num?->value) {
-            if (!is_null($event['location_name']) && !is_null($event['room_number'])) {
-              $event['location_name'] = implode(' - ', [$event['location_name'], $event['room_number']]);
-            }
-          }
-
-          $variables['content'][] = sitenow_events_build_card($event);
+          $include_room_number = (bool) $paragraph?->field_slide_events_room_num?->value;
+          $variables['content'][] = sitenow_events_build_card($event, $include_room_number);
         }
       }
       else {
@@ -888,7 +880,8 @@ function sitenow_signage_preprocess_paragraph(&$variables) {
           if (isset($room['value'])) {
             $building_and_room = explode('-', $room['value']);
 
-            // We add them this way so that we don't have duplicates in the array.
+            // We add them this way so that
+            // we don't have duplicates in the array.
             $building_and_room[0] ? $request_body['buildingIds'][$building_and_room[0]] = 0 : NULL;
             $building_and_room[1] ? $request_body['roomIds'][$building_and_room[1]] = 0 : NULL;
           }


### PR DESCRIPTION
Resolves #9677 

<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

```
ddev blt ds --site=signage.sites.uiowa.edu && ddev drush @sitessignage.local uli /node/2251
```

- Clean sync, and see that the sign doesn't include room numbers (default state for existing signs, and an empty field)
- Edit the sign, edit the slide, and check to "display room number"
- See that the room numbers are now displaying (non-default state, field to true)
- Repeat, and turn the "display room number" back off
- See that the room numbers no longer display (non-default state, field to false)
- Try adding a new events slide, with and without the room number, and see that it displays correctly
- Check an events block (such as at https://sandbox.uiowa.ddev.site/extra-events-testing), and see that the room number is not displaying