### PR TITLE
Remove pecl memcache from Travis CI and bump guzzlehttp/psr7 for security

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_install:
 - mv deploy_key $HOME/.ssh/id_rsa
 - chmod 600 $HOME/.ssh/id_rsa
 - phpenv config-rm xdebug.ini
-- yes | pecl install memcache-8.0
 install:
 - nvm install
 - nvm use

--- a/composer.json
+++ b/composer.json
@@ -248,6 +248,7 @@
         "npm-asset/vanilla-icon-picker": "^1.2",
         "oomphinc/composer-installers-extender": "^2.0",
         "richardbporter/drush-users-commands": "^4.0.0",
+        "guzzlehttp/psr7": "2.10.2 as 2.7.1",
         "uiowa/uiowa_auth": "^2.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "27bfbfb9dbc178f8aca55d1548b49d0e",
+    "content-hash": "7666a8554821dd31338389346b4a5120",
     "packages": [
         {
             "name": "acquia/blt",
@@ -13685,16 +13685,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.7.1",
+            "version": "2.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16"
+                "reference": "a1bbdc172f32a25fe999965b65b6e71fd87da9ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c2270caaabe631b3b44c85f99e5a04bbb8060d16",
-                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a1bbdc172f32a25fe999965b65b6e71fd87da9ed",
+                "reference": "a1bbdc172f32a25fe999965b65b6e71fd87da9ed",
                 "shasum": ""
             },
             "require": {
@@ -13709,8 +13709,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -13781,7 +13782,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.7.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.10.2"
             },
             "funding": [
                 {
@@ -13797,7 +13798,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T12:30:47+00:00"
+            "time": "2026-05-25T22:58:15+00:00"
         },
         {
             "name": "html2text/html2text",
@@ -24785,7 +24786,14 @@
             "time": "2023-02-08T20:20:19+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "guzzlehttp/psr7",
+            "version": "2.10.2.0",
+            "alias": "2.7.1",
+            "alias_normalized": "2.7.1.0"
+        }
+    ],
     "minimum-stability": "dev",
     "stability-flags": {
         "acquia/blt-multisite": 20,


### PR DESCRIPTION
## Problem

All PRs are failing Travis CI with:

```
$ yes | pecl install memcache-8.0
No releases available for package "pecl/php.net/memcache"
install failed
The command "yes | pecl install memcache-8.0" failed and exited with 1 during .
```

Additionally, Composer audit reports two medium-severity CVEs in `guzzlehttp/psr7`:

| CVE | Title | Affected versions |
|-----|-------|-------------------|
| CVE-2026-48998 | Host Confusion via Authority Reinterpretation | <2.10.2 |
| CVE-2026-49214 | CRLF Injection via URI Host Component | <2.10.2 |

Both are fixed in `guzzlehttp/psr7` 2.10.2, but `drupal/core-recommended` pins `~2.7.1`, blocking the update.

## Why removing pecl memcache is safe

This is **not** a blip — the package has been removed from PECL. However, removing the install line is safe because:

1. **Travis CI doesn't run a memcache service.** The `services:` block only lists `mysql`. Even if the extension installed, there'd be no daemon to connect to.
2. **Drupal's memcache module falls back gracefully.** Without the extension and daemon, it uses the default database cache — which is fine for CI.
3. **Production is unaffected.** Acquia provides its own memcache extension via `acquia/memcache-settings`, which configures the extension already installed on Acquia's infrastructure. That package and `drupal/memcache` remain in composer.json.

## Why the `as` alias for guzzlehttp/psr7

Following the pattern from [PR #9869](https://github.com/uiowa/uiowa/pull/9869), `drupal/core-recommended` pins `guzzlehttp/psr7` to `~2.7.1`. Adding `"guzzlehttp/psr7": "2.10.2 as 2.7.1"` to the root composer.json allows installing the secure version while satisfying the core-recommended constraint.

Reference: https://www.drupal.org/docs/updating-drupal/updating-drupal-core-via-composer#s-problem-a-dependency-cannot-be-updated-because-of-version-constraints

## Changes

- Removed `yes | pecl install memcache-8.0` from `.travis.yml` `before_install` step
- Added `"guzzlehttp/psr7": "2.10.2 as 2.7.1"` to `composer.json` require
- Updated `composer.lock`

## How to test

- Verify Travis CI build passes (memcache line removed, no install failure)
- `composer audit` should report no advisories for guzzlehttp/psr7
- Functional testing: confirm memcache module status remains installed, cache backend falls back to database in CI
