### PR TITLE
[UME] document -v flag

### DIFF
--- a/sitenow/src/Command/MultisiteExecuteCommand.php
+++ b/sitenow/src/Command/MultisiteExecuteCommand.php
@@ -78,6 +78,9 @@ Before the fleet runs, the drush command is checked on one canary site (via
 `drush help`, which executes nothing). A typo'd command aborts before any site
 runs; a command that only exists on some sites asks for confirmation.
 
+Use -v (verbose) to see command output from each site. By default, only success/failure
+status is shown.
+
 Examples:
   # Cache rebuild on every site of two apps:
   ddev exec ./sn ume --apps=uiowa02,uiowa03 -y -- cr
@@ -90,6 +93,9 @@ Examples:
 
   # Preview what would run, without executing anything:
   ddev exec ./sn ume --dry-run -- cron
+
+  # See output from each site (e.g., config values):
+  ddev exec ./sn ume -v --apps=uiowa09 -- config:get system.site
 HELP);
   }
 


### PR DESCRIPTION
Trying out the new command and was struggling to understand the -v flag was needed for drush response and not just process verbosity.
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

<!-- Include detailed steps for how to test this PR. -->

```
ddev exec ./sn ume --help                                                                                                     [07/24/26 | 11:00:25]
Description:
  (ddev required) Execute a drush command across manifest-selected sites.

Usage:
  multisite:execute [options] [--] <cmd>...
  me
  ume

Arguments:
  cmd                            The drush command with its arguments and options. Separate from this command's own options with "--", e.g.: sn ume --apps=uiowa09 -- pm:list --status=enabled

Options:
      --apps=APPS                Comma-separated app names to run against (e.g. uiowa02,uiowa03). Defaults to all apps. [default: ""]
      --exclude=EXCLUDE          Comma-separated site domains to skip. [default: ""]
      --env=ENV                  Target environment: dev, test, or prod. [default: "prod"]
      --concurrency=CONCURRENCY  Maximum simultaneous drush processes. Defaults to 8 per app in scope, capped at 32. At most 8 run per app at once regardless.
      --dry-run                  Print the per-site drush invocations without running them.
  -y, --yes                      Skip the confirmation prompt.
  -h, --help                     Display help for the given command. When no command is given display help for the list command
  -q, --quiet                    Do not output any message
  -V, --version                  Display this application version
      --ansi|--no-ansi           Force (or disable --no-ansi) ANSI output
  -n, --no-interaction           Do not ask any interactive question
  -v|vv|vvv, --verbose           Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  Everything after "--" is passed to drush verbatim, one site at a time.
  
  The per-site drush processes run non-interactively — drush can't stop and ask a
  question mid-fleet. Drush commands that normally ask their own confirmation
  (pm:uninstall, config:set, ...) need their own -y inside the passthrough, or
  every site will auto-answer with drush's default (usually cancel).
  
  Before the fleet runs, the drush command is checked on one canary site (via
  `drush help`, which executes nothing). A typo'd command aborts before any site
  runs; a command that only exists on some sites asks for confirmation.
  
  Use -v (verbose) to see command output from each site. By default, only success/failure
  status is shown.
  
  Examples:
    # Cache rebuild on every site of two apps:
    ddev exec ./sn ume --apps=uiowa02,uiowa03 -y -- cr
  
    # Arguments with spaces/quotes pass through unmodified:
    ddev exec ./sn ume --apps=uiowa09 -- sql:query "SELECT COUNT(*) FROM node"
  
    # Two different -y's: ours skips the fleet confirmation, drush's skips its own:
    ddev exec ./sn ume -y --apps=uiowa09 -- pm:uninstall some_module -y
  
    # Preview what would run, without executing anything:
    ddev exec ./sn ume --dry-run -- cron
  
    # See output from each site (e.g., config values):
    ddev exec ./sn ume -v --apps=uiowa09 -- config:get system.site
```