### PR TITLE
add composer to the path so deploy can find blt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ install:
 
   # PHP dependencies
   - composer install
+  - export PATH="$COMPOSER_BIN:$PATH"
 
   # Frontend build (still using BLT command hook for now)
   - yarn install --production --ignore-optional --frozen-lockfile --non-interactive


### PR DESCRIPTION
>The old install step sourced setup_environment which adds vendor/bin to $PATH. PR #9913 removed all the BLT-travis scripts but forgot that setup_environment was what put blt on the path — the deploy step still needs it.

>After composer install creates vendor/bin, we export $COMPOSER_BIN onto $PATH so blt is findable for both the remaining script steps and the deploy phase.

# How to test

- Passing build.
- Merge to see if deploy steps occur.
