### PR TITLE
Keyboard focus indicator

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/brand-bar.scss
+++ b/docroot/themes/custom/uids_base/scss/components/brand-bar.scss
@@ -9,6 +9,10 @@
   }
 }
 
+.iowa-bar {
+  z-index: 3;
+}
+
 .iowa-bar--narrow .site_name--wrapper {
   border-bottom: 1px solid #e6e5e5;
 }

--- a/docroot/themes/custom/uids_base/scss/components/menus/superfish/superfish.scss
+++ b/docroot/themes/custom/uids_base/scss/components/menus/superfish/superfish.scss
@@ -468,6 +468,13 @@ ul.sf-accordion ul:focus-within {
   }
 }
 
+// Add a dotted outline on focus for level 1 nolink menu items.
+.block-superfish .menu li.sf-depth-1 > .nolink {
+  &:focus {
+    outline: 1px dotted;
+  }
+}
+
 .block-superfish .menu li li .nolink:focus {
   font-weight: bold;
 }
@@ -483,6 +490,13 @@ ul.sf-accordion ul:focus-within {
 .block-superfish .menu.sf-accordion li .nolink,
 .block-superfish .menu.sf-accordion li a {
   line-height: 1.3;
+}
+
+// Add a dotted outline on focus for nolink menu items in the mobile accordion.
+.block-superfish .menu.sf-accordion li > .nolink {
+  &:focus {
+    outline: 1px dotted;
+  }
 }
 
 .menu.sf-accordion ul li a.is-active {

--- a/docroot/themes/custom/uids_base/scss/components/menus/superfish/superfish.scss
+++ b/docroot/themes/custom/uids_base/scss/components/menus/superfish/superfish.scss
@@ -524,21 +524,19 @@ ul.sf-menu.sf-accordion .active-trail.sf-no-children.sf-depth-1 > .is-active {
   padding: 0.9rem 0;
 }
 
-.menu.sf-accordion > li > a {
-  display: inline-block;
-}
-
-.menu.sf-accordion > li > .nolink::after,
-.menu.sf-accordion > li > a::after,
-.menu.sf-accordion > li > span::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: 100%;
-  height: 100%;
+.menu.sf-accordion > li > .nolink,
+.menu.sf-accordion > li > a,
+.menu.sf-accordion > li > span {
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    height: 5px;
+    transition: 0s;
+  }
 }
 
 .block-superfish .menu.sf-accordion > li > .sf-depth-1.menuparent {

--- a/docroot/themes/custom/uids_base/scss/components/menus/superfish/superfish.scss
+++ b/docroot/themes/custom/uids_base/scss/components/menus/superfish/superfish.scss
@@ -291,10 +291,12 @@ ul.sf-menu.sf-horizontal > li.active-trail > .sf-depth-1:hover:after {
 
 ul.sf-menu.sf-horizontal > li.sfHover > .nolink:after,
 ul.sf-menu.sf-horizontal > li.sfHover > a:after,
-ul.sf-menu.sf-horizontal > li:focus > .nolink:focus:after,
-ul.sf-menu.sf-horizontal > li:focus > a:focus:after,
 ul.sf-menu.sf-horizontal > li:hover > .nolink:after,
-ul.sf-menu.sf-horizontal > li:hover > a:after {
+ul.sf-menu.sf-horizontal > li:hover > a:after,
+ul.sf-menu.sf-horizontal > li > .nolink:focus:after,
+ul.sf-menu.sf-horizontal > li > a:focus:after,
+ul.sf-menu.sf-horizontal > li:focus-within > .nolink:after,
+ul.sf-menu.sf-horizontal > li:focus-within > a:after {
   position: absolute;
   bottom: 0;
   left: 0;


### PR DESCRIPTION
resolves #9665 

# How to test

1. check out this branch
2. Sync the Performing Arts site: `ddev composer install && ddev blt ds --site=performingarts.uiowa.edu && ddev drush @performingarts.local uli`
3. `ddev blt frontend`

Use the browser Inspect tool to test the :focus state of the first menu "Explore Departments". The :focus state should have a gold underline and and outline.

This also includes a fix for the play/pause banner button on the homepage showing up in the Toggle navigation. Switch to the Toggle navigation in the Settings and review the homepage.
