### PR TITLE
Updates default content to remove its-web@uiowa.edu email

### DIFF
--- a/docroot/profiles/custom/sitenow/content/block_content/3d24809e-7064-4859-934c-6d07cbb33ed9.yml
+++ b/docroot/profiles/custom/sitenow/content/block_content/3d24809e-7064-4859-934c-6d07cbb33ed9.yml
@@ -24,5 +24,5 @@ default:
       child_heading_size: ''
   field_uiowa_text_area:
     -
-      value: "<p>The SiteNow service is maintained by a dedicated team of campus web professionals. If you'd like to submit a feature request or have any questions for the team, please email <a href=\"mailto:its-web@uiowa.edu\">its-web@uiowa.edu</a>.</p>\r\n\r\n<p>If you have any questions or need technical support, please consult the SiteNow service site and the SiteNow documentation.</p>\r\n\r\n<p><a class=\"bttn bttn--primary\" href=\"https://sitenow.uiowa.edu/documentation\">SiteNow Documentation <span class=\"fa-arrow-right fas\"></span></a></p>\r\n\r\n<p>&nbsp;</p>\r\n"
+      value: "<p>The SiteNow service is maintained by a dedicated team of campus web professionals. If you'd like to submit a feature request or have any questions for the team, <a href=\"https://sitenow.uiowa.edu/contact-us\">please contact us</a>.</p>\r\n\r\n<p>If you have any questions or need technical support, please consult the SiteNow service site and the SiteNow documentation.</p>\r\n\r\n<p><a class=\"bttn bttn--primary\" href=\"https://sitenow.uiowa.edu/documentation\">SiteNow Documentation <span class=\"fa-arrow-right fas\"></span></a></p>\r\n\r\n<p>&nbsp;</p>\r\n"
       format: filtered_html


### PR DESCRIPTION
resolves #9946 

Updates default content to replace its-web@uiowa.edu email with link to SiteNow Contact Us page.

# How to test

Install a fresh default with `ddev blt drupal:install --site=default`

Review that the content on the homepage has the its-web@uiowa.edu email removed and replaced with a link to the SiteNow Contact Us page and that everything else looks normal on the site.

<img width="681" height="389" alt="Screen Shot 2026-07-01 at 15 18 26 PM" src="https://github.com/user-attachments/assets/01368fef-4233-4843-8ea8-e796bf15f2ed" />

previously looked like.
<img width="663" height="376" alt="Screen Shot 2026-07-01 at 15 14 17 PM" src="https://github.com/user-attachments/assets/ad05d26c-f283-47cc-8b83-2f11e9031156" />
