### PR TITLE
bump layout_builder_shortcuts to 1.0.3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6612,26 +6612,26 @@
         },
         {
             "name": "drupal/layout_builder_shortcuts",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/layout_builder_shortcuts.git",
-                "reference": "1.0.2"
+                "reference": "1.0.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/layout_builder_shortcuts-1.0.2.zip",
-                "reference": "1.0.2",
-                "shasum": "c39a8bd2f9d7d45535ccad353911b85578fcd31a"
+                "url": "https://ftp.drupal.org/files/projects/layout_builder_shortcuts-1.0.3.zip",
+                "reference": "1.0.3",
+                "shasum": "4425829191d1b99ff71ad93cd8fc3bc0c980b93a"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9 || ^10"
+                "drupal/core": "^8.8 || ^9 || ^10 || ^11"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.0.2",
-                    "datestamp": "1696272272",
+                    "version": "1.0.3",
+                    "datestamp": "1786997659",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/10017

Changelog: https://git.drupalcode.org/project/layout_builder_shortcuts/-/compare/1.0.2...1.0.3?from_project_id=65744

# How to test

- d10 testing not needed. info file change at this time.
