### PR TITLE
Restore committed assets/js dropped from the deploy artifact

### DIFF
--- a/scripts/deploy/assemble.sh
+++ b/scripts/deploy/assemble.sh
@@ -56,4 +56,13 @@ rsync -a --delete \
   --exclude-from="${EXCLUDE_FILE}" \
   "${REPO_ROOT}/" "${BUILD_DIR}/"
 
+# rsync's .gitignore emulation does not honor git's cross-file negations: the
+# root .gitignore ignores **/assets/js as a build artifact, and uids_base
+# re-includes its committed copy with !assets/js. rsync drops it, so restore the
+# assets/js files git actually tracks. (assets/css is ignored the same way, but
+# gulp regenerates that; assets/js is committed source with nothing to rebuild
+# it.) The pathspec covers any theme that adds the same negation later.
+git -C "${REPO_ROOT}" ls-files -- ':(glob)**/assets/js/**' \
+  | rsync -a --files-from=- "${REPO_ROOT}/" "${BUILD_DIR}/"
+
 echo "assemble: working tree copied to ${BUILD_DIR}"


### PR DESCRIPTION
_Opened by Claude on behalf of @pyrello._

Hotfix for the deploy pipeline merged in #9932.

## Problem

`uids_base`'s committed JS 404s on deployed sites, e.g. `themes/custom/uids_base/assets/js/click-a11y-init.js`. The files never reach the build artifact.

## Root cause

`scripts/deploy/assemble.sh` copied the working tree with `rsync --filter=':- .gitignore'`. rsync's `.gitignore` emulation does not honor git's cross-file negation: the root `.gitignore` ignores `**/assets/js` as a build artifact, and `uids_base/.gitignore` re-includes its committed copy with `!assets/js`. rsync applied the exclude but not the re-include, so `uids_base/assets/js` was dropped. git tracks those files; rsync just disagreed.

`uids_base/assets/js` is hand-written source (init scripts), not compiled, which is why it is the one theme carrying that negation. Every other `assets/js` is built by its workspace and correctly gitignored.

## Fix

After the copy, restore the `assets/js` files git actually tracks, driven from `git ls-files` (which honors the negation):

```
git -C "${REPO_ROOT}" ls-files -- ':(glob)**/assets/js/**' \
  | rsync -a --files-from=- "${REPO_ROOT}/" "${BUILD_DIR}/"
```

## Verification

- Ran `assemble.sh`: `uids_base/assets/js` now has all 18 files including `click-a11y-init.js`; `vendor`, `node_modules`, `docroot/core`, `tests`, `README.md`, `.github` remain excluded.
- Diffed the artifact's file selection against the old BLT build's. `uids_base/assets/js` was the only committed source the new pipeline was dropping. Everything else BLT shipped that the new build does not is either correctly excluded (OS junk, dev/agent files, generated config) or regenerated by the build (compiled `assets/css`, workspace-built JS, composer-installed modules).
