### PR TITLE
Run cron script

### DIFF
--- a/scripts/drush-cron.sh
+++ b/scripts/drush-cron.sh
@@ -3,7 +3,7 @@
 # Runs drush cron on every site on the current application.
 # Triggered by an Acquia scheduled job.
 # The key in the manifest is AH_SITE_GROUP (e.g. uiowa07),
-# the code path uses AH_SITE_NAME (e.g. uiowa07.prod).
+# the code path uses AH_SITE_NAME (e.g. uiowa07prod).
 
 log="/shared/logs/drush-cron-${AH_SITE_GROUP}.log"
 manifest="/var/www/html/${AH_SITE_NAME}/blt/manifest.yml"

--- a/scripts/drush-cron.sh
+++ b/scripts/drush-cron.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Runs drush cron on every site on the current application.
+# Triggered by an Acquia scheduled job.
+# The key in the manifest is AH_SITE_GROUP (e.g. uiowa07),
+# the code path uses AH_SITE_NAME (e.g. uiowa07.prod).
+
+log="/shared/logs/drush-cron-${AH_SITE_GROUP}.log"
+manifest="/var/www/html/${AH_SITE_NAME}/blt/manifest.yml"
+
+sites=$(sed -n "/^${AH_SITE_GROUP}:/,/^[^ ]/p" "$manifest" | grep "  -" | awk '{print $2}')
+
+for site in $sites; do
+  echo "----- ${site} -----" &>> "$log"
+  drush @${AH_SITE_GROUP}.${AH_SITE_ENVIRONMENT} -l "$site" cron -v 2>&1 | awk '{print "["strftime("%Y-%m-%d %H:%M:%S %Z")"] "$0}' &>> "$log"
+done


### PR DESCRIPTION
The old blt ume cron ran on each app via a scheduled job. The replacement ./sn ume only works inside DDEV (it needs drush aliases + SSH agent), so it can't run on Acquia servers directly. 

The interim one-liner approach from Slack failed for three reasons:
1. Wrong path — used /var/www/html/blt/manifest.yml (missing the app directory). F
  - Fixed: /var/www/html/${AH_SITE_NAME}/blt/manifest.yml.
2. Acquia cron doesn't run shell loops — the scheduled job runner executes simple commands, not for/$(...) subshells. The one-liner worked interactively but silently failed as a job. 
  - Fixed: move the loop into a bash script (scripts/drush-cron.sh), so the job just calls the script path — same pattern as hawkalert.sh.
3. 255-char limit — the full one-liner exceeded the Acquia job command limit. 
 - Fixed: the script call is ~50 chars. 

scripts/drush-cron.sh reads the manifest for the current app (AH_SITE_GROUP key, AH_SITE_NAME path), loops through every site, and runs drush cron with the @${AH_SITE_GROUP}.${AH_SITE_ENVIRONMENT} alias. 

Scheduled job command to add once deployed:

`/var/www/html/${AH_SITE_NAME}/scripts/drush-cron.sh`

# How to test

Verify the manifest parsing produces a site list
`ddev drush @uiowa07.prod ssh`
```
AH_SITE_GROUP=uiowa07 AH_SITE_NAME=uiowa07.prod AH_SITE_ENVIRONMENT=prod \
  bash -c 'sed -n "/^${AH_SITE_GROUP}:/,/^[^ ]/p" /var/www/html/${AH_SITE_NAME}/blt/manifest.yml | grep "  -" | awk "{print \$2}" | head -5'
```
Should list 5 sites from the uiowa07 block.

# Check the log path the script will write to:
ls -la /shared/logs/drush-cron-${AH_SITE_GROUP}.log

The logrotate config at logrotate.conf:2 already matches drush-cron-*.log - `drush-cron-${AH_SITE_GROUP}.log` matches.