### PR TITLE
[Facilities] Adapt project dates handling

### DIFF
--- a/docroot/sites/facilities.uiowa.edu/modules/facilities_core/src/ProjectsProcessor.php
+++ b/docroot/sites/facilities.uiowa.edu/modules/facilities_core/src/ProjectsProcessor.php
@@ -75,6 +75,13 @@ class ProjectsProcessor extends EntityProcessorBase {
     // Function to transform dates.
     $transform_date = function ($timestamp) {
       if (!is_null($timestamp)) {
+        // If string, assume Y-m-d format.
+        if (is_string($timestamp)) {
+          $parsed = \DateTime::createFromFormat('Y-m-d', $timestamp);
+          // If it can't be parsed, import as null.
+          return $parsed ? $timestamp : NULL;
+        }
+        // Otherwise, convert from milliseconds to seconds and format.
         $date_formatter = \Drupal::service('date.formatter');
         return $date_formatter->format($timestamp / 1000, 'custom', 'Y-m-d');
       }


### PR DESCRIPTION
> In this change, the value of Date will be changed from the number of milliseconds since Unix epoch to date string in ISO format.
> 
> For example: "substantialCompletionDate":1594098000000
> 
> To
> 
> "substantialCompletionDate":"2020-07-07"
> 
> Can you check if you need to make changes to consume for format?
> As far as I know the following API returns data that have dates. 
> https://buildui.facilities.uiowa.edu/buildui/ext/projectinfo?projnumber=0329501
> 
> The current output is:
> 
> {"projectTitle":"College of Pharmacy Building - Construct New Facility ","buiProjectId":"0329501","buildingName":"College of Pharmacy Building","preBidLocation":"Pharmacy Building - Room 100A @ 2:00 pm","hospitalProjectId":null,"vendorName":"Miron Construction Company Inc","buiProgramId":"0329500","programTitle":"College of Pharmacy Building - Construct New Facility ","programBudget":96300000.00,"substantialCompletionDate":1594098000000,"projectStatus":"Archive","buildingNumber":"0106","primaryConsultant":"OPN Architects","projectScope":"This project includes the design and construction of a new facility for the College of Pharmacy.    ","buildingLocation":"180 South Grand Avenue","grossSqFeet":209756,"estimatedAmount":"60001320.00","bidOpeningDate":1485410400000,"constructionStartDate":1488348000000,"preBidDate":1483560000000}
> 
> It is going to change it to:
> 
> {"programBudget":96300000.00,"estimatedAmount":"60001320.00","bidOpeningDate":"2017-01-26","constructionStartDate":"2017-03-01","preBidDate":"2017-01-04","preBidLocation":"Pharmacy Building - Room 100A @ 2:00 pm","projectScope":"This project includes the design and construction of a new facility for the College of Pharmacy.    ","grossSqFeet":209756,"hospitalProjectId":null,"projectTitle":"College of Pharmacy Building - Construct New Facility ","buiProjectId":"0329501","buildingName":"College of Pharmacy Building","vendorName":"Miron Construction Company Inc","buiProgramId":"0329500","programTitle":"College of Pharmacy Building - Construct New Facility ","substantialCompletionDate":"2020-07-07","projectStatus":"Archive","buildingNumber":"0106","primaryConsultant":"OPN Architects","buildingLocation":"180 South Grand Avenue"}

We still output the dates the same, but all the dates on the project should be using the new format. If not, the milleseconds timestamp is still supported as a fallback. If the date doesn't come over as Y-m-d it is treated as NULL as they did not say it would be anything other than Y-m-d

# How to test

- Get facilities build ui API credentials from Joe in DM or from uiowa03.prod secrets. Add them to the local.settings.php file within the site directory.
- `ddev blt ds --site=facilities.uiowa.edu && ddev drush @facilities.local fm-projects`
- See that the dates import as expected, no errors. 3 new, 2 updated, 1 deleted?
- Spot check: https://facilities.uiowa.ddev.site/project/1151801

You can also check the api directly (basic auth) https://buildui.facilities.uiowa.edu/buildui/ext/projectinfo?projnumber=1151801 to see they are now Y-m-d formatted.
