### PR TITLE
[Search Results] increase contrast for sort by function

### DIFF
--- a/docroot/themes/custom/uids_base/scss/components/search-results.scss
+++ b/docroot/themes/custom/uids_base/scss/components/search-results.scss
@@ -51,6 +51,10 @@
 #search-results .gsc-orderby-container {
   padding-right: 0;
 }
+
+#search-results .gsc-orderby-label .gsc-inline-block {
+  color: variables.$brand-cool-gray;
+}
 /* Do no display the count of search results */
 #search-results .gsc-result-info {
   display: none;

--- a/docroot/themes/custom/uids_base/scss/components/search-results.scss
+++ b/docroot/themes/custom/uids_base/scss/components/search-results.scss
@@ -52,7 +52,7 @@
   padding-right: 0;
 }
 
-#search-results .gsc-orderby-label .gsc-inline-block {
+#search-results .gsc-orderby-label, #search-results .gsc-option {
   color: variables.$brand-cool-gray;
 }
 /* Do no display the count of search results */


### PR DESCRIPTION
Relates to https://github.com/uiowa/uiowa/issues/5107

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

Since you can't get enough search results locally to test...

- Review the change
- Know that brand-cool-gray is `#63666A`
- Go to https://pathology.medicine.uiowa.edu/search?terms=site%3Apathology.medicine.uiowa.edu%2Fprofile%2F%2A+%22clinical+associate%22+%7C+%22clinical+professor%22+%7C+%22clinical+assistant%22#gsc.tab=0&gsc.q=site%3Apathology.medicine.uiowa.edu%2Fprofile%2F*%20%22clinical%20associate%22%20%7C%20%22clinical%20professor%22%20%7C%20%22clinical%20assistant%22&gsc.page=1 and see that `#80868B` is the sort color.
- See that `#80868B` is not suitable for 4.5:1 contrast:
https://contrast-finder.tanaguru.com/result.html;jsessionid=63B7B06FDE431468981B2066CC89D010?foreground=%2380868b&background=%23FFFFFF&ratio=4.5&isBackgroundTested=false&algo=Rgb&distanceSort=asc
- Check that `#63666A` is suitable: https://contrast-finder.tanaguru.com/result.html?foreground=%2363666A&background=%23FFFFFF&ratio=4.5&isBackgroundTested=false&algo=Rgb
- Compare with the scanned issue here: https://my2.siteimprove.com/Inspector/1216456/A11y/Page?pageId=85499206150&impmd=49AB80B97CC512FFF56539C8AABB1CD8&conf=aa#/sia-r69/failed
