### PR TITLE
Bump entity_browser to 8.x-2.16

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4466,17 +4466,17 @@
         },
         {
             "name": "drupal/entity_browser",
-            "version": "2.15.0",
+            "version": "2.16.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/entity_browser.git",
-                "reference": "8.x-2.15"
+                "reference": "8.x-2.16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/entity_browser-8.x-2.15.zip",
-                "reference": "8.x-2.15",
-                "shasum": "86265fadf12f8c2eb4bc0dc813589efe8fa180a2"
+                "url": "https://ftp.drupal.org/files/projects/entity_browser-8.x-2.16.zip",
+                "reference": "8.x-2.16",
+                "shasum": "afcfa23e5e4b57539a48b5fa333465827f8758c9"
             },
             "require": {
                 "drupal/core": "^10.2 || ^11"
@@ -4497,8 +4497,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.15",
-                    "datestamp": "1756969160",
+                    "version": "8.x-2.16",
+                    "datestamp": "1785952684",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
https://www.drupal.org/project/entity_browser/releases/8.x-2.16

Been awhile since I've done one of these, I just did `ddev composer update drupal/entity_browser` for this. Tested the media browser on sandbox and it worked fine, not sure if we need to test something more specific here, hoping others might know. 
