### PR TITLE
[Admissions] update default text for careers, outcomes field

### DIFF
--- a/config/sites/admissions.uiowa.edu/field.field.node.area_of_study.field_area_of_study_career.yml
+++ b/config/sites/admissions.uiowa.edu/field.field.node.area_of_study.field_area_of_study_career.yml
@@ -17,7 +17,7 @@ required: false
 translatable: false
 default_value:
   -
-    value: "<p>Iowa graduates have job placement rates ranging from 86-100 percent, depending on their area of study, and our <a href=\"http://www.careers.uiowa.edu/\">Pomerantz Career Center</a> offers multiple resources to help students find internships and jobs.</p>\r\n"
+    value: '<p>Within six months of graduating, 96 percent of Iowa graduates are employed, continuing education, or not seeking work. Our <a href="https://careers.uiowa.edu/">Pomerantz Career Center</a> offers multiple resources to help students find internships and jobs.</p>'
     format: filtered_html
 default_value_callback: ''
 settings:


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/10065
<!--- Explain the problem briefly. Remember to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) if this PR fixes an existing issue. Be sure to remove any sensitive information from log messages, console output, etc. This includes but is not limited to usernames, passwords, server paths, ssh keys, etc. -->

<!---
Also remember to:
- Add the appropriate PR labels.
- Request approval from @uiowa/developer across units.
- Ensure that dependencies have been properly updated, if applicable.
  - https://github.com/uiowa/uiowa#updating-dependencies
- Ensure that site config splits have been accounted for, if applicable.
  - Go to https://github.com/uiowa/uiowa/find/master to find split config entities potentially affected by this PR.
- Test the PR locally with multiple sites.
- Update documentation.
-->

# How to test

```
ddev sn ds admissions.uiowa.edu -y && ddev drush @admissions.local uli admin/structure/types/manage/area_of_study/fields/node.area_of_study.field_area_of_study_career
```

See the default text change and then go to https://admissions.uiowa.ddev.site/node/add/area_of_study#edit-field-area-of-study-career-wrapper and see that it is in the field for new content.

