### PR TITLE
Menu keyboard focus indicator.

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/brand-bar.scss
+++ b/docroot/themes/custom/uids_base/scss/components/brand-bar.scss
@@ -9,6 +9,10 @@
   }
 }
 
+.iowa-bar {
+  z-index: 3;
+}
+
 .iowa-bar--narrow .site_name--wrapper {
   border-bottom: 1px solid #e6e5e5;
 }

--- a/docroot/themes/custom/uids_base/scss/components/menus/superfish/superfish.scss
+++ b/docroot/themes/custom/uids_base/scss/components/menus/superfish/superfish.scss
@@ -300,6 +300,17 @@ ul.sf-menu.sf-horizontal > li:hover > a:after {
   left: 0;
   width: 100%;
   height: 5px;
+}
+
+ul.sf-menu.sf-horizontal > li.sfHover > .nolink:after,
+ul.sf-menu.sf-horizontal > li.sfHover > a:after {
+  background: variables.$secondary;
+}
+
+ul.sf-menu.sf-horizontal > li > .nolink:focus:after,
+ul.sf-menu.sf-horizontal > li > a:focus:after,
+ul.sf-menu.sf-horizontal > li:hover > .nolink:after,
+ul.sf-menu.sf-horizontal > li:hover > a:after {
   background: variables.$primary;
 }
 

--- a/docroot/themes/custom/uids_base/scss/components/menus/superfish/superfish.scss
+++ b/docroot/themes/custom/uids_base/scss/components/menus/superfish/superfish.scss
@@ -309,8 +309,8 @@ ul.sf-menu.sf-horizontal > li.sfHover > a:after {
 
 ul.sf-menu.sf-horizontal > li > .nolink:focus:after,
 ul.sf-menu.sf-horizontal > li > a:focus:after,
-ul.sf-menu.sf-horizontal > li:hover > .nolink:after,
-ul.sf-menu.sf-horizontal > li:hover > a:after {
+ul.sf-menu.sf-horizontal > li:hover:not(:has(ul li:hover)) > .nolink:after,
+ul.sf-menu.sf-horizontal > li:hover:not(:has(ul li:hover)) > a:after {
   background: variables.$primary;
 }
 

--- a/docroot/themes/custom/uids_base/scss/components/menus/superfish/superfish.scss
+++ b/docroot/themes/custom/uids_base/scss/components/menus/superfish/superfish.scss
@@ -519,10 +519,6 @@ ul.sf-menu.sf-accordion .active-trail.sf-no-children.sf-depth-1 > .is-active {
   padding: 0.9rem 0;
 }
 
-.menu.sf-accordion > li > a {
-  display: inline-block;
-}
-
 .menu.sf-accordion > li > .nolink::after,
 .menu.sf-accordion > li > a::after,
 .menu.sf-accordion > li > span::after {

--- a/docroot/themes/custom/uids_base/scss/components/menus/superfish/superfish.scss
+++ b/docroot/themes/custom/uids_base/scss/components/menus/superfish/superfish.scss
@@ -519,17 +519,23 @@ ul.sf-menu.sf-accordion .active-trail.sf-no-children.sf-depth-1 > .is-active {
   padding: 0.9rem 0;
 }
 
-.menu.sf-accordion > li > .nolink::after,
-.menu.sf-accordion > li > a::after,
-.menu.sf-accordion > li > span::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: 100%;
-  height: 100%;
+.menu.sf-accordion > li > .nolink,
+.menu.sf-accordion > li > a,
+.menu.sf-accordion > li > span {
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    height: 5px;
+    transition: 0s;
+  }
+
+  &:focus::after {
+    background: variables.$primary;
+  }
 }
 
 .block-superfish .menu.sf-accordion > li > .sf-depth-1.menuparent {


### PR DESCRIPTION
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

## Setup
1. check out this branch
2. ddev composer install
3. ddev blt frontend
4. sync performingarts.uiowa.edu

## Horizontal
1. Check that when you tab through the menu that when you go by a nolink that you still get focus as gold underline while focused on it, and black as you move away.
2. Same as above, but with hovering.

## Megamenu
1. Check the same things as horizontal.

## Toggle
1. Tab through the toggle menu and see that the menu items do not open side by side, unlike the prod site.
2. Tab through the menu and see that when you are focusing on top level items that they have a gold border underline, unlike the prod site.
3. Ensure that you cannot see or interact with the play button through the toggle menu, unlike the prod site.

## Extra points
1. Break things?
2. ???
3. Profit.