### PR TITLE
Bump guzzle to 7.15.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
     "require": {
         "ext-json": "*",
         "ext-simplexml": "*",
-        "guzzlehttp/guzzle": "7.15.1 as 7.9.3",
+        "guzzlehttp/guzzle": "7.15.2 as 7.9.3",
         "guzzlehttp/promises": "2.5.1 as 2.2.0",
         "guzzlehttp/psr7": "2.13.0 as 2.10.4",
         "acquia/blt": "^13.7.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0d274c819befc9027880cd03a2c02ba",
+    "content-hash": "62e46c27cbd6a55fb4fb36869785b8e4",
     "packages": [
         {
             "name": "acquia/blt",
@@ -12318,16 +12318,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.1",
+            "version": "7.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
                 "shasum": ""
             },
             "require": {
@@ -12426,7 +12426,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
             },
             "funding": [
                 {
@@ -12442,7 +12442,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-18T11:23:11+00:00"
+            "time": "2026-07-26T23:23:20+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -24813,7 +24813,7 @@
     "aliases": [
         {
             "package": "guzzlehttp/guzzle",
-            "version": "7.15.1.0",
+            "version": "7.15.2.0",
             "alias": "7.9.3",
             "alias_normalized": "7.9.3.0"
         },


### PR DESCRIPTION
Bumps `guzzlehttp/guzzle` to 7.15.2. The `as 7.9.3` alias is preserved.

# How to test

Adding a Panopto media item is the most useful manual check: the thumbnail fetch is the one custom code path that hands guzzle a URI it got from a remote server, since it tracks redirects and then re-requests the final URL. 

- The security audit job passes.
- Sync a site and get a login link to the add form:
```
ddev sn ds sandbox.uiowa.edu && ddev drush @sandbox.local uli /media/add/panopto
```

- Paste a Panopto viewer URL and save. Use an ID from an existing media item on a live site, so the video resolves without a Panopto login.
```
https://uicapture.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=fd33f2f7-1110-4271-adec-b48901636300
```

- Confirm both on save:
   1. The Name field auto-populates with the video's title.
   2. A thumbnail renders at `/admin/content/media`, with the file in `docroot/sites/sandbox.uiowa.edu/files/panopto_thumbnails/`.

---

*Drafted by Claude on behalf of @pyrello.*
