### PR TITLE
[Intranet] Allow SiteimproveBot-Crawler before Disallow all

### DIFF
--- a/docroot/modules/custom/sitenow_intranet/src/ConfigOverride/RobotstxtOverride.php
+++ b/docroot/modules/custom/sitenow_intranet/src/ConfigOverride/RobotstxtOverride.php
@@ -19,7 +19,7 @@ class RobotstxtOverride implements ConfigFactoryOverrideInterface {
     $overrides = [];
 
     if (in_array('robotstxt.settings', $names)) {
-      $overrides['robotstxt.settings']['content'] = "User-agent: *\r\nDisallow: /";
+      $overrides['robotstxt.settings']['content'] = "User-agent: SiteimproveBot-Crawler\r\nAllow: /\r\n\r\nUser-agent: *\r\nDisallow: /";
     }
 
     return $overrides;

--- a/docroot/modules/custom/sitenow_intranet/tests/src/Functional/AccessTest.php
+++ b/docroot/modules/custom/sitenow_intranet/tests/src/Functional/AccessTest.php
@@ -93,15 +93,6 @@ class AccessTest extends BrowserTestBase {
   }
 
   /**
-   * Test robots.txt denies all except the Siteimprove crawler.
-   */
-  public function testRobotsDeniesAll() {
-    $this->drupalGet('robots.txt');
-    $content = $this->getSession()->getPage()->getContent();
-    $this->assertEquals("User-agent: SiteimproveBot-Crawler\r\nAllow: /\r\n\r\nUser-agent: *\r\nDisallow: /", $content);
-  }
-
-  /**
    * Test the top links do not render on the access denied page.
    */
   public function testNoTopLinks() {

--- a/docroot/modules/custom/sitenow_intranet/tests/src/Functional/AccessTest.php
+++ b/docroot/modules/custom/sitenow_intranet/tests/src/Functional/AccessTest.php
@@ -93,12 +93,12 @@ class AccessTest extends BrowserTestBase {
   }
 
   /**
-   * Test robots.txt denies all.
+   * Test robots.txt denies all except the Siteimprove crawler.
    */
   public function testRobotsDeniesAll() {
     $this->drupalGet('robots.txt');
     $content = $this->getSession()->getPage()->getContent();
-    $this->assertEquals("User-agent: *\r\nDisallow: /", $content);
+    $this->assertEquals("User-agent: SiteimproveBot-Crawler\r\nAllow: /\r\n\r\nUser-agent: *\r\nDisallow: /", $content);
   }
 
   /**

--- a/docroot/modules/custom/sitenow_intranet/tests/src/Unit/RobotstxtOverrideTest.php
+++ b/docroot/modules/custom/sitenow_intranet/tests/src/Unit/RobotstxtOverrideTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\Tests\sitenow_intranet\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\sitenow_intranet\ConfigOverride\RobotstxtOverride;
+
+/**
+ * Robotstxt config override test.
+ *
+ * @group sitenow_intranet
+ */
+class RobotstxtOverrideTest extends UnitTestCase {
+
+  /**
+   * Test robots.txt denies all except the Siteimprove crawler.
+   */
+  public function testLoadOverrides() {
+    $sut = new RobotstxtOverride();
+
+    $overrides = $sut->loadOverrides(['robotstxt.settings']);
+    $this->assertEquals("User-agent: SiteimproveBot-Crawler\r\nAllow: /\r\n\r\nUser-agent: *\r\nDisallow: /", $overrides['robotstxt.settings']['content']);
+  }
+
+  /**
+   * Test that the override does not apply to other config.
+   */
+  public function testLoadOverridesSkipsOtherConfig() {
+    $sut = new RobotstxtOverride();
+
+    $overrides = $sut->loadOverrides(['system.site']);
+    $this->assertArrayNotHasKey('robotstxt.settings', $overrides);
+  }
+
+}


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/10025

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

- `ddev sn site:sync intradent.dentistry.uiowa.edu`
- Go to `https://dentistryintradent.uiowa.ddev.site/robots.txt`
- Optional: run original tests and check replacement unit tests
  - `ddev ssh`
  - `vendor/bin/phpunit docroot/modules/custom/sitenow_intranet/tests/src/Functional/AccessTest.php`
  - `vendor/bin/phpunit docroot/modules/custom/sitenow_intranet/tests/src/Unit`
