### PR TITLE
[Facilities] change label for download link

### DIFF
--- a/docroot/sites/facilities.uiowa.edu/modules/facilities_core/facilities_core.module
+++ b/docroot/sites/facilities.uiowa.edu/modules/facilities_core/facilities_core.module
@@ -256,7 +256,7 @@ function facilities_core_preprocess_field(&$variables) {
 
         if ($file_entity) {
           $file_url = \Drupal::service('file_url_generator')->generateAbsoluteString($file_entity->getFileUri());
-          $link = Link::fromTextAndUrl('Download Traffic Plan', Url::fromUri($file_url));
+          $link = Link::fromTextAndUrl('Download Project Location File', Url::fromUri($file_url));
           $variables['items'][0]['content'] = $link->toString();
         }
       }


### PR DESCRIPTION
Follow up from https://github.com/uiowa/uiowa/issues/10057

>When a file is uploaded in the Project location description, the hyperlink that follows still reads “Download Traffic Control Plan” can we change that to “Download Project Location File” or “View Project Location”?

# How to test

```
ddev sn ds facilities.uiowa.edu -y && ddev drush @facilities.local uli alert/11066
```
See that the project location link says `Download Project Location File` instead of `Download Traffic Control Plan` like in PROD https://facilities.uiowa.edu/alert/11066
